### PR TITLE
fix(preview): shift theme/language toggles below banner

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -857,7 +857,7 @@ textarea {
 .theme-toggle,
 .lang-toggle {
   position: fixed;
-  top: 16px;
+  top: calc(16px + var(--banner-offset, 0px));
   z-index: 60;
   width: 36px;
   height: 36px;

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -1,12 +1,23 @@
 'use client';
 
+import { useEffect } from 'react';
 import { isPreviewEnv } from '@/lib/flags';
 
 const BANNER_HEIGHT = 28;
 const REPORT_EMAIL = 'xyzou2012@gmail.com';
 
 export default function PreviewBanner() {
-  if (!isPreviewEnv()) return null;
+  const show = isPreviewEnv();
+
+  useEffect(() => {
+    if (!show) return;
+    document.documentElement.style.setProperty('--banner-offset', `${BANNER_HEIGHT}px`);
+    return () => {
+      document.documentElement.style.removeProperty('--banner-offset');
+    };
+  }, [show]);
+
+  if (!show) return null;
 
   const sha = (process.env.NEXT_PUBLIC_GIT_SHA ?? 'dev').slice(0, 7);
 


### PR DESCRIPTION
## Problem
On bpm-next the preview banner (28px tall, `position: fixed; top: 0`) was covering the theme and language toggle buttons, which are `position: fixed; top: 16px`. The spacer div from #16 only helps normal-flow content; fixed-position elements ignored it.

## Fix
`PreviewBanner` now sets a CSS variable `--banner-offset=28px` on the html element when mounted. The toggles use `top: calc(16px + var(--banner-offset, 0px))` so they shift down only on preview. Stable unaffected (var defaults to 0px).

## Test plan
- [x] 245 tests pass
- [ ] After deploy: toggles visible and clickable on bpm-next
- [ ] Stable: toggles remain at top:16px (no offset)