### PR TITLE
fix(infra): correct indentation on NEXT_PUBLIC_GIT_SHA env var

### DIFF
--- a/.github/workflows/main_badminton-app.yml
+++ b/.github/workflows/main_badminton-app.yml
@@ -36,8 +36,8 @@ jobs:
           NEXT_PUBLIC_BASE_PATH: /bpm
           NEXT_PUBLIC_MAX_PLAYERS: '12'
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
-            NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}   # ← add this line
-        
+          NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
+    
       - name: Package standalone build
         run: |
           cp -r .next/static .next/standalone/.next/static


### PR DESCRIPTION
Follow-up to #13. The added `NEXT_PUBLIC_GIT_SHA` env var was over-indented by 2 spaces, which would make YAML parse it as a continuation of `NEXT_PUBLIC_ETRANSFER_EMAIL`'s value instead of a sibling key. Build would silently fail to inject the SHA into the bundle, and the preview banner would always show 'dev' instead of a real commit hash.

## Test plan
- [x] YAML lints as valid after fix
- [x] Build will correctly populate `process.env.NEXT_PUBLIC_GIT_SHA` once merged