### PR TITLE
feat(i18n): C2 content sweep — BottomNav + HomeTab + PlayersTab

### DIFF
--- a/__tests__/components/BottomNav.test.tsx
+++ b/__tests__/components/BottomNav.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import BottomNav from '../../components/BottomNav';
+import enMessages from '../../messages/en.json';
+import zhMessages from '../../messages/zh-CN.json';
+
+function renderWithLocale(locale: 'en' | 'zh-CN', showAdmin = true) {
+  const messages = locale === 'en' ? enMessages : zhMessages;
+  return render(
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <BottomNav activeTab="home" onTabChange={vi.fn()} showAdmin={showAdmin} />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('BottomNav — i18n', () => {
+  afterEach(cleanup);
+
+  it('renders English tab labels', () => {
+    renderWithLocale('en');
+    expect(screen.getByRole('button', { name: 'Home' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sign-Ups' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Coming Soon' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Admin' })).toBeTruthy();
+  });
+
+  it('renders zh-CN tab labels', () => {
+    renderWithLocale('zh-CN');
+    expect(screen.getByRole('button', { name: '首页' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '报名' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '即将推出' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '管理' })).toBeTruthy();
+  });
+
+  it('splits EN "Coming Soon" into two stacked lines', () => {
+    const { container } = renderWithLocale('en');
+    const skillsBtn = screen.getByRole('button', { name: 'Coming Soon' });
+    const blocks = skillsBtn.querySelectorAll('span.block');
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]?.textContent).toBe('Coming');
+    expect(blocks[1]?.textContent).toBe('Soon');
+    expect(container).toBeTruthy();
+  });
+
+  it('renders zh-CN skills label as a single line (no whitespace split)', () => {
+    renderWithLocale('zh-CN');
+    const skillsBtn = screen.getByRole('button', { name: '即将推出' });
+    const blocks = skillsBtn.querySelectorAll('span.block');
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]?.textContent).toBe('即将推出');
+  });
+
+  it('hides admin tab when showAdmin is false', () => {
+    renderWithLocale('en', false);
+    expect(screen.queryByRole('button', { name: 'Admin' })).toBeNull();
+    expect(screen.getAllByRole('button').length).toBe(3);
+  });
+});

--- a/__tests__/i18n/locale-parity.test.ts
+++ b/__tests__/i18n/locale-parity.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import enMessages from '../../messages/en.json';
+import zhMessages from '../../messages/zh-CN.json';
+
+function leafPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix];
+  const entries = Object.entries(obj as Record<string, unknown>);
+  return entries.flatMap(([k, v]) => leafPaths(v, prefix ? `${prefix}.${k}` : k));
+}
+
+describe('locale parity — en.json and zh-CN.json have identical key shape', () => {
+  const enPaths = leafPaths(enMessages).sort();
+  const zhPaths = leafPaths(zhMessages).sort();
+
+  it('no key exists in en.json that is missing from zh-CN.json', () => {
+    const missingInZh = enPaths.filter((p) => !zhPaths.includes(p));
+    expect(missingInZh).toEqual([]);
+  });
+
+  it('no key exists in zh-CN.json that is missing from en.json', () => {
+    const extraInZh = zhPaths.filter((p) => !enPaths.includes(p));
+    expect(extraInZh).toEqual([]);
+  });
+
+  it('leaf counts match', () => {
+    expect(enPaths.length).toBe(zhPaths.length);
+  });
+});

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { Tab } from '@/app/page';
 
 interface Props {
@@ -8,24 +9,28 @@ interface Props {
   showAdmin?: boolean;
 }
 
-const TABS: { id: Tab; label: string; icon?: string; textLines?: string[] }[] = [
-  { id: 'home', label: 'Home', icon: 'home' },
-  { id: 'players', label: 'Sign-Ups', icon: 'group' },
-  { id: 'skills', label: 'Coming Soon', textLines: ['Coming', 'Soon'] },
-  { id: 'admin', label: 'Admin', icon: 'admin_panel_settings' },
-];
+type NavItem = { id: Tab; label: string; icon?: string; stack?: boolean };
 
 export default function BottomNav({ activeTab, onTabChange, showAdmin }: Props) {
-  const visibleTabs = TABS.filter(tab => tab.id !== 'admin' || showAdmin);
+  const t = useTranslations('nav');
+  const tabs: NavItem[] = [
+    { id: 'home', label: t('home'), icon: 'home' },
+    { id: 'players', label: t('signups'), icon: 'group' },
+    { id: 'skills', label: t('skills'), stack: true },
+    { id: 'admin', label: t('admin'), icon: 'admin_panel_settings' },
+  ];
+  const visibleTabs = tabs.filter((tab) => tab.id !== 'admin' || showAdmin);
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 nav-safe-area">
       <div className="max-w-lg mx-auto px-4">
       <div className="nav-glass flex px-2 py-1.5">
         {visibleTabs.map((tab) => {
           const active = activeTab === tab.id;
+          const lines = tab.stack && tab.label.includes(' ') ? tab.label.split(' ') : null;
           return (
             <button
               key={tab.id}
+              type="button"
               onClick={() => onTabChange(tab.id)}
               aria-label={tab.label}
               aria-current={active ? 'page' : undefined}
@@ -41,9 +46,13 @@ export default function BottomNav({ activeTab, onTabChange, showAdmin }: Props) 
                 </>
               ) : (
                 <span className="text-[9px] font-medium leading-snug text-center tracking-wide uppercase opacity-70" aria-hidden="true">
-                  {tab.textLines?.map((line, i) => (
-                    <span key={i} className="block">{line}</span>
-                  ))}
+                  {lines ? (
+                    lines.map((line, i) => (
+                      <span key={i} className="block">{line}</span>
+                    ))
+                  ) : (
+                    <span className="block">{tab.label}</span>
+                  )}
                 </span>
               )}
             </button>

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -44,6 +44,7 @@ function fmtDeadline(iso: string) {
 
 export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onTabChange?: (tab: 'home' | 'players' | 'admin') => void; onTitleTap?: () => void; devOverrides?: DevOverrides }) {
   const t = useTranslations('home');
+  const tStates = useTranslations('home.states');
   const [session, setSession] = useState<Session | null>(null);
   const [players, setPlayers] = useState<Player[]>([]);
   const [announcement, setAnnouncement] = useState<Announcement | null>(null);
@@ -183,7 +184,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
 
   async function handleSignUp(e: React.FormEvent) {
     e.preventDefault();
-    if (!name.trim()) { setError('Enter your name to sign up'); return; }
+    if (!name.trim()) { setError(t('signup.nameRequired')); return; }
     setIsSubmitting(true);
     setError('');
     try {
@@ -197,7 +198,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
         if (data.error === 'invite_list_not_found') {
           setError(t('signup.inviteError', { name: name.trim() }));
         } else {
-          setError(data.error ?? 'Failed to sign up');
+          setError(data.error ?? t('signup.genericFailure'));
         }
         if (res.status === 409) loadData();
       } else {
@@ -207,7 +208,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
         await loadData();
       }
     } catch {
-      setError('Network error. Please try again.');
+      setError(t('signup.networkError'));
     } finally {
       setIsSubmitting(false);
     }
@@ -215,7 +216,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
 
   async function handleJoinWaitlist(e: React.FormEvent) {
     e.preventDefault();
-    if (!name.trim()) { setError('Enter your name to sign up'); return; }
+    if (!name.trim()) { setError(t('signup.nameRequired')); return; }
     setIsSubmitting(true);
     setError('');
     try {
@@ -229,7 +230,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
         if (data.error === 'invite_list_not_found') {
           setError(t('signup.inviteError', { name: name.trim() }));
         } else {
-          setError(data.error ?? 'Failed to join waitlist');
+          setError(data.error ?? t('signup.waitlistFailure'));
         }
       } else {
         setIdentity({ name: name.trim(), token: data.deleteToken ?? '', sessionId: session?.id ?? '' });
@@ -238,14 +239,14 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
         await loadData();
       }
     } catch {
-      setError('Network error. Please try again.');
+      setError(t('signup.networkError'));
     } finally {
       setIsSubmitting(false);
     }
   }
 
   if (loading) {
-    return <ShuttleLoader text="Loading session..." />;
+    return <ShuttleLoader text={t('loading')} />;
   }
 
   const mapsUrl = session?.locationAddress
@@ -338,8 +339,8 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
             <div className="status-banner-green">
               <span className="material-icons icon-status text-green-400">celebration</span>
               <div>
-                <p className="font-semibold text-green-400 text-sm">Thanks for playing!</p>
-                <p className="text-xs text-gray-400 mt-0.5">Sign up for next week will be announced soon.</p>
+                <p className="font-semibold text-green-400 text-sm">{tStates('finishedTitle')}</p>
+                <p className="text-xs text-gray-400 mt-0.5">{tStates('finishedBody')}</p>
               </div>
             </div>
           </div>
@@ -350,8 +351,8 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
             <div className="status-banner-orange">
               <span className="material-icons icon-status text-amber-400">hourglass_top</span>
               <div>
-                <p className="font-semibold text-amber-300 text-sm">Sign-ups opening soon</p>
-                <p className="text-xs text-gray-400 mt-0.5">Check back soon.</p>
+                <p className="font-semibold text-amber-300 text-sm">{tStates('openingSoonTitle')}</p>
+                <p className="text-xs text-gray-400 mt-0.5">{tStates('openingSoonBody')}</p>
               </div>
             </div>
           </div>
@@ -362,8 +363,8 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
             <div className="status-banner-orange">
               <span className="material-icons icon-status text-amber-400">lock_clock</span>
               <div>
-                <p className="font-semibold text-amber-300 text-sm">Sign-ups closed</p>
-                <p className="text-xs text-gray-400 mt-0.5">Sign-ups closed on {fmtDeadline(session!.deadline)}</p>
+                <p className="font-semibold text-amber-300 text-sm">{tStates('closedTitle')}</p>
+                <p className="text-xs text-gray-400 mt-0.5">{t('signup.closedPreviously', { date: fmtDeadline(session!.deadline) })}</p>
               </div>
             </div>
           </div>
@@ -372,17 +373,17 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <p className="text-xl font-bold text-green-400">{t('signup.heading')}</p>
-              <p className="text-sm text-gray-400">Signed-up: {activePlayers.length} · {spotsTotal - activePlayers.length} spots left</p>
+              <p className="text-sm text-gray-400">{t('signup.spotsRemaining', { count: activePlayers.length, remaining: spotsTotal - activePlayers.length })}</p>
             </div>
             <div className="status-banner-green">
               <span className="material-icons icon-status text-green-400">check_circle</span>
               <div>
-                <p className="font-semibold text-green-400 text-sm">{currentUser ? `${currentUser}, thank you for signing up!` : 'Thanks for signing up!'}</p>
-                <p className="text-xs text-gray-400 mt-0.5">See you soon!</p>
+                <p className="font-semibold text-green-400 text-sm">{currentUser ? tStates('signedUpTitle', { name: currentUser }) : tStates('signedUpTitleGeneric')}</p>
+                <p className="text-xs text-gray-400 mt-0.5">{tStates('signedUpBody')}</p>
               </div>
             </div>
             <button type="button" onClick={() => onTabChange?.('players')} className="btn-ghost w-full">
-              View Sign Up List
+              {t('signup.viewList')}
             </button>
           </div>
         ) : isWaitlisted ? (
@@ -391,7 +392,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
             <div className="flex items-start justify-between">
               <p className="text-xl font-bold text-green-400">{t('signup.heading')}</p>
               <div className="text-right">
-                <p className="text-xs text-gray-400">Waitlist</p>
+                <p className="text-xs text-gray-400">{tStates('waitlistLabel')}</p>
                 <p className="text-2xl font-bold text-amber-400 leading-none mt-0.5">
                   #{waitlistPosition}
                 </p>
@@ -400,12 +401,12 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
             <div className="status-banner-orange">
               <span className="material-icons icon-status text-amber-400">schedule</span>
               <div>
-                <p className="font-semibold text-amber-400 text-sm">You&apos;re on the waitlist</p>
-                <p className="text-xs text-gray-400 mt-0.5">Position #{waitlistPosition} of {waitlistPlayers.length} · {t('signup.confirmed', { name: currentUser ?? '' })}</p>
+                <p className="font-semibold text-amber-400 text-sm">{tStates('waitlistTitle')}</p>
+                <p className="text-xs text-gray-400 mt-0.5">{tStates('waitlistPositionLabel', { position: waitlistPosition, total: waitlistPlayers.length })} · {t('signup.confirmed', { name: currentUser ?? '' })}</p>
               </div>
             </div>
             <button type="button" onClick={() => onTabChange?.('players')} className="btn-ghost w-full">
-              View Sign Up List
+              {t('signup.viewList')}
             </button>
           </div>
         ) : isFull && !isDeadlinePast ? (
@@ -413,13 +414,13 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <p className="text-xl font-bold text-green-400">{t('signup.heading')}</p>
-              <p className="text-sm text-gray-400">Signed-up: {activePlayers.length} · Full</p>
+              <p className="text-sm text-gray-400">{t('signup.spotsFull', { count: activePlayers.length })}</p>
             </div>
             <div className="status-banner-orange">
               <span className="material-icons icon-status text-orange-400">lock</span>
               <div>
                 <p className="font-semibold text-orange-300 text-sm">{t('signup.full')}</p>
-                <p className="text-xs text-gray-400 mt-0.5">All {spotsTotal} spots are taken.</p>
+                <p className="text-xs text-gray-400 mt-0.5">{t('signup.allSpotsTaken', { total: spotsTotal })}</p>
               </div>
             </div>
             <form onSubmit={handleJoinWaitlist} className="space-y-3">
@@ -428,8 +429,8 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
                   id="waitlist-name"
                   name="name"
                   type="text"
-                  placeholder="Enter your name"
-                  aria-label="Your name"
+                  placeholder={t('signup.namePlaceholder')}
+                  aria-label={t('signup.nameAriaLabel')}
                   aria-describedby={error ? 'signup-error' : undefined}
                   value={name}
                   onChange={(e) => { setName(e.target.value); setError(''); setShowSuggestions(true); }}
@@ -463,7 +464,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
               </div>
               {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
               <button type="submit" disabled={isSubmitting} className="btn-primary w-full">
-                {isSubmitting ? 'Joining…' : t('signup.waitlist')}
+                {isSubmitting ? t('signup.joining') : t('signup.waitlist')}
               </button>
             </form>
           </div>
@@ -472,7 +473,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <p className="text-xl font-bold text-green-400">{t('signup.heading')}</p>
-              <p className="text-sm text-gray-400">Signed-up: {activePlayers.length} · {spotsTotal - activePlayers.length} spots left</p>
+              <p className="text-sm text-gray-400">{t('signup.spotsRemaining', { count: activePlayers.length, remaining: spotsTotal - activePlayers.length })}</p>
             </div>
             <form onSubmit={handleSignUp} className="space-y-3">
               <div className="relative">
@@ -480,8 +481,8 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
                   id="signup-name"
                   name="name"
                   type="text"
-                  placeholder="Enter your name"
-                  aria-label="Your name"
+                  placeholder={t('signup.namePlaceholder')}
+                  aria-label={t('signup.nameAriaLabel')}
                   aria-describedby={error ? 'signup-error' : undefined}
                   value={name}
                   onChange={(e) => { setName(e.target.value); setError(''); setShowSuggestions(true); }}
@@ -516,11 +517,11 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
               {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
               <button type="submit" disabled={isSubmitting} className="btn-primary w-full">
                 {!isSubmitting && <span className="material-icons icon-sm" aria-hidden="true">how_to_reg</span>}
-                {isSubmitting ? 'Signing up…' : t('signup.button')}
+                {isSubmitting ? t('signup.submitting') : t('signup.button')}
               </button>
               {session?.deadline && (
                 <p className={`text-center text-xs font-medium ${isDeadlineApproaching ? 'text-red-400' : 'text-gray-400'}`}>
-                  Sign up closes on {fmtDeadline(session.deadline)}
+                  {t('signup.closesOn', { date: fmtDeadline(session.deadline) })}
                 </p>
               )}
             </form>

--- a/components/PlayersTab.tsx
+++ b/components/PlayersTab.tsx
@@ -11,6 +11,7 @@ const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
 export default function PlayersTab() {
   const pageT = useTranslations('pages.signup');
+  const t = useTranslations('players');
   const [players, setPlayers] = useState<Player[]>([]);
   const [session, setSession] = useState<Session | null>(null);
   const [currentUser, setCurrentUser] = useState<string | null>(null);
@@ -56,10 +57,10 @@ export default function PlayersTab() {
         setConfirmingCancel(false);
         loadPlayers();
       } else {
-        setCancelError('Failed to cancel. Please try again.');
+        setCancelError(t('cancelFailure'));
       }
     } catch {
-      setCancelError('Failed to cancel. Please try again.');
+      setCancelError(t('cancelFailure'));
     }
   }
 
@@ -69,7 +70,7 @@ export default function PlayersTab() {
         <h1 className="text-3xl font-bold text-gray-200 leading-tight px-2">
           {pageT('title')}
         </h1>
-        <ShuttleLoader text="Loading players..." />
+        <ShuttleLoader text={t('loading')} />
       </div>
     );
   }
@@ -85,7 +86,7 @@ export default function PlayersTab() {
         </h1>
         <div className="glass-card p-10 text-center">
           <span className="material-icons block mb-2 text-gray-500" style={{ fontSize: 36, opacity: 0.25 }}>sports_tennis</span>
-          <p className="text-gray-500 text-sm">No one&apos;s signed up yet — be the first!</p>
+          <p className="text-gray-500 text-sm">{t('empty')}</p>
         </div>
       </div>
     );
@@ -102,7 +103,7 @@ export default function PlayersTab() {
       {/* Active players card */}
       <div className="glass-card overflow-hidden">
         <div className="px-4 pt-3 pb-2 section-label">
-          {gameDate || 'UPCOMING SESSION'}
+          {gameDate || t('upcomingSession')}
         </div>
 
         <div className="px-2 pb-2 space-y-0.5">
@@ -123,7 +124,7 @@ export default function PlayersTab() {
                     {player.name}
                     {isMe && (
                       <span className="ml-1.5 text-xs text-green-400 font-normal">
-                        (you)
+                        {t('youSuffix')}
                       </span>
                     )}
                   </span>
@@ -131,16 +132,17 @@ export default function PlayersTab() {
                     <div className="flex flex-col items-end gap-0.5">
                       {confirmingCancel ? (
                         <div className="flex items-center gap-2 text-xs">
-                          <span className="text-gray-400">Cancel your spot?</span>
-                          <button onClick={handleCancel} className="text-red-400 hover:text-red-300 transition-colors px-2 py-1" style={{ minHeight: 32 }}>Yes</button>
-                          <button onClick={() => setConfirmingCancel(false)} className="text-gray-400 hover:text-white transition-colors px-2 py-1" style={{ minHeight: 32 }}>No</button>
+                          <span className="text-gray-400">{t('cancelConfirm')}</span>
+                          <button type="button" onClick={handleCancel} className="text-red-400 hover:text-red-300 transition-colors px-2 py-1" style={{ minHeight: 32 }}>{t('confirmYes')}</button>
+                          <button type="button" onClick={() => setConfirmingCancel(false)} className="text-gray-400 hover:text-white transition-colors px-2 py-1" style={{ minHeight: 32 }}>{t('confirmNo')}</button>
                         </div>
                       ) : (
                         <button
+                          type="button"
                           onClick={() => setConfirmingCancel(true)}
                           className="text-xs text-red-400 hover:text-red-300 transition-colors ml-1"
                         >
-                          Cancel
+                          {t('cancelAction')}
                         </button>
                       )}
                       {cancelError && (
@@ -158,7 +160,7 @@ export default function PlayersTab() {
       {waitlistPlayers.length > 0 && (
         <div className="glass-card overflow-hidden">
           <div className="list-header-amber px-4 pt-3 pb-2">
-            WAITLIST
+            {t('waitlistHeader')}
           </div>
             <div className="px-2 pb-2 space-y-0.5">
               {waitlistPlayers.map((player, i) => {
@@ -178,7 +180,7 @@ export default function PlayersTab() {
                       {player.name}
                       {isMe && (
                         <span className="ml-1.5 text-xs text-amber-400 font-normal">
-                          (you)
+                          {t('youSuffix')}
                         </span>
                       )}
                     </span>
@@ -186,16 +188,17 @@ export default function PlayersTab() {
                       <div className="flex flex-col items-end gap-0.5">
                         {confirmingCancel ? (
                           <div className="flex items-center gap-2 text-xs">
-                            <span className="text-gray-400">Cancel your spot?</span>
-                            <button onClick={handleCancel} className="text-red-400 hover:text-red-300 transition-colors">Yes</button>
-                            <button onClick={() => setConfirmingCancel(false)} className="text-gray-400 hover:text-white transition-colors">No</button>
+                            <span className="text-gray-400">{t('cancelConfirm')}</span>
+                            <button type="button" onClick={handleCancel} className="text-red-400 hover:text-red-300 transition-colors">{t('confirmYes')}</button>
+                            <button type="button" onClick={() => setConfirmingCancel(false)} className="text-gray-400 hover:text-white transition-colors">{t('confirmNo')}</button>
                           </div>
                         ) : (
                           <button
+                            type="button"
                             onClick={() => setConfirmingCancel(true)}
                             className="text-xs text-red-400 hover:text-red-300 transition-colors ml-1"
                           >
-                            Leave
+                            {t('leaveAction')}
                           </button>
                         )}
                         {cancelError && (

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,8 +7,35 @@
       "full": "Session Full",
       "confirmed": "Signed up as {name}",
       "inviteError": "We don't have \"{name}\" on our invite list. Check the spelling, or ask the friend who shared this app with you to add you.",
-      "networkError": "Network error. Please try again."
+      "networkError": "Network error. Please try again.",
+      "nameRequired": "Enter your name to sign up",
+      "genericFailure": "Failed to sign up",
+      "waitlistFailure": "Failed to join waitlist",
+      "namePlaceholder": "Enter your name",
+      "nameAriaLabel": "Your name",
+      "joining": "Joining…",
+      "submitting": "Signing up…",
+      "viewList": "View Sign Up List",
+      "spotsRemaining": "Signed-up: {count} · {remaining} spots left",
+      "spotsFull": "Signed-up: {count} · Full",
+      "allSpotsTaken": "All {total} spots are taken.",
+      "closesOn": "Sign up closes on {date}",
+      "closedPreviously": "Sign-ups closed on {date}"
     },
+    "states": {
+      "finishedTitle": "Thanks for playing!",
+      "finishedBody": "Sign up for next week will be announced soon.",
+      "openingSoonTitle": "Sign-ups opening soon",
+      "openingSoonBody": "Check back soon.",
+      "closedTitle": "Sign-ups closed",
+      "signedUpTitle": "{name}, thank you for signing up!",
+      "signedUpTitleGeneric": "Thanks for signing up!",
+      "signedUpBody": "See you soon!",
+      "waitlistLabel": "Waitlist",
+      "waitlistTitle": "You're on the waitlist",
+      "waitlistPositionLabel": "Position #{position} of {total}"
+    },
+    "loading": "Loading session...",
     "cost": {
       "label": "Estimated cost",
       "emphasis": "Cost this week: <amount>{value}</amount>"
@@ -48,6 +75,25 @@
     "signup": { "title": "Sign-Up" },
     "learn": { "title": "Learn" },
     "admin": { "title": "Admin" }
+  },
+  "nav": {
+    "home": "Home",
+    "signups": "Sign-Ups",
+    "skills": "Coming Soon",
+    "admin": "Admin"
+  },
+  "players": {
+    "loading": "Loading players...",
+    "empty": "No one's signed up yet — be the first!",
+    "upcomingSession": "UPCOMING SESSION",
+    "waitlistHeader": "WAITLIST",
+    "youSuffix": "(you)",
+    "cancelAction": "Cancel",
+    "leaveAction": "Leave",
+    "cancelConfirm": "Cancel your spot?",
+    "confirmYes": "Yes",
+    "confirmNo": "No",
+    "cancelFailure": "Failed to cancel. Please try again."
   },
   "admin": {
     "releases": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -7,8 +7,35 @@
       "full": "名额已满",
       "confirmed": "已报名：{name}",
       "inviteError": "邀请名单上没有\"{name}\"。请检查拼写，或联系分享此应用的朋友将您添加。",
-      "networkError": "网络错误，请重试。"
+      "networkError": "网络错误，请重试。",
+      "nameRequired": "请输入您的姓名以报名",
+      "genericFailure": "报名失败",
+      "waitlistFailure": "加入候补失败",
+      "namePlaceholder": "输入您的姓名",
+      "nameAriaLabel": "您的姓名",
+      "joining": "正在加入…",
+      "submitting": "正在报名…",
+      "viewList": "查看报名列表",
+      "spotsRemaining": "已报名 {count} 人 · 剩余 {remaining} 个名额",
+      "spotsFull": "已报名 {count} 人 · 满员",
+      "allSpotsTaken": "全部 {total} 个名额已满。",
+      "closesOn": "报名截止于 {date}",
+      "closedPreviously": "报名已于 {date} 截止"
     },
+    "states": {
+      "finishedTitle": "感谢参与！",
+      "finishedBody": "下周的报名稍后公布。",
+      "openingSoonTitle": "报名即将开放",
+      "openingSoonBody": "稍后再来查看。",
+      "closedTitle": "报名已截止",
+      "signedUpTitle": "{name}，感谢您的报名！",
+      "signedUpTitleGeneric": "感谢您的报名！",
+      "signedUpBody": "期待与您相见！",
+      "waitlistLabel": "候补",
+      "waitlistTitle": "您在候补名单上",
+      "waitlistPositionLabel": "候补第 {position} 位 / 共 {total} 位"
+    },
+    "loading": "正在加载活动…",
     "cost": {
       "label": "预估费用",
       "emphasis": "本周费用：<amount>{value}</amount>"
@@ -48,6 +75,25 @@
     "signup": { "title": "报名" },
     "learn": { "title": "进阶技能" },
     "admin": { "title": "管理" }
+  },
+  "nav": {
+    "home": "首页",
+    "signups": "报名",
+    "skills": "即将推出",
+    "admin": "管理"
+  },
+  "players": {
+    "loading": "正在加载报名名单…",
+    "empty": "还没有人报名 — 来当第一个吧！",
+    "upcomingSession": "即将举行的活动",
+    "waitlistHeader": "候补名单",
+    "youSuffix": "（您）",
+    "cancelAction": "取消",
+    "leaveAction": "离开",
+    "cancelConfirm": "取消您的名额？",
+    "confirmYes": "是",
+    "confirmNo": "否",
+    "cancelFailure": "取消失败，请重试。"
   },
   "admin": {
     "releases": {


### PR DESCRIPTION
## Summary
- Extends C1's 14-key canary to full player happy-path translation coverage: nav tabs, HomeTab state banners (signed-up/waitlisted/full/deadline-past/finished/opening-soon), sign-up form affordances, PlayersTab list chrome + cancel flow.
- New top-level namespaces: `nav`, `home.states`, `players`. Extended `home.signup` with errors, buttons, form, spot counts, deadline.
- BottomNav renders stacked layout only when the label contains whitespace, so zh-CN single-word labels render single-line while EN "Coming Soon" stays stacked.
- New **locale-parity test** walks both JSON files and asserts leaf-key shape is identical — guards against dropped translations in either locale going forward.
- +5 BottomNav component tests, +3 locale parity assertions → **236 tests total**.

## Out of scope (bounded by user intent)
- `components/admin/*` surfaces — deferred until market launch
- Learn page (`SkillsTab`, `SkillsRadar`, `lib/skills-data.ts` ACE matrix) — content still being finalized
- `zh-TW` locale — deferred
- Server-side API error strings (`app/api/players/route.ts` returns English) — needs error-code refactor (separate PR)
- Date localization via `toLocaleDateString(undefined, ...)` in `lib/formatters.ts` — pre-existing gap exposed by i18n rollout; recommend **C3** follow-up

## Test plan
- [x] `npm test` — 236/236 pass
- [x] Browser: zh-CN happy path (open sign-up, invite error, signed-up banner with name interpolation, PlayersTab list + youSuffix, cancel confirm prompt, actual delete round-trip)
- [x] Browser: EN baseline (nav labels, sign-up card)
- [x] Locale toggle — cookie flips, refresh triggers re-render
- [ ] Manual spot-check after merge on live Azure app

🤖 Generated with [Claude Code](https://claude.com/claude-code)