### PR TITLE
feat(preview): enrich bug-report email + add layout spacer

### DIFF
--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -2,42 +2,61 @@
 
 import { isPreviewEnv } from '@/lib/flags';
 
-const BUG_REPORT_URL = 'mailto:xyzou2012@gmail.com?subject=bpm-next%20bug%20report';
+const BANNER_HEIGHT = 28;
+const REPORT_EMAIL = 'xyzou2012@gmail.com';
 
 export default function PreviewBanner() {
   if (!isPreviewEnv()) return null;
 
   const sha = (process.env.NEXT_PUBLIC_GIT_SHA ?? 'dev').slice(0, 7);
 
+  function handleReportClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    const subject = `bpm-next bug report · ${sha}`;
+    const body = [
+      `URL: ${window.location.href}`,
+      `SHA: ${sha}`,
+      `UA: ${navigator.userAgent}`,
+      '',
+      'What went wrong:',
+      '',
+    ].join('\n');
+    window.location.href = `mailto:${REPORT_EMAIL}?subject=${encodeURIComponent(
+      subject,
+    )}&body=${encodeURIComponent(body)}`;
+  }
+
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 9999,
-        padding: '6px 12px',
-        textAlign: 'center',
-        fontSize: '12px',
-        fontWeight: 600,
-        letterSpacing: '0.02em',
-        background: 'linear-gradient(90deg, #f59e0b, #f97316)',
-        color: '#111',
-        boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
-      }}
-    >
-      preview bpm vnext · {sha} not the stable site ·{' '}
-      <a
-        href={BUG_REPORT_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        style={{ color: '#111', textDecoration: 'underline' }}
+    <>
+      <div
+        role="status"
+        aria-live="polite"
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 9999,
+          padding: '6px 12px',
+          textAlign: 'center',
+          fontSize: '12px',
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+          background: 'linear-gradient(90deg, #f59e0b, #f97316)',
+          color: '#111',
+          boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
+        }}
       >
-        report a bug
-      </a>
-    </div>
+        preview bpm vnext · {sha} not the stable site ·{' '}
+        <a
+          href={`mailto:${REPORT_EMAIL}`}
+          onClick={handleReportClick}
+          style={{ color: '#111', textDecoration: 'underline' }}
+        >
+          report a bug
+        </a>
+      </div>
+      <div style={{ height: BANNER_HEIGHT }} aria-hidden="true" />
+    </>
   );
 }


### PR DESCRIPTION
## Two small improvements to the preview banner

### Bug-report email now includes context
Tapping "report a bug" opens your mail client with:
- **Subject:** `bpm-next bug report · <sha>`
- **Body:** pre-filled with the exact URL they were viewing, the commit SHA, and their user agent

You'll know which build a tester was on the moment their email arrives — no back-and-forth asking for repro steps.

### Banner no longer blocks page content
Previously the fixed banner sat on top of content (splash, HomeTab title). Now a 28px spacer div after the banner reserves DOM space so everything flows below it. Banner still `position: fixed` so it persists during scroll.

## Test plan
- [x] 245 tests still passing
- [ ] After deploy, verify spacer pushes splash + HomeTab below the banner on bpm-next
- [ ] Tap "report a bug" — mail client should open with pre-filled subject and body
- [ ] Stable site unaffected (banner returns null when `NEXT_PUBLIC_ENV` unset or `stable`)