### PR TITLE
feat(admin): Cost Details UX cleanup + 0.25 tube increments

### DIFF
--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -165,7 +165,7 @@ describe('PUT /api/session', () => {
     expect(data.birdUsage).toBeUndefined();
   });
 
-  it('rejects bird tubes not in 0.5 increments', async () => {
+  it('rejects bird tubes not in 0.25 increments', async () => {
     const bird = await (await CREATE_BIRD(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
       name: 'Test', tubes: 4, totalCost: 80,
     }))).json();

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -62,9 +62,9 @@ export async function PUT(req: NextRequest) {
         if (!Number.isFinite(tubes) || tubes <= 0 || tubes > 100) {
           return NextResponse.json({ error: 'Bird tubes must be between 0 and 100' }, { status: 400 });
         }
-        // Multiple of 0.5 — rejects 0.33, 1.7, etc.
-        if (Math.round(tubes * 2) !== tubes * 2) {
-          return NextResponse.json({ error: 'Bird tubes must be in 0.5 increments' }, { status: 400 });
+        // Multiple of 0.25 — rejects 0.33, 1.7, etc.
+        if (Math.round(tubes * 4) !== tubes * 4) {
+          return NextResponse.json({ error: 'Bird tubes must be in 0.25 increments' }, { status: 400 });
         }
         const purchaseId = entry?.purchaseId;
         if (typeof purchaseId !== 'string' || !purchaseId) {

--- a/components/AdminTab.tsx
+++ b/components/AdminTab.tsx
@@ -106,18 +106,8 @@ export default function AdminTab() {
     );
   }
 
-  return (
-    <div className="space-y-5">
-      <h1 className="text-3xl font-bold text-gray-200 leading-tight px-2">
-        {pageT('title')}
-      </h1>
-      <AdminPanel onLogout={handleLogout} />
-    </div>
-  );
-}
-
-/* ─────────────────────────── Admin Panel ─────────────────────────── */
-
-function AdminPanel({ onLogout }: { onLogout: () => void }) {
-  return <AdminDashboard onLogout={onLogout} />;
+  // Dashboard renders its own h1 when on the dashboard view so the header
+  // disappears when the user drills into a sub-editor (Session Details,
+  // Members, etc.) — those render AdminBackHeader instead.
+  return <AdminDashboard onLogout={handleLogout} />;
 }

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
+import { useTranslations } from 'next-intl';
 import type { AdminView } from './types';
 import { ShimmerLoader } from '../ShuttleLoader';
 import SessionContextBar from './SessionContextBar';
@@ -73,6 +74,7 @@ interface DashboardProps {
 }
 
 function Dashboard({ onLogout, refreshKey, setView }: DashboardProps) {
+  const pageT = useTranslations('pages.admin');
   const anno = useAnnouncements(refreshKey);
 
   // Player management needs navigation state, navigation needs loadPlayers
@@ -87,13 +89,17 @@ function Dashboard({ onLogout, refreshKey, setView }: DashboardProps) {
   /* ── Render ── */
 
   return (
-    <div className="space-y-4 w-full">
-      {/* Header */}
-      <div className="flex items-center justify-between px-1">
-        <h2 className="font-semibold text-green-400">Admin</h2>
+    <div className="space-y-5 w-full">
+      {/* Header: page h1 matches the 30px style on Sign-Up/Learn pages.
+          Sign-out is aligned to the baseline so it reads as a tertiary action. */}
+      <div className="flex items-end justify-between">
+        <h1 className="text-3xl font-bold text-gray-200 leading-tight px-2">
+          {pageT('title')}
+        </h1>
         <button
+          type="button"
           onClick={onLogout}
-          className="text-xs text-gray-400 hover:text-white transition-colors flex items-center gap-1"
+          className="text-xs text-gray-400 hover:text-white transition-colors flex items-center gap-1 px-2 pb-1"
         >
           <span className="material-icons" style={{ fontSize: 16 }}>logout</span>
           Sign out

--- a/components/admin/SessionDetailsEditor.tsx
+++ b/components/admin/SessionDetailsEditor.tsx
@@ -24,6 +24,59 @@ function CardDescription({ children }: { children: React.ReactNode }) {
   );
 }
 
+/* Quarter-tube stepper. Value is clamped to 0+ and rounded to 2 decimals
+   each tap to avoid floating-point drift (0.1 + 0.2 ≠ 0.3). Valid values
+   are 0, 0.25, 0.5, 0.75, 1.0, … */
+function TubeStepper({ value, onChange }: { value: number; onChange: (next: number) => void }) {
+  const step = 0.25;
+  const canDec = value > 0;
+  const round = (n: number) => Math.round(n * 100) / 100;
+  // Drop trailing zeros so 0.5 shows as "0.5" not "0.50", while 0.25 stays "0.25"
+  const display = value === 0 ? '0' : parseFloat(value.toFixed(2)).toString();
+  const btn: React.CSSProperties = {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+    background: 'var(--inner-card-bg)',
+    border: '1px solid var(--inner-card-border)',
+  };
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        type="button"
+        onClick={() => onChange(round(Math.max(0, value - step)))}
+        disabled={!canDec}
+        aria-label="Decrease tubes"
+        className="flex items-center justify-center transition-opacity"
+        style={{
+          ...btn,
+          color: 'var(--text-primary)',
+          opacity: canDec ? 1 : 0.35,
+          cursor: canDec ? 'pointer' : 'not-allowed',
+        }}
+      >
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 20 }}>remove</span>
+      </button>
+      <span
+        className="text-base font-semibold tabular-nums"
+        style={{ color: 'var(--text-primary)', minWidth: 48, textAlign: 'center' }}
+        aria-live="polite"
+      >
+        {display}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(round(value + step))}
+        aria-label="Increase tubes"
+        className="flex items-center justify-center"
+        style={{ ...btn, color: 'var(--text-primary)', cursor: 'pointer' }}
+      >
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 20 }}>add</span>
+      </button>
+    </div>
+  );
+}
+
 type BirdUsageRow = { purchaseId: string; tubes: number };
 
 type DetailsForm = {
@@ -300,30 +353,36 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
             </div>
           </Label>
 
-          {/* ── Bird sources — inline rows, no nested card ── */}
-          <div className="space-y-3">
+          {/* ── Bird usage — divider separates from cost-per-court above.
+               mt-2 + pt-6 widens the breathing room on both sides of the
+               rule so Cost-per-court doesn't feel jammed against it and
+               the "Bird usage" header doesn't hug the line. ── */}
+          <div
+            className="space-y-4 mt-2 pt-6"
+            style={{ borderTop: '1px solid var(--glass-border)' }}
+          >
             <div className="flex items-center justify-between">
-              <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
-                Bird sources
+              <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+                Bird usage
               </span>
               <button
                 type="button"
                 onClick={() =>
                   setForm((f) => ({
                     ...f,
-                    birdUsages: [...f.birdUsages, { purchaseId: '', tubes: 0.5 }],
+                    birdUsages: [...f.birdUsages, { purchaseId: '', tubes: 0 }],
                   }))
                 }
                 className="text-xs font-medium px-2 py-1 rounded-md"
                 style={{ color: 'var(--accent)', background: 'var(--inner-card-bg)' }}
               >
-                + Add source
+                + Add from inventory
               </button>
             </div>
 
             {form.birdUsages.length === 0 && (
               <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
-                No bird sources selected.
+                No bird usage recorded.
               </p>
             )}
 
@@ -336,15 +395,19 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                   return (
                     <div
                       key={idx}
-                      className="py-3 space-y-2"
+                      className="py-3 space-y-3"
                       style={
                         isLast
                           ? undefined
                           : { borderBottom: '1px solid var(--glass-border)' }
                       }
                     >
-                      <div className="flex items-start gap-2">
-                        <div className="flex-1 space-y-2">
+                      <Label text="Brand">
+                        {/* Native browser chevron varies across macOS/iOS/
+                            Android and doesn't match the app's icon set.
+                            Suppress with appearance:none and render our own
+                            material-icons chevron positioned absolutely. */}
+                        <div className="relative">
                           <select
                             value={row.purchaseId}
                             onChange={(e) =>
@@ -355,17 +418,13 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                               })
                             }
                             style={{
-                              width: '100%',
-                              padding: '8px 12px',
-                              borderRadius: 8,
-                              background: 'var(--inner-card-bg)',
-                              border: '1px solid var(--inner-card-border)',
-                              color: 'var(--text-primary)',
-                              fontSize: 14,
+                              appearance: 'none',
+                              WebkitAppearance: 'none',
+                              MozAppearance: 'none',
+                              paddingRight: 40,
                             }}
-                            aria-label="Bird purchase"
                           >
-                            <option value="">Select purchase…</option>
+                            <option value="">Select brand…</option>
                             {purchases.map((p) => (
                               <option key={p.id} value={p.id}>
                                 {p.name} — ${p.costPerTube.toFixed(2)}/tube (
@@ -373,52 +432,74 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                               </option>
                             ))}
                           </select>
-                          <div className="flex items-center gap-2">
-                            <span className="text-xs shrink-0" style={{ color: 'var(--text-muted)' }}>
-                              Tubes
-                            </span>
-                            <input
-                              type="number"
-                              min={0}
-                              step={0.5}
-                              value={row.tubes || ''}
-                              placeholder="0.5"
-                              aria-label="Tubes used"
-                              onChange={(e) =>
-                                setForm((f) => {
-                                  const next = [...f.birdUsages];
-                                  next[idx] = { ...next[idx], tubes: parseFloat(e.target.value) || 0 };
-                                  return { ...f, birdUsages: next };
-                                })
-                              }
-                              className="flex-1"
-                            />
-                          </div>
-                          {selected && row.tubes > 0 && (
-                            <p className="text-xs" style={{ color: 'var(--accent)' }}>
-                              {row.tubes} × ${selected.costPerTube.toFixed(2)} = ${rowTotal.toFixed(2)}
-                            </p>
-                          )}
+                          <span
+                            className="material-icons absolute top-1/2 pointer-events-none"
+                            aria-hidden="true"
+                            style={{
+                              right: 10,
+                              transform: 'translateY(-50%)',
+                              fontSize: 20,
+                              color: 'var(--text-muted)',
+                            }}
+                          >
+                            expand_more
+                          </span>
                         </div>
+                      </Label>
+                      <Label text="Tubes used">
+                        <TubeStepper
+                          value={row.tubes}
+                          onChange={(next) =>
+                            setForm((f) => {
+                              const rows = [...f.birdUsages];
+                              rows[idx] = { ...rows[idx], tubes: next };
+                              return { ...f, birdUsages: rows };
+                            })
+                          }
+                        />
+                      </Label>
+                      {/* Footer row: equation reads in plain English. Unset
+                          slots show their label (Tube usage / Cost per tube /
+                          Bird cost); filled slots show the value inline. Color
+                          shifts from muted → accent when fully complete. */}
+                      {(() => {
+                        const complete = !!selected && row.tubes > 0;
+                        const tubesSlot = row.tubes > 0
+                          ? `${parseFloat(row.tubes.toFixed(2))} ${row.tubes === 1 ? 'tube' : 'tubes'}`
+                          : 'Tube usage';
+                        const costSlot = selected
+                          ? `$${selected.costPerTube.toFixed(2)} per tube`
+                          : 'Cost per tube';
+                        const totalSlot = complete ? `$${rowTotal.toFixed(2)}` : 'Bird cost';
+                        return (
+                          <div className="flex items-center justify-between gap-2 min-h-8">
+                            <p
+                              className="text-xs"
+                              style={{ color: complete ? 'var(--accent)' : 'var(--text-muted)' }}
+                            >
+                              {tubesSlot} × {costSlot} = {totalSlot}
+                            </p>
                         <button
                           type="button"
-                          aria-label="Remove bird source"
+                          aria-label="Remove bird usage"
                           onClick={() =>
                             setForm((f) => ({
                               ...f,
                               birdUsages: f.birdUsages.filter((_, i) => i !== idx),
                             }))
                           }
-                          className="text-base rounded-md flex items-center justify-center"
+                          className="rounded-md flex items-center justify-center shrink-0 -mr-2"
                           style={{
                             color: 'var(--text-muted)',
-                            minHeight: 44,
-                            minWidth: 44,
+                            height: 32,
+                            width: 32,
                           }}
                         >
-                          ×
+                          <span className="material-icons" aria-hidden="true" style={{ fontSize: 20 }}>delete_outline</span>
                         </button>
                       </div>
+                        );
+                      })()}
                     </div>
                   );
                 })}
@@ -438,28 +519,6 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                 </span>
               </div>
             )}
-          </div>
-
-          {/* ── Show cost toggle (now a real switch) ── */}
-          <div className="flex items-center justify-between pt-1">
-            <div>
-              <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                Show cost to players
-              </p>
-              <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
-                {form.showCostBreakdown ? 'Visible on the Home announcement' : 'Hidden from players'}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => setForm((f) => ({ ...f, showCostBreakdown: !f.showCostBreakdown }))}
-              className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${form.showCostBreakdown ? 'bg-green-500' : 'bg-white/20'}`}
-              role="switch"
-              aria-checked={form.showCostBreakdown}
-              aria-label="Toggle cost visibility"
-            >
-              <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform duration-200 ${form.showCostBreakdown ? 'translate-x-5' : 'translate-x-0'}`} />
-            </button>
           </div>
 
           {/* ── Per-person preview ── */}
@@ -487,6 +546,28 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
               )}
             </div>
           )}
+
+          {/* ── Show cost toggle (now a real switch) ── */}
+          <div className="flex items-center justify-between pt-1">
+            <div>
+              <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                Show cost to players
+              </p>
+              <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                {form.showCostBreakdown ? 'Visible on the Home announcement' : 'Hidden from players'}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setForm((f) => ({ ...f, showCostBreakdown: !f.showCostBreakdown }))}
+              className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none ${form.showCostBreakdown ? 'bg-green-500' : 'bg-white/20'}`}
+              role="switch"
+              aria-checked={form.showCostBreakdown}
+              aria-label="Toggle cost visibility"
+            >
+              <span className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform duration-200 ${form.showCostBreakdown ? 'translate-x-5' : 'translate-x-0'}`} />
+            </button>
+          </div>
         </div>
 
         {/* ── Error + Update ── */}


### PR DESCRIPTION
## Summary
Reshape the Cost Details card on the Session Details admin editor so every field uses a consistent Label treatment, tube counts feel native on mobile, and the Admin page header stops doubling up on sub-pages.

## Bird usage section
- **Tube count steps in 0.25 increments** (was 0.5) via a new ± stepper that physically constrains input rather than suggesting "any decimal is fine" like a free-form number field does.
- Server-side validator (\`app/api/session/route.ts\`) updated to enforce 0.25 multiples; test name updated.
- **Brand** dropdown + **Tubes used** stepper both wrapped in \`<Label>\`, consistent with Cost per court above. Native browser chevron suppressed (\`appearance: none\`) and replaced with a material \`expand_more\` icon to match the rest of the app's iconography across macOS/iOS/Android.
- **Equation footer reads in plain English**: \`0.5 tubes × $3.50 per tube = $1.75\`. Unset slots show their own label (\`Tube usage / Cost per tube / Bird cost\`) so the scaffold is always legible. Color shifts muted → accent when both inputs are set.
- **Trash icon** moved onto the equation row, flush-right against the card's content edge via \`-mr-2\`.
- Copy cleanup: "Bird sources" → "Bird usage", "+ Add source" → "+ Add from inventory", "Select purchase…" → "Select brand…"
- New rows default to \`tubes: 0\` so the user steps up explicitly.
- Divider separates Cost-per-court from Bird usage block.

## Per-person preview / Show cost toggle
- Swapped order — preview reads first, toggle follows (keeps the preview's existing borderTop; no new dividers added).

## Admin page header
- Dropped the duplicate h1 "Admin" that appeared both from AdminTab and AdminBackHeader on sub-pages.
- Dashboard component now renders its own 30px h1 (matches Sign-Up / Learn page styles via \`pages.admin.title\` i18n key) with Sign-out aligned baseline.
- Sub-pages (Session Details, Members, Bird Inventory, etc.) show only AdminBackHeader's back-link + sub-page title — no redundant header.

## Test plan
- [x] \`npm test\` — 236/236 pass
- [x] Browser: stepper enforces 0.25 increments, minus disabled at 0
- [x] Browser: custom chevron replaces native select arrow
- [x] Browser: equation reads naturally in both complete and empty states
- [x] Browser: admin page shows single 30px h1 on dashboard, no h1 on sub-pages
- [x] Saving a row with 0.25 tubes succeeds; saving 0.33 still rejects with "must be in 0.25 increments"

🤖 Generated with [Claude Code](https://claude.com/claude-code)