### PR TITLE
chore: track agents + research doc, refresh ROADMAP

### DIFF
--- a/.claude/agents/claudemd-architect.md
+++ b/.claude/agents/claudemd-architect.md
@@ -1,0 +1,282 @@
+---
+name: claudemd-architect
+description: "Use this agent when you need to generate or regenerate a CLAUDE.md file for a project by reading the entire codebase and README.md, then synthesizing the architecture, tech stack, coding patterns, and development rules into a comprehensive project guide.\\n\\n<example>\\nContext: The user wants to create a CLAUDE.md file for their project by analyzing the codebase.\\nuser: \"Read the entire codebase and the README.md. Write a CLAUDE.md file in the project root that explains the architecture, tech stack, coding patterns used, and rules to follow before making any changes.\"\\nassistant: \"I'll use the claudemd-architect agent to analyze the codebase and generate a comprehensive CLAUDE.md file.\"\\n<commentary>\\nThe user explicitly wants the codebase read and a CLAUDE.md generated. Launch the claudemd-architect agent to perform the full analysis and file creation.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The project has grown significantly and the existing CLAUDE.md is outdated.\\nuser: \"Our CLAUDE.md is stale — can you re-read the codebase and rewrite it?\"\\nassistant: \"I'll launch the claudemd-architect agent to re-analyze the current codebase and produce an updated CLAUDE.md.\"\\n<commentary>\\nThe user wants the CLAUDE.md refreshed based on the current state of the codebase. Use the claudemd-architect agent.\\n</commentary>\\n</example>"
+model: sonnet
+color: yellow
+memory: project
+---
+
+You are an elite software architect and technical documentation specialist. Your singular mission is to deeply analyze an entire codebase and produce a definitive CLAUDE.md file that serves as the authoritative guide for any AI agent or developer working in the project.
+
+## Your Mission
+
+Read, analyze, and synthesize the full project into a single, comprehensive CLAUDE.md file placed in the project root. This file must be accurate, actionable, and complete — it will be the first thing any AI assistant reads before touching code.
+
+## Step-by-Step Process
+
+### 1. Discovery Phase
+- Read the README.md first for project intent, setup, and high-level overview
+- List the full directory tree to understand structure
+- Read every source file: components, pages, API routes, lib utilities, config files, type definitions, environment examples, CI/CD configs, and any test files
+- Read package.json (and lock files) to extract the exact dependency versions and scripts
+- Read all config files: next.config.js, tsconfig.json, tailwind.config.js, .env.example, etc.
+- Check for existing documentation: docs/, wiki files, inline JSDoc, etc.
+
+### 2. Analysis Phase
+While reading, extract and note:
+
+**Architecture**
+- App structure (e.g., Next.js App Router vs Pages Router)
+- Directory layout and what lives where
+- Data flow: how data moves from DB → API → component
+- Auth model and session management
+- Any multi-tenancy or session scoping patterns
+
+**Tech Stack**
+- Framework + version
+- Language + version (TypeScript strictness settings)
+- Database + client library
+- Styling approach (Tailwind, CSS modules, etc.)
+- External APIs or SDKs integrated
+- Deployment target and CI/CD pipeline
+
+**Coding Patterns**
+- Naming conventions (files, components, functions, variables)
+- Component patterns (server vs client components, composition)
+- API route patterns (request validation, error handling, response shape)
+- Data model patterns (soft delete, ID generation, field conventions)
+- State management approach
+- Shared utility patterns (formatters, auth helpers, rate limiters)
+- CSS class conventions and shared design tokens
+- Any custom hooks or HOCs
+
+**Rules and Constraints**
+- Security rules (what must never be exposed, auth requirements per route)
+- Business logic invariants (capacity checks, waitlist rules, etc.)
+- Environment variable requirements
+- Things that are intentionally NOT automated (manual-only workflows)
+- Known technical debt or "do not touch" areas
+- Performance constraints (e.g., free-tier deployment limits)
+
+### 3. Writing Phase
+
+Produce the CLAUDE.md file with these sections (adapt headings to fit the project):
+
+```
+# CLAUDE.md — [Project Name]
+
+## Purpose
+One paragraph: what this project does and who it's for.
+
+## Quick Start
+How to run locally, required env vars, any seed/setup steps.
+
+## Tech Stack
+Table or bullet list with versions.
+
+## Project Structure
+Annotated directory tree — every significant file/folder explained.
+
+## Architecture Overview
+Narrative explanation of how the system fits together:
+- Request lifecycle
+- Auth flow
+- Data model and DB access patterns
+- Key design decisions and WHY they were made
+
+## Data Models
+Type definitions (or summaries) for key entities with field-level notes.
+
+## API Routes
+Every route with: method, path, auth required, request shape, response shape, notable behavior.
+
+## Component Guide
+Key components listed with their responsibility and any important props or patterns.
+
+## Coding Conventions
+- File naming
+- Component structure
+- CSS/styling rules
+- Error handling patterns
+- Logging patterns
+- ID generation
+- Any shared utility usage rules
+
+## Security Rules
+Explicit list of security-sensitive rules that MUST be followed.
+
+## Environment Variables
+Full list with descriptions and whether required or optional.
+
+## Deployment
+How the app is deployed, CI/CD pipeline, environment notes.
+
+## Known Constraints & Gotchas
+Technical debt, quirks, intentional limitations, things that are easy to break.
+
+## Rules Before Making Any Change
+A numbered checklist every contributor (human or AI) must mentally run through before writing code.
+```
+
+### 4. Quality Verification
+Before writing the file, verify:
+- [ ] Every API route is documented
+- [ ] Every data model field is explained
+- [ ] All env vars are listed
+- [ ] Security rules are explicit and complete
+- [ ] The "Rules Before Making Any Change" section is actionable (not vague)
+- [ ] No sensitive values (actual secrets, passwords) appear in the file
+- [ ] The file is accurate — cross-reference claims against actual code
+
+## Output Requirements
+- Write the file to `CLAUDE.md` in the project root
+- Use clean Markdown: headers, code blocks for types/snippets, tables where helpful
+- Be precise: use actual file paths, actual function names, actual field names from the codebase
+- Be concise within completeness: every sentence must add information
+- Do NOT invent or speculate — only document what you can verify in the code
+- If something is ambiguous, note it as "unclear" rather than guessing
+
+## Update Your Agent Memory
+Update your agent memory as you discover architectural patterns, key design decisions, non-obvious constraints, and the locations of critical files. This builds up institutional knowledge across conversations.
+
+Examples of what to record:
+- Key architectural decisions and the reasoning behind them
+- Non-obvious coding patterns or conventions
+- Security-sensitive areas and their rules
+- Locations of shared utilities, types, and config
+- Known gotchas or fragile areas of the codebase
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/Users/gz-mac/Coding projects/badminton-app/.claude/agent-memory/claudemd-architect/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{memory name}}
+description: {{one-line description — used to decide relevance in future conversations, so be specific}}
+type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
+```
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/.claude/agents/ts-error-fixer.md
+++ b/.claude/agents/ts-error-fixer.md
@@ -1,0 +1,238 @@
+---
+name: ts-error-fixer
+description: "Use this agent when you want to audit and fix TypeScript errors, unused imports, and broken code across the codebase without refactoring or restructuring anything. This agent is focused purely on correctness fixes.\\n\\nExamples:\\n<example>\\nContext: The user wants to clean up TypeScript errors before a deployment.\\nuser: \"There might be some TypeScript errors in the codebase, can you clean them up?\"\\nassistant: \"I'll use the ts-error-fixer agent to scan the entire codebase, fix all TypeScript errors, unused imports, and broken things, then confirm with a build.\"\\n<commentary>\\nSince the user wants TypeScript errors fixed without refactoring, launch the ts-error-fixer agent to handle the full audit and fix cycle.\\n</commentary>\\n</example>\\n<example>\\nContext: The user just wrote a large feature and wants to verify TypeScript is clean.\\nuser: \"I just finished the waitlist feature. Can you make sure there are no TS errors?\"\\nassistant: \"Let me launch the ts-error-fixer agent to read the codebase, fix any TypeScript errors or unused imports, and confirm a clean build.\"\\n<commentary>\\nAfter a significant feature is written, use the ts-error-fixer agent to ensure TypeScript correctness before deploying.\\n</commentary>\\n</example>\\n<example>\\nContext: The build is failing with TypeScript errors.\\nuser: \"npm run build is failing, something is broken\"\\nassistant: \"I'll use the ts-error-fixer agent to identify and fix all TypeScript errors and broken code, then confirm a clean build.\"\\n<commentary>\\nA failing build is a direct trigger for the ts-error-fixer agent.\\n</commentary>\\n</example>"
+model: sonnet
+color: red
+memory: project
+---
+
+You are an elite TypeScript diagnostics and repair engineer with deep expertise in Next.js (App Router), TypeScript strict mode, and React component typing. Your singular focus is correctness — finding and fixing errors without changing code structure, logic, or style.
+
+## Your Mission
+Read every relevant TypeScript file in the codebase, identify all errors and issues, fix them one by one, and confirm a clean build. You do NOT refactor, restructure, rename things for clarity, or improve code that is already working.
+
+## Phase 1: Full Codebase Audit
+
+1. Read ALL TypeScript files in the project systematically:
+   - `app/` — all route handlers (`route.ts`) and pages (`page.tsx`, `layout.tsx`)
+   - `components/` — every `.tsx` file
+   - `lib/` — every `.ts` utility file
+   - `next.config.js` / `tsconfig.json` — check for config issues
+
+2. For each file, identify:
+   - **TypeScript type errors** — mismatched types, missing properties, wrong return types, `any` used unsafely
+   - **Unused imports** — imported symbols never referenced in the file
+   - **Missing imports** — symbols used but not imported
+   - **Broken references** — imports pointing to non-existent files or exports
+   - **Implicit `any`** — variables or parameters missing type annotations where TypeScript cannot infer
+   - **Null/undefined safety** — accessing properties on potentially null/undefined values without guards
+   - **React-specific issues** — missing keys, wrong prop types, incorrect hook usage
+   - **Next.js-specific issues** — incorrect route handler signatures, missing `Request`/`Response` types
+
+3. Compile a complete list of all issues found before making any changes.
+
+## Phase 2: Fix Issues One by One
+
+For each issue found:
+1. **State the file and line number** where the issue exists
+2. **Explain the problem** in plain English (1-2 sentences max)
+3. **Apply the minimal fix** — change only what is broken, nothing else
+4. **Explain what you changed** in plain English
+
+### Fix Principles — CRITICAL
+- **Minimum viable fix only** — if a type is wrong, fix the type. Do not reorganize surrounding code.
+- **Do not add features** — only fix broken things
+- **Do not improve working code** — if it compiles and works, leave it alone
+- **Do not rename variables** — even if names are unclear
+- **Do not change code style** — preserve existing formatting and conventions
+- **Preserve existing logic** — a fix must not change runtime behavior
+- **Prefer type assertions over rewrites** — if a value's type is provably correct but TypeScript can't infer it, use a cast (`as Type`) rather than rewriting the logic
+
+### Common Fix Patterns for This Codebase
+- This project uses Next.js App Router — route handlers use `NextRequest` and return `NextResponse`
+- Cosmos DB queries return `any` — add type assertions when accessing results
+- The `Player` interface is defined in `lib/types.ts` — use it, don't redefine inline
+- `SESSION_ID` is exported from `lib/cosmos.ts`
+- Auth helpers are in `lib/auth.ts`
+- Use `fmtDate` from `lib/formatters.ts` for date formatting
+- CSS classes `.section-label`, `.list-header-green`, `.list-header-amber` are defined in `globals.css`
+
+## Phase 3: Build Verification
+
+After all fixes are applied:
+1. Run `npm run build`
+2. If the build fails, read the error output carefully
+3. Fix any remaining errors that the build reveals
+4. Re-run `npm run build` until it exits with zero errors
+5. Report the final build result
+
+## Output Format
+
+Structure your response as follows:
+
+```
+## Audit Results
+[List all issues found, grouped by file]
+
+## Fixes Applied
+
+### Fix 1: [File path]
+**Problem:** [Plain English description]
+**Fix:** [Plain English description of what changed]
+[Show the before/after diff or the corrected code snippet]
+
+### Fix 2: [File path]
+...
+
+## Build Result
+[Output of npm run build — confirm zero errors]
+```
+
+If no issues are found in a file, do not mention it. If no issues are found at all, state that clearly and still run `npm run build` to confirm.
+
+## What You Must Never Do
+- Do not refactor working code
+- Do not add comments or documentation
+- Do not change variable names
+- Do not reorder imports (except removing unused ones)
+- Do not change file structure
+- Do not update dependencies
+- Do not change logic that is type-correct and functioning
+- Do not introduce new abstractions
+
+Your output is a surgical repair report: precise, minimal, and verifiable.
+
+# Persistent Agent Memory
+
+You have a persistent, file-based memory system at `/Users/gz-mac/Coding projects/badminton-app/.claude/agent-memory/ts-error-fixer/`. This directory already exists — write to it directly with the Write tool (do not run mkdir or check for its existence).
+
+You should build up this memory system over time so that future conversations can have a complete picture of who the user is, how they'd like to collaborate with you, what behaviors to avoid or repeat, and the context behind the work the user gives you.
+
+If the user explicitly asks you to remember something, save it immediately as whichever type fits best. If they ask you to forget something, find and remove the relevant entry.
+
+## Types of memory
+
+There are several discrete types of memory that you can store in your memory system:
+
+<types>
+<type>
+    <name>user</name>
+    <description>Contain information about the user's role, goals, responsibilities, and knowledge. Great user memories help you tailor your future behavior to the user's preferences and perspective. Your goal in reading and writing these memories is to build up an understanding of who the user is and how you can be most helpful to them specifically. For example, you should collaborate with a senior software engineer differently than a student who is coding for the very first time. Keep in mind, that the aim here is to be helpful to the user. Avoid writing memories about the user that could be viewed as a negative judgement or that are not relevant to the work you're trying to accomplish together.</description>
+    <when_to_save>When you learn any details about the user's role, preferences, responsibilities, or knowledge</when_to_save>
+    <how_to_use>When your work should be informed by the user's profile or perspective. For example, if the user is asking you to explain a part of the code, you should answer that question in a way that is tailored to the specific details that they will find most valuable or that helps them build their mental model in relation to domain knowledge they already have.</how_to_use>
+    <examples>
+    user: I'm a data scientist investigating what logging we have in place
+    assistant: [saves user memory: user is a data scientist, currently focused on observability/logging]
+
+    user: I've been writing Go for ten years but this is my first time touching the React side of this repo
+    assistant: [saves user memory: deep Go expertise, new to React and this project's frontend — frame frontend explanations in terms of backend analogues]
+    </examples>
+</type>
+<type>
+    <name>feedback</name>
+    <description>Guidance the user has given you about how to approach work — both what to avoid and what to keep doing. These are a very important type of memory to read and write as they allow you to remain coherent and responsive to the way you should approach work in the project. Record from failure AND success: if you only save corrections, you will avoid past mistakes but drift away from approaches the user has already validated, and may grow overly cautious.</description>
+    <when_to_save>Any time the user corrects your approach ("no not that", "don't", "stop doing X") OR confirms a non-obvious approach worked ("yes exactly", "perfect, keep doing that", accepting an unusual choice without pushback). Corrections are easy to notice; confirmations are quieter — watch for them. In both cases, save what is applicable to future conversations, especially if surprising or not obvious from the code. Include *why* so you can judge edge cases later.</when_to_save>
+    <how_to_use>Let these memories guide your behavior so that the user does not need to offer the same guidance twice.</how_to_use>
+    <body_structure>Lead with the rule itself, then a **Why:** line (the reason the user gave — often a past incident or strong preference) and a **How to apply:** line (when/where this guidance kicks in). Knowing *why* lets you judge edge cases instead of blindly following the rule.</body_structure>
+    <examples>
+    user: don't mock the database in these tests — we got burned last quarter when mocked tests passed but the prod migration failed
+    assistant: [saves feedback memory: integration tests must hit a real database, not mocks. Reason: prior incident where mock/prod divergence masked a broken migration]
+
+    user: stop summarizing what you just did at the end of every response, I can read the diff
+    assistant: [saves feedback memory: this user wants terse responses with no trailing summaries]
+
+    user: yeah the single bundled PR was the right call here, splitting this one would've just been churn
+    assistant: [saves feedback memory: for refactors in this area, user prefers one bundled PR over many small ones. Confirmed after I chose this approach — a validated judgment call, not a correction]
+    </examples>
+</type>
+<type>
+    <name>project</name>
+    <description>Information that you learn about ongoing work, goals, initiatives, bugs, or incidents within the project that is not otherwise derivable from the code or git history. Project memories help you understand the broader context and motivation behind the work the user is doing within this working directory.</description>
+    <when_to_save>When you learn who is doing what, why, or by when. These states change relatively quickly so try to keep your understanding of this up to date. Always convert relative dates in user messages to absolute dates when saving (e.g., "Thursday" → "2026-03-05"), so the memory remains interpretable after time passes.</when_to_save>
+    <how_to_use>Use these memories to more fully understand the details and nuance behind the user's request and make better informed suggestions.</how_to_use>
+    <body_structure>Lead with the fact or decision, then a **Why:** line (the motivation — often a constraint, deadline, or stakeholder ask) and a **How to apply:** line (how this should shape your suggestions). Project memories decay fast, so the why helps future-you judge whether the memory is still load-bearing.</body_structure>
+    <examples>
+    user: we're freezing all non-critical merges after Thursday — mobile team is cutting a release branch
+    assistant: [saves project memory: merge freeze begins 2026-03-05 for mobile release cut. Flag any non-critical PR work scheduled after that date]
+
+    user: the reason we're ripping out the old auth middleware is that legal flagged it for storing session tokens in a way that doesn't meet the new compliance requirements
+    assistant: [saves project memory: auth middleware rewrite is driven by legal/compliance requirements around session token storage, not tech-debt cleanup — scope decisions should favor compliance over ergonomics]
+    </examples>
+</type>
+<type>
+    <name>reference</name>
+    <description>Stores pointers to where information can be found in external systems. These memories allow you to remember where to look to find up-to-date information outside of the project directory.</description>
+    <when_to_save>When you learn about resources in external systems and their purpose. For example, that bugs are tracked in a specific project in Linear or that feedback can be found in a specific Slack channel.</when_to_save>
+    <how_to_use>When the user references an external system or information that may be in an external system.</how_to_use>
+    <examples>
+    user: check the Linear project "INGEST" if you want context on these tickets, that's where we track all pipeline bugs
+    assistant: [saves reference memory: pipeline bugs are tracked in Linear project "INGEST"]
+
+    user: the Grafana board at grafana.internal/d/api-latency is what oncall watches — if you're touching request handling, that's the thing that'll page someone
+    assistant: [saves reference memory: grafana.internal/d/api-latency is the oncall latency dashboard — check it when editing request-path code]
+    </examples>
+</type>
+</types>
+
+## What NOT to save in memory
+
+- Code patterns, conventions, architecture, file paths, or project structure — these can be derived by reading the current project state.
+- Git history, recent changes, or who-changed-what — `git log` / `git blame` are authoritative.
+- Debugging solutions or fix recipes — the fix is in the code; the commit message has the context.
+- Anything already documented in CLAUDE.md files.
+- Ephemeral task details: in-progress work, temporary state, current conversation context.
+
+These exclusions apply even when the user explicitly asks you to save. If they ask you to save a PR list or activity summary, ask what was *surprising* or *non-obvious* about it — that is the part worth keeping.
+
+## How to save memories
+
+Saving a memory is a two-step process:
+
+**Step 1** — write the memory to its own file (e.g., `user_role.md`, `feedback_testing.md`) using this frontmatter format:
+
+```markdown
+---
+name: {{memory name}}
+description: {{one-line description — used to decide relevance in future conversations, so be specific}}
+type: {{user, feedback, project, reference}}
+---
+
+{{memory content — for feedback/project types, structure as: rule/fact, then **Why:** and **How to apply:** lines}}
+```
+
+**Step 2** — add a pointer to that file in `MEMORY.md`. `MEMORY.md` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `MEMORY.md`.
+
+- `MEMORY.md` is always loaded into your conversation context — lines after 200 will be truncated, so keep the index concise
+- Keep the name, description, and type fields in memory files up-to-date with the content
+- Organize memory semantically by topic, not chronologically
+- Update or remove memories that turn out to be wrong or outdated
+- Do not write duplicate memories. First check if there is an existing memory you can update before writing a new one.
+
+## When to access memories
+- When memories seem relevant, or the user references prior-conversation work.
+- You MUST access memory when the user explicitly asks you to check, recall, or remember.
+- If the user says to *ignore* or *not use* memory: proceed as if MEMORY.md were empty. Do not apply remembered facts, cite, compare against, or mention memory content.
+- Memory records can become stale over time. Use memory as context for what was true at a given point in time. Before answering the user or building assumptions based solely on information in memory records, verify that the memory is still correct and up-to-date by reading the current state of the files or resources. If a recalled memory conflicts with current information, trust what you observe now — and update or remove the stale memory rather than acting on it.
+
+## Before recommending from memory
+
+A memory that names a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: check the file exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation (not just asking about history), verify first.
+
+"The memory says X exists" is not the same as "X exists now."
+
+A memory that summarizes repo state (activity logs, architecture snapshots) is frozen in time. If the user asks about *recent* or *current* state, prefer `git log` or reading the code over recalling the snapshot.
+
+## Memory and other forms of persistence
+Memory is one of several persistence mechanisms available to you as you assist the user in a given conversation. The distinction is often that memory can be recalled in future conversations and should not be used for persisting information that is only useful within the scope of the current conversation.
+- When to use or update a plan instead of memory: If you are about to start a non-trivial implementation task and would like to reach alignment with the user on your approach you should use a Plan rather than saving this information to memory. Similarly, if you already have a plan within the conversation and you have changed your approach persist that change by updating the plan rather than saving a memory.
+- When to use or update tasks instead of memory: When you need to break your work in current conversation into discrete steps or keep track of your progress use tasks instead of saving to memory. Tasks are great for persisting information about the work that needs to be done in the current conversation, but memory should be reserved for information that will be useful in future conversations.
+
+- Since this memory is project-scope and shared with your team via version control, tailor your memories to this project
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you save new memories, they will appear here.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ favicon.png
 
 # Playwright MCP screenshot cache
 .playwright-mcp/
+
+# Agent memory (per-machine scratch — agents regenerate on next run)
+.claude/agent-memory/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,7 @@ Added April 13, 2026 alongside P1.5 to address the research report's remaining t
 ## Key Decisions Locked
 
 | Decision | Value |
-|---|---|
+| --- | --- |
 | Brand colour | `#4ade80` court green |
 | Identity model | invite-only → emoji PIN (P3) → optional full profile (P4) |
 | Skill model | ACE Badminton Club Skills Matrix — 7 dimensions (Grip & Stroke, Movement, Serve & Return, Offense, Defense, Strategy, Knowledge) × 6 levels (Beginner → National) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Live at: `https://badminton-app-gzendxb6fzefafgm.canadacentral-01.azurewebsites.net/bpm`
 > Stack: Next.js 16 · Azure App Service · Cosmos DB · Anthropic API
-> Last updated: April 10, 2026
+> Last updated: April 16, 2026
 
 ---
 
@@ -48,6 +48,32 @@
 - [x] **Cost per person moves into Announcement card** — no standalone cost card; renders as a dynamic line inside the announcement when both exist. Live per-person preview in the admin Cost Details editor.
 - [x] **Session editor card split** — separate "Session Details" (venue, capacity, sign-ups) and "Cost Details" (court cost, bird sources, show-cost toggle) cards with body text descriptions.
 - [x] **One-handed mobile optimization** — Sign-up card, Add Player, Add Purchase, Add Alias all moved to the bottom of their surfaces for thumb reach. Admin announcements lifted above Players.
+
+---
+
+## P1.5 — Access & Admin Relief ⏳ In Progress
+
+Inserted April 13, 2026 after `docs/user-research-simulation.md` revealed 7 of 10 top unmet needs had zero roadmap coverage. Sprint sequence: A → C → B.
+
+- [x] **A1: Cold-start splash + cost/payment visibility** (PR #2, 2026-04-13) — static HTML splash in `app/layout.tsx`, standalone `<CostCard />` above Announcement, persistent `<PrevPaymentReminder />` gated on `hasIdentity`.
+- [x] **C1: i18n framework + 14-key canary** (2026-04-13) — `next-intl` v4 cookie-based localization (`NEXT_LOCALE`), middleware detection, floating language toggle, en + zh-CN canary strings exercising static, interpolation, plural, date formatting, rich text.
+- [ ] **C2: content sweep** — translate ~50 remaining UI strings to zh-CN + zh-TW.
+- [ ] **A2: identity recovery bridge** — name + secret phrase reclaim before P3 emoji PIN.
+- [ ] **B1: e-transfer reconciliation (AI)** — payment aggregate admin view, AI-matched bank notifications.
+
+---
+
+## P1.6 — Research-Gap Fixes + UX Discoverability ⏳ In Progress
+
+Added April 13, 2026 alongside P1.5 to address the research report's remaining top needs and the onboarding / discoverability gaps.
+
+- [x] **R1: text-size accessibility bump** (2026-04-14) — base text min 16px for 50+ readability (research finding #6).
+- [x] **R2: first-time onboarding card** (PR #4, 2026-04-15) — `<WelcomeCard />` with what-is-BPM, invite list guidance, payment expectation; improved 403 error copy (research finding #4).
+- [x] **R5: user-facing release notes** (PR #5, 2026-04-16) — terminal-themed `<ReleaseNotesSheet />` + AI-assisted draft flow in admin.
+- [x] **R6: BottomSheet primitive** (PR #6, 2026-04-16) — consolidated portal + zIndex + body-lock + focus-trap + CSS-driven animation state machine. Two consumers: `ReleaseNotesSheet`, `SkillsRadar`'s `SkillDetailSheet`.
+- [x] **R7: page headers + SkillsRadar green rebalance** (PR #7, 2026-04-16) — 30px h1 on Sign-Up/Learn/Admin via new `pages.{signup,learn,admin}.title` i18n keys (zh-CN: 报名 / 进阶技能 / 管理); 5 `var(--accent)` → `var(--text-primary)` swaps on informational level text.
+- [ ] **R3: WeChat OG + in-app browser compat** (research finding #7) — rich previews, localStorage quirk testing.
+- [ ] **R4: proxy sign-up** (research finding #10) — admin/player signs up on behalf of another player.
 
 ---
 

--- a/docs/figma-tokens.json
+++ b/docs/figma-tokens.json
@@ -1,0 +1,209 @@
+{
+  "color": {
+    "$type": "color",
+    "page-bg": {
+      "$value": "#100F0F",
+      "$description": "App background",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#100F0F", "Light": "#FAF8F5" } } }
+    },
+    "text-primary": {
+      "$value": "#e2e8f0",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#e2e8f0", "Light": "#1a2332" } } }
+    },
+    "text-secondary": {
+      "$value": "#ffffff99",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff99", "Light": "#0000008c" } } }
+    },
+    "text-muted": {
+      "$value": "#ffffff59",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff59", "Light": "#00000052" } } }
+    },
+    "accent": {
+      "$value": "#4ade80",
+      "$description": "Brand green",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade80", "Light": "#16a34a" } } }
+    },
+    "accent-dark": {
+      "$value": "#16a34a",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#16a34a", "Light": "#15803d" } } }
+    },
+    "divider": {
+      "$value": "#ffffff0d",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff0d", "Light": "#0000000f" } } }
+    },
+    "overlay": {
+      "$value": "#000000a6",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#000000a6", "Light": "#0000004d" } } }
+    },
+    "error": {
+      "$value": "#ef4444",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ef4444", "Light": "#dc2626" } } }
+    },
+    "glass-border": {
+      "$value": "#ffffff24",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff24", "Light": "#00000014" } } }
+    },
+    "glass-bg-start": {
+      "$value": "#ffffff0f",
+      "$description": "Glass gradient start",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff0f", "Light": "#ffffffb8" } } }
+    },
+    "glass-bg-end": {
+      "$value": "#ffffff05",
+      "$description": "Glass gradient end",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff05", "Light": "#ffffff8c" } } }
+    },
+    "inner-card-bg": {
+      "$value": "#ffffff08",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff08", "Light": "#00000005" } } }
+    },
+    "inner-card-border": {
+      "$value": "#ffffff0f",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff0f", "Light": "#0000000d" } } }
+    },
+    "inner-card-green-bg": {
+      "$value": "#4ade800f",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade800f", "Light": "#16a34a0a" } } }
+    },
+    "inner-card-green-border": {
+      "$value": "#4ade8026",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8026", "Light": "#16a34a1f" } } }
+    },
+    "btn-primary-text": {
+      "$value": "#ffffff",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff", "Light": "#ffffff" } } }
+    },
+    "btn-primary-border": {
+      "$value": "#4ade8073",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8073", "Light": "#16a34a4d" } } }
+    },
+    "btn-ghost-border": {
+      "$value": "#ffffff24",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff24", "Light": "#0000001a" } } }
+    },
+    "btn-ghost-text": {
+      "$value": "#ffffffd9",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffffd9", "Light": "#000000b3" } } }
+    },
+    "input-border": {
+      "$value": "#ffffff24",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff24", "Light": "#0000001a" } } }
+    },
+    "input-text": {
+      "$value": "#e2e8f0",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#e2e8f0", "Light": "#1a2332" } } }
+    },
+    "input-placeholder": {
+      "$value": "#ffffff80",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff80", "Light": "#00000059" } } }
+    },
+    "input-focus-border": {
+      "$value": "#4ade8073",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8073", "Light": "#16a34a80" } } }
+    },
+    "nav-active": {
+      "$value": "#4ade80",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade80", "Light": "#16a34a" } } }
+    },
+    "nav-inactive": {
+      "$value": "#ffffff80",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff80", "Light": "#00000066" } } }
+    },
+    "pill-paid-bg": {
+      "$value": "#4ade8026",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8026", "Light": "#16a34a1a" } } }
+    },
+    "pill-paid-text": {
+      "$value": "#4ade80",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade80", "Light": "#16a34a" } } }
+    },
+    "pill-unpaid-bg": {
+      "$value": "#ffffff0f",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff0f", "Light": "#0000000a" } } }
+    },
+    "pill-unpaid-text": {
+      "$value": "#ffffff59",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff59", "Light": "#00000059" } } }
+    },
+    "banner-green-bg": {
+      "$value": "#4ade8014",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8014", "Light": "#16a34a0f" } } }
+    },
+    "banner-green-border": {
+      "$value": "#4ade8033",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8033", "Light": "#16a34a26" } } }
+    },
+    "banner-amber-bg": {
+      "$value": "#fb923c14",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#fb923c14", "Light": "#d97706f" } } }
+    },
+    "banner-amber-border": {
+      "$value": "#fb923c33",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#fb923c33", "Light": "#d9770626" } } }
+    },
+    "list-green-bg": {
+      "$value": "#4ade800f",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade800f", "Light": "#16a34a0d" } } }
+    },
+    "list-green-text": {
+      "$value": "#4ade80a6",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade80a6", "Light": "#16a34abf" } } }
+    },
+    "list-amber-bg": {
+      "$value": "#fbbf240f",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#fbbf240f", "Light": "#d976060d" } } }
+    },
+    "list-amber-text": {
+      "$value": "#fbbf24a6",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#fbbf24a6", "Light": "#d97706bf" } } }
+    },
+    "dropdown-bg": {
+      "$value": "#1e281ef8",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#1e281ef8", "Light": "#fffffff8" } } }
+    },
+    "segment-bg": {
+      "$value": "#7676801f",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#7676801f", "Light": "#0000000d" } } }
+    },
+    "segment-active-bg": {
+      "$value": "#4ade8033",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade8033", "Light": "#16a34a1f" } } }
+    },
+    "segment-active-text": {
+      "$value": "#4ade80",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#4ade80", "Light": "#16a34a" } } }
+    },
+    "segment-inactive-text": {
+      "$value": "#ffffff99",
+      "$extensions": { "com.figma": { "mode": { "Dark": "#ffffff99", "Light": "#00000073" } } }
+    }
+  },
+  "size": {
+    "$type": "number",
+    "radius-card": { "$value": 24, "$description": "Glass card border radius" },
+    "radius-button": { "$value": 14, "$description": "Button & input radius" },
+    "radius-inner-card": { "$value": 12, "$description": "Inner card radius" },
+    "radius-banner": { "$value": 16, "$description": "Status banner radius" },
+    "radius-segment": { "$value": 100, "$description": "Segment control pill" },
+    "radius-segment-tab": { "$value": 20, "$description": "Segment tab radius" },
+    "height-input": { "$value": 42, "$description": "Input/date field height" },
+    "height-segment": { "$value": 32, "$description": "Segment control height" },
+    "min-tap-target": { "$value": 44, "$description": "Minimum touch target" },
+    "blur-glass-dark": { "$value": 10, "$description": "Glass blur (dark)" },
+    "blur-glass-light": { "$value": 16, "$description": "Glass blur (light)" }
+  },
+  "fontWeight": {
+    "$type": "number",
+    "section-label": { "$value": 700 },
+    "btn-primary": { "$value": 600 },
+    "btn-ghost": { "$value": 500 },
+    "segment-active": { "$value": 590 },
+    "segment-inactive": { "$value": 510 }
+  },
+  "duration": {
+    "$type": "number",
+    "fast": { "$value": 150, "$description": "ms" },
+    "normal": { "$value": 250, "$description": "ms" },
+    "slow": { "$value": 400, "$description": "ms" }
+  }
+}

--- a/docs/user-research-simulation.md
+++ b/docs/user-research-simulation.md
@@ -1,0 +1,516 @@
+# BPM Badminton — User Research Report (AI-Simulated)
+
+> **Date:** April 12, 2026
+> **Method:** AI-simulated personas, usability testing, and needs analysis
+> **Status:** Draft — findings should be validated with real players
+
+---
+
+## 1. Executive Summary
+
+This report reconstructs lost user research notes through AI simulation. Using deep analysis of the BPM Badminton codebase, badminton player culture, and the demographics of a Chinese-Canadian recreational group, we generated 8 personas, simulated usability tests across 25+ task scenarios, and identified unmet needs cross-referenced against the P0-P4 product roadmap.
+
+**Key finding:** 7 of the top 10 unmet needs have zero roadmap coverage. The single largest gap is **Chinese language support** — roughly half the player base reads Chinese primarily, yet every UI string, error message, and state banner is English-only. The roadmap (P1-P3) is heavily weighted toward skill/progress features while localization, payment, and accessibility for the actual user demographics remain unaddressed.
+
+**Recommendation:** Insert a **P1.5 — Localization & Accessibility** tier before continuing with P2.
+
+---
+
+## 2. Methodology
+
+| Phase | Activity | Output |
+|-------|----------|--------|
+| 1 | Persona creation from app feature inventory + casual badminton culture | 8 personas |
+| 2 | Simulated usability testing (6 personas x 4-5 tasks each) | 25+ task walkthroughs |
+| 3 | Unmet needs analysis cross-referenced against P0-P4 roadmap | Top 10 ranked needs |
+| 4 | Report compilation and recommendations | This document |
+
+**Limitations:**
+- AI-simulated, not real user interviews — behavioral patterns are inferred, not observed
+- Persona demographics extrapolated from app context (Chinese-Canadian badminton group, dim sum culture, WeChat/WhatsApp split)
+- Usability "tests" are cognitive walkthroughs, not screen recordings
+- Findings should be validated by asking 2-3 real players from each archetype
+
+---
+
+## 3. User Personas
+
+### Persona 1: Kevin Tran — The Organizer
+
+| | |
+|---|---|
+| **Age / Occupation** | 34, Software Developer |
+| **Role** | Admin (built the app) |
+| **Language** | Bilingual (English / Chinese) |
+| **Tech Comfort** | Expert |
+| **Sign-up** | First — creates the session |
+| **Payment** | Collects from others |
+| **Primary Need** | Reduce admin overhead |
+| **Key Frustration** | People message him instead of using the app; chasing payments weekly |
+
+Kevin has organized the weekly session for 3 years. He creates sessions Monday evening, monitors sign-ups through the week, manages bird inventory, chases 2-3 late payments via WhatsApp/WeChat after every session, and advances the session on Sunday. He spends more time managing badminton than playing it.
+
+---
+
+### Persona 2: Priya Sharma — The Core Regular
+
+| | |
+|---|---|
+| **Age / Occupation** | 29, Physiotherapist |
+| **Role** | Regular Player |
+| **Language** | English-primary |
+| **Tech Comfort** | Comfortable |
+| **Sign-up** | Within hours of opening |
+| **Payment** | Immediate (same day) |
+| **Primary Need** | Quick info: when, where, who, how much |
+| **Key Frustration** | Missing cost info when no announcement posted; no skill data visible |
+
+Priya played competitively in India. She's one of the strongest players and never misses a week. Her app interaction is 15 seconds: open, sign up, done. She checks the roster once mid-week to anticipate doubles matchups. She pays on the drive home.
+
+---
+
+### Persona 3: Marcus Chen — The Flaky One
+
+| | |
+|---|---|
+| **Age / Occupation** | 27, Marketing Coordinator |
+| **Role** | Irregular Player |
+| **Language** | English-primary |
+| **Tech Comfort** | Savvy but careless |
+| **Sign-up** | Last minute or not at all |
+| **Payment** | 2-3 days late, needs reminding |
+| **Primary Need** | Keep options open without committing |
+| **Key Frustration** | Losing identity when browser data clears; feeling pressured to commit early |
+
+Marcus decides Friday night whether he's going Saturday. He's cancelled 3 times in 2 months. He clears browser data periodically, which wipes his localStorage identity — he can see his name on the roster but can't cancel or interact. He texts Kevin to fix it.
+
+---
+
+### Persona 4: Emily Nguyen — The Beginner
+
+| | |
+|---|---|
+| **Age / Occupation** | 24, Junior Accountant |
+| **Role** | New Player (6 weeks) |
+| **Language** | English-primary |
+| **Tech Comfort** | Very comfortable |
+| **Sign-up** | Early (prompted by Priya) |
+| **Payment** | Prompt |
+| **Primary Need** | Get better without embarrassment; feel included |
+| **Key Frustration** | Skills tab is a dead-end; no group norms explained; no progress tracking |
+
+Emily joined through Priya. She holds the racket with a frying pan grip and apologizes after missed shots. She checks the Skills tab every week hoping it'll have content. She watches YouTube tutorials after each session. She'd love a self-assessment to track her improvement.
+
+---
+
+### Persona 5: Jason Park — The Competitive One
+
+| | |
+|---|---|
+| **Age / Occupation** | 31, Financial Analyst |
+| **Role** | Regular Player |
+| **Language** | Bilingual (English / Korean / Chinese) |
+| **Tech Comfort** | Proficient |
+| **Sign-up** | Immediate, every week |
+| **Payment** | Immediate |
+| **Primary Need** | Skill data, stats, balanced courts |
+| **Key Frustration** | No skill info on roster; Skills tab admin-gated; no performance tracking |
+
+Jason is the best player in the group — ex-competitive, provincial ranking. He mentally plans doubles combinations from the roster. He discovered the 5-tap admin easter egg but couldn't get past the PIN. He's asked Kevin twice about opening the Skills tab to players.
+
+---
+
+### Persona 6: Linda Wu — The Social Glue
+
+| | |
+|---|---|
+| **Age / Occupation** | 38, HR Manager |
+| **Role** | Regular-ish Player |
+| **Language** | Bilingual (English / Chinese) |
+| **Tech Comfort** | Comfortable |
+| **Sign-up** | Mid-week |
+| **Payment** | Within 24 hours |
+| **Primary Need** | Community, social connection, group coordination |
+| **Key Frustration** | No social features; supplements everything via WhatsApp/WeChat |
+
+Linda organizes post-game dim sum, texts people who haven't shown up in weeks, and welcomes new players. She screenshots the app's sign-up list into WhatsApp every week. She calls the app "a spreadsheet with good skin" — functional but personality-free.
+
+---
+
+### Persona 7: Uncle Chen — The Chinese-Primary Elder
+
+| | |
+|---|---|
+| **Age / Occupation** | 55, Semi-retired |
+| **Role** | Regular Player |
+| **Language** | Mandarin / Cantonese primary, minimal English |
+| **Tech Comfort** | Low (phone is main device, uses WeChat) |
+| **Sign-up** | Needs family member's help |
+| **Payment** | Cash or late e-transfer (with help) |
+| **Primary Need** | Chinese UI so he can use the app independently |
+| **Key Frustration** | Entire app is in English; can't read error messages, buttons, or announcements |
+
+Uncle Chen has played badminton recreationally for 30+ years. He's a strong player with excellent court sense. But the English-only UI means he can't sign up, check the roster, or understand announcements without asking his nephew to translate. He uses WeChat exclusively — WhatsApp links feel foreign.
+
+---
+
+### Persona 8: Amy Zhang — The Occasional Spouse
+
+| | |
+|---|---|
+| **Age / Occupation** | 35, Office Manager |
+| **Role** | Occasional Player |
+| **Language** | Mandarin-primary, functional English |
+| **Tech Comfort** | Moderate |
+| **Sign-up** | Via husband (doesn't have link saved) |
+| **Payment** | Via husband |
+| **Primary Need** | Simple, one-tap sign-up when she decides to come |
+| **Key Frustration** | Not on invite list; has to get the link fresh each time; English UI is friction |
+
+Amy comes when her husband plays (~2x/month). She's a beginner and slightly intimidated by the group. She doesn't save the app link and gets it from her husband each time. If the invite list is active and she's not on it, she gets a confusing 403 error and gives up.
+
+---
+
+## 4. Usability Test Results
+
+### Critical Issues (2)
+
+#### 4.1 Cold Start Blank Screen (10-20s)
+
+The app shows a **white screen** for 10-20 seconds during initial JavaScript hydration on B1 tier cold starts. The `ShuttleLoader` animation only renders after React hydrates — before that, nothing is visible. Users think the app is broken.
+
+- **Affected:** All users on first visit or after 20min idle
+- **Most impacted:** Uncle Chen (closes tab), Amy (gives up), Marcus ("your app is broken")
+
+> *"I waited like 15 seconds staring at a white screen. I almost closed it."* — Marcus
+
+#### 4.2 localStorage Identity Unrecoverable
+
+Clearing browser data **permanently** destroys the `deleteToken`. Users can see their name on the roster but cannot self-cancel, self-identify, or regain control. Attempting to re-sign-up returns a 409 ("already signed up"). The only recovery is asking the admin.
+
+- **Affected:** Anyone who clears browser data, switches phones, or uses incognito
+- **Most impacted:** Marcus (clears data regularly), Uncle Chen (might use different browser)
+
+> *"It says I'm already signed up but it won't let me do anything. The app literally forgot who I am but remembers my name."* — Marcus
+
+---
+
+### Major Issues (9)
+
+#### 4.3 No Onboarding for First-Time Users
+
+The app assumes you know what BPM is, how the group works, what the invite list means, and how payment works. Zero welcome, zero FAQ, zero "how this works" guidance.
+
+> *"The app looks polished and I can sign up easily. But I still don't know basic stuff like 'should I bring my own shuttles?'"* — Emily
+
+#### 4.4 Invite List Blocks with Unhelpful Error
+
+When `approvedNames` is active, non-listed players get a 403: "Name not on the invite list." No guidance on what the list is, how to get on it, or who to contact.
+
+> *"Nobody told me about a list. I had to text Kevin and wait for him to fix it. By then I almost just said forget it."* — Marcus
+
+#### 4.5 Skills Tab Dead-End for Non-Admins
+
+25-33% of nav real estate occupied by a tab that shows only "Progress together?" — no explanation, no timeline, no self-assessment, no value.
+
+> *"I keep checking this tab every week hoping something appears. 'Progress together?' — how? When? Give me something."* — Emily
+
+#### 4.6 Skill Data Entirely Admin-Gated
+
+The admin has a full radar chart with 7 ACE dimensions for every player. Regular players have **zero** access to this data — not even their own profile.
+
+> *"Just let me see my own skill chart, man. I don't need to edit anything."* — Jason
+
+#### 4.7 Cost Visibility Coupled to Announcement
+
+No announcement posted = no cost info visible to players. The coupling is non-obvious. Players have to ask on WhatsApp.
+
+> *"Last week cost wasn't showing. Apparently Kevin hadn't posted an announcement yet. Why would the cost depend on whether there's an announcement?"* — Priya
+
+#### 4.8 Payment Info Disappears After Session Ends
+
+The e-transfer email and payment reminder only render during the "signed up" state. After the session finishes, payment details vanish — exactly when players need them most.
+
+> *"I know I owe $11.25, but the e-transfer email vanished from the app."* — Linda
+
+#### 4.9 No Payment Aggregate for Admin
+
+Kevin manually scans each player row to count who has and hasn't paid. No counter, no filter, no cross-session report.
+
+> *"I'm basically keeping a mental tally. A simple 'X of Y paid' counter would save me five minutes of squinting."* — Kevin
+
+#### 4.10 No Social Features
+
+Zero comments, reactions, profiles, photos, or messaging. Linda screenshots the sign-up list into WhatsApp weekly. The app handles transactions but not community.
+
+> *"It's a beautiful app for signing up, but that's all it does. I still coordinate everything fun in WhatsApp."* — Linda
+
+#### 4.11 "Next Week" Button Buried
+
+Admin's most frequent action (advancing to next session) requires scrolling past the entire player list, waitlist, removed players, and quick-access buttons. With 12+ players, this is significant scroll distance.
+
+> *"I set up next week's session every Sunday night and I always have to scroll past everyone just to hit that button."* — Kevin
+
+---
+
+### Minor Issues (11)
+
+1. No cost breakdown visible to non-admins (just the final per-person number)
+2. "Coming Soon" tab label nearly invisible (9px, 70% opacity, no icon)
+3. No confirmation notification after sign-up (no email, no push)
+4. "Reported" payment badge is 9px and easy to miss
+5. No beginner guide or FAQ for new players
+6. No player profiles or attendance history on roster
+7. No payment history or "I already paid" self-check for players
+8. Sign-up form provides no guidance on required name format for invite list
+9. No preview of announcement appearance on Home tab before posting
+10. 5-tap easter egg reveals Admin tab you can't use (false promise)
+11. `signupOpen` defaults to closed on advance with no toggle in the advance form
+
+### Cosmetic Issues (3)
+
+1. No scheduling for announcements (post now or not at all)
+2. No player disambiguation for common names
+3. Theme preference (`badminton_theme`) lost when browser data cleared
+
+---
+
+## 5. Unmet Needs Analysis — Top 10
+
+| Rank | Need | Category | Impact | In Roadmap? |
+|------|------|----------|--------|-------------|
+| 1 | Chinese language support (zh-CN + zh-TW) | Localization | HIGH | **No** |
+| 2 | Cold start loading UX (static skeleton) | Accessibility | HIGH | **No** |
+| 3 | Identity recovery (interim before Emoji PIN) | Identity | HIGH | P3 (distant) |
+| 4 | First-time onboarding + invite list guidance | Onboarding | HIGH | **No** |
+| 5 | Payment tracking aggregate (admin view) | Payment | HIGH | **No** |
+| 6 | Text size accessibility for 50+ users | Accessibility | MED-HIGH | **No** |
+| 7 | WeChat sharing & browser compatibility | Communication | MED-HIGH | **No** |
+| 8 | Payment info persistence after session ends | Payment | MEDIUM | **No** |
+| 9 | Skills tab value for non-admins | Skill/Progress | MEDIUM | P1-S2 (planned) |
+| 10 | Proxy sign-up (on behalf of another player) | Social | MEDIUM | **No** |
+
+---
+
+### Need 1: Chinese Language Support
+
+**"As Uncle Chen, I need the app in Chinese so I can sign up, read announcements, and understand errors without asking my nephew for help."**
+
+- **Workaround:** Family member translates or signs up on their behalf
+- **Affected:** Uncle Chen, Amy Zhang, Linda Wu, Jason Park (partially)
+- **Impact:** HIGH — affects ~50% of users on every single visit
+
+### Need 2: Cold Start Loading UX
+
+**"As Amy Zhang, I need to see something loading during the 10-20s cold start so I know the app isn't broken."**
+
+- **Workaround:** Refresh repeatedly or give up
+- **Affected:** All users, especially first-time visitors and after idle periods
+- **Impact:** HIGH — happens every cold start, causes abandonment
+
+### Need 3: Identity Recovery
+
+**"As Marcus, I need to reclaim my sign-up after clearing browser data so I don't have to bother Kevin every time."**
+
+- **Workaround:** Text Kevin (admin) to remove/re-add manually
+- **Affected:** Marcus, Uncle Chen, Amy, anyone switching phones
+- **Impact:** HIGH — permanent lockout with no self-service recovery
+
+### Need 4: First-Time Onboarding
+
+**"As Amy Zhang, I need to understand what this app is, whether I can sign up, and what happens if I'm not on the invite list."**
+
+- **Workaround:** Ask partner or another player to explain
+- **Affected:** Emily, Amy, Uncle Chen, any new player
+- **Impact:** HIGH — every new user hits this; 403 errors cause abandonment
+
+### Need 5: Payment Tracking Aggregate
+
+**"As Kevin (admin), I need a 'X/Y paid' counter and filter so I don't manually count paid status across 12 player rows."**
+
+- **Workaround:** Visual scan + mental tally + cross-reference bank notifications
+- **Affected:** Kevin (admin)
+- **Impact:** HIGH — happens every session, significant admin time sink
+
+### Need 6: Text Size for Older Users
+
+**"As Uncle Chen, I need larger text so I can read session details and player names without pinch-to-zoom."**
+
+- **Workaround:** Pinch-to-zoom or system accessibility settings
+- **Affected:** Uncle Chen, Linda (38), older players
+- **Impact:** MED-HIGH — base text 14px, errors/costs at 12px; difficult for 50+ on phone screens
+
+### Need 7: WeChat Sharing & Browser Compatibility
+
+**"As Linda Wu, I need to share the app link via WeChat with rich previews so the Chinese-speaking members can easily access it."**
+
+- **Workaround:** Copy-paste raw URL into WeChat (no rich preview, in-app browser quirks)
+- **Affected:** Linda, Uncle Chen, Amy, all WeChat users
+- **Impact:** MED-HIGH — WeChat is primary messaging for ~50% of users
+
+### Need 8: Payment Info Persistence
+
+**"As Marcus, I need to see how much I owe and where to pay even after the session ends."**
+
+- **Workaround:** Ask Kevin or scroll through banking app for previous transfer details
+- **Affected:** Marcus, Linda, any player who pays after the session
+- **Impact:** MEDIUM — payment details vanish at the moment they're most needed
+
+### Need 9: Skills Tab for Non-Admins
+
+**"As Emily (beginner), I need the Skills tab to show me something useful so I can track my improvement."**
+
+- **Workaround:** None — tap once, see placeholder, never return
+- **Affected:** Emily, Jason, Priya, all non-admin users
+- **Impact:** MEDIUM — addressed in P1 Stage 2 (planned but not shipped)
+
+### Need 10: Proxy Sign-Up
+
+**"As Linda Wu, I need to sign up my husband or another player who doesn't have the app open."**
+
+- **Workaround:** Ask Kevin (admin) to add the person, or use the other person's phone
+- **Affected:** Linda, Uncle Chen's family, Amy's husband
+- **Impact:** MEDIUM — common in family/social groups
+
+---
+
+## 6. Localization Deep-Dive
+
+### Why It Matters
+
+For a Chinese-Canadian badminton group where ~50% of players read Chinese primarily, English-only UI is not a cosmetic issue — it's an accessibility barrier. Uncle Chen cannot use the app independently. Amy struggles through functional English. Even bilingual players like Linda and Jason would prefer their primary language.
+
+### Scope
+
+- **~120 UI strings** need translation: buttons, labels, error messages, state banners, form placeholders, tab names, status text
+- **Both Simplified (zh-CN) and Traditional (zh-TW)** Chinese needed to serve the full community
+- **Player names** are already Unicode-safe — no code changes needed for Chinese names in the roster
+- **Date/time formatting** already uses `toLocaleDateString(undefined, ...)` which respects browser locale
+- **Admin-authored content** (announcements) stays in whatever language the admin writes
+
+### Technical Approach
+
+- **Framework:** `next-intl` or a simple JSON dictionary with `useTranslations()` hook
+- **Detection:** Browser locale via `Accept-Language` header for initial language, with manual toggle in UI
+- **Toggle placement:** Header or settings — visible but not intrusive
+- **Fallback:** English for any untranslated strings
+- **Build impact:** Minimal — string extraction, no layout changes needed (Chinese text is generally more compact than English)
+
+### Cultural UX Considerations
+
+| Aspect | Current | Needed |
+|--------|---------|--------|
+| **Messaging platform** | WhatsApp-centric | WeChat sharing with rich OG previews |
+| **Confirmation patterns** | Single-tap cancel | Chinese UX norms expect more confirmation steps; especially important for older users |
+| **Payment norms** | E-transfer assumed | Some older players prefer cash; payment method flexibility |
+| **Link sharing** | Standard URL | WeChat in-app browser has localStorage quirks — test thoroughly |
+| **Communication style** | Direct/informal English | More polite/formal tone in Chinese translations |
+
+### Bilingual Announcements
+
+The existing "Improve with AI" feature for announcements could be extended to auto-generate a Chinese translation alongside the English text. This would let Kevin write in English and automatically produce a bilingual announcement visible on the Home tab.
+
+---
+
+## 7. Roadmap Gap Analysis
+
+### Current Roadmap Coverage
+
+| Tier | Focus | Covers Research Needs? |
+|------|-------|----------------------|
+| P0 | Core app (invite list, identity, roster, admin) | N/A — complete |
+| P1 | Skill framework (radar chart, persistence, admin tools) | Partially — Stage 2 (non-admin view) addresses Need #9 |
+| P2 | Self-assessment, spider graph, attendance, cost splitting | Partially — attendance + cost features address some gaps |
+| P3 | Emoji PIN identity, peer assessment, matchmaking | Partially — Emoji PIN addresses Need #3 (but distant) |
+| P4 | Polish, multi-admin, subdomain | Minimal overlap with research needs |
+
+### Gap Summary
+
+| Need | Roadmap Status |
+|------|---------------|
+| 1. Chinese localization | **NOT IN ROADMAP** |
+| 2. Cold start UX | **NOT IN ROADMAP** (noted as gotcha only) |
+| 3. Identity recovery | P3 (2+ tiers away, no interim bridge) |
+| 4. Onboarding | **NOT IN ROADMAP** |
+| 5. Payment aggregate | **NOT IN ROADMAP** |
+| 6. Text size accessibility | **NOT IN ROADMAP** |
+| 7. WeChat sharing | **NOT IN ROADMAP** (WhatsApp only in P2) |
+| 8. Payment persistence | **NOT IN ROADMAP** |
+| 9. Skills for non-admins | P1-S2 (planned, not shipped) |
+| 10. Proxy sign-up | **NOT IN ROADMAP** |
+
+**7 of 10 top needs have zero roadmap coverage.**
+
+### The Mismatch
+
+The roadmap prioritizes **skill/progress features** (P1-P3) — radar charts, self-assessment, coaching, matchmaking. These serve Jason (competitive) and Emily (beginner wanting structure) well.
+
+But the roadmap **misses the demographic reality**: half the users can't read the UI, older players struggle with text size, payment tracking is manual, and there's no onboarding. These aren't edge cases — they affect 50%+ of the user base on every visit.
+
+### Recommendation: Insert P1.5
+
+**P1.5 — Localization & Accessibility** (before P2):
+1. Chinese i18n framework + first-pass translation (~120 strings)
+2. Language toggle (auto-detect + manual)
+3. Cold start static skeleton
+4. Text size minimum increase (base 16px)
+5. Payment info always visible (decouple from announcement)
+6. Onboarding card for first-time users
+7. Invite list error improvement (guidance text)
+8. "X/Y paid" counter for admin view
+
+---
+
+## 8. Recommendations
+
+### Immediate (Next 1-2 Sessions)
+
+| # | Action | Effort | Impact |
+|---|--------|--------|--------|
+| 1 | Set up i18n framework (`next-intl` or JSON dict) + translate ~120 strings to zh-CN and zh-TW | Medium | HIGH — unlocks app for ~50% of users |
+| 2 | Add static HTML skeleton for cold start (before React hydrates) | Small | HIGH — prevents abandonment |
+| 3 | Decouple payment info from announcement card — always show e-transfer details | Small | MEDIUM — fixes disappearing payment info |
+
+### Short-Term (Next Month)
+
+| # | Action | Effort | Impact |
+|---|--------|--------|--------|
+| 4 | First-time onboarding overlay explaining BPM + sign-up flow + invite list | Small | HIGH — reduces confusion and admin support burden |
+| 5 | Increase base text to 16px, minimum 14px for secondary content | Small | MED-HIGH — accessibility for older users |
+| 6 | Payment aggregate admin view ("5/8 paid" counter + filter toggle) | Medium | HIGH — saves Kevin 5-10 min/session |
+| 7 | Improve invite list error: explain what it is, who to contact | Small | MEDIUM — reduces 403 abandonment |
+| 8 | Move "Next Week" button above player list (or pin it) | Small | MINOR — reduces admin scroll friction |
+
+### Medium-Term
+
+| # | Action | Effort | Impact |
+|---|--------|--------|--------|
+| 9 | Test WeChat in-app browser + optimize OG meta tags for Chinese previews | Medium | MED-HIGH — WeChat is primary for ~50% |
+| 10 | Identity recovery bridge (name + secret phrase reclaim) before P3 emoji PIN | Medium | HIGH — self-service recovery without full account system |
+| 11 | Proxy sign-up flow (sign up on behalf of another player) | Medium | MEDIUM — helps families and social coordinators |
+| 12 | Bilingual AI announcements (English + Chinese auto-translation) | Medium | MEDIUM — leverages existing AI improve feature |
+
+### Continue As Planned
+
+- **P1 Stage 2:** Non-admin read-only skills view (addresses Need #9)
+- **P2:** Self-assessment across 7 ACE dimensions
+- **P3:** Emoji PIN identity (addresses Need #3 fully)
+
+---
+
+## 9. Appendix: Persona Comparison Matrix
+
+| Persona | Age | Language | Tech Comfort | Frequency | Sign-up Timing | Payment | Primary Need |
+|---------|-----|----------|-------------|-----------|---------------|---------|-------------|
+| Kevin (Admin) | 34 | EN / ZH | Expert | Every week | First (creates) | Collects | Reduce admin burden |
+| Priya | 29 | EN | Comfortable | Every week | Within hours | Immediate | Info + reliability |
+| Marcus | 27 | EN | Savvy / careless | 2-3x/month | Last minute | 2-3 days late | Flexibility |
+| Emily | 24 | EN | Very comfortable | Most weeks | Early (prompted) | Prompt | Learning structure |
+| Jason | 31 | EN / KR / ZH | Proficient | Every week | Immediate | Immediate | Skill data + stats |
+| Linda | 38 | EN / ZH | Comfortable | Most weeks | Mid-week | Within 24h | Community + social |
+| Uncle Chen | 55 | ZH primary | Low | Every week | Needs help | Cash / late | Chinese UI |
+| Amy (Spouse) | 35 | ZH primary | Moderate | 2x/month | Via husband | Via husband | Simple sign-up |
+
+---
+
+*This report was AI-simulated on April 12, 2026. Findings are grounded in actual app architecture and badminton culture but have not been validated with real user interviews. Recommended next step: share key findings with 2-3 players from each archetype to confirm or adjust priorities.*


### PR DESCRIPTION
## Summary
Track four files that were sitting untracked in the repo and refresh ROADMAP.md to capture April 13–16 shipped work.

### Files now tracked
- **`.claude/agents/claudemd-architect.md`** — codebase-reading agent that writes/refreshes `CLAUDE.md`. Same pattern as the already-tracked `design-review.md`.
- **`.claude/agents/ts-error-fixer.md`** — strict correctness-only TS auditor (no refactors, confirms with `npm run build`).
- **`docs/user-research-simulation.md`** — the AI-simulated user research report (2026-04-12) that **drove the entire P1.5 + P1.6 sprint**. 8 personas, 25+ usability scenarios, top-10 unmet needs. Every R1–R7 ticket traces back to a finding in this doc.
- **`docs/figma-tokens.json`** — design tokens export (color, size, fontWeight, duration) from the Figma MCP.

### Gitignored
- **`.claude/agent-memory/`** — per-machine agent scratch. Agents regenerate these files on next run; tracking would just cause stale-snapshot drift.

### ROADMAP.md refresh
- Bumped "Last updated" from `April 10, 2026` → `April 16, 2026`.
- Added **P1.5 — Access & Admin Relief** tier (A1 ✅, C1 ✅; C2/A2/B1 pending).
- Added **P1.6 — Research-Gap Fixes + UX Discoverability** tier (R1 ✅, R2 ✅, R5 ✅, R6 ✅, R7 ✅; R3/R4 pending).
- Every shipped item links to its PR and ties back to the research report's finding.

## Test plan
- [ ] Pull, `ls .claude/agents/` shows all three agent files.
- [ ] `cat .gitignore | grep agent-memory` returns the ignore pattern.
- [ ] `ROADMAP.md` renders with new P1.5 + P1.6 sections.
- [ ] No code impact; CI should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)