### PR TITLE
fix(i18n): render datetimes in America/Vancouver instead of UTC

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import PreviewBanner from '@/components/PreviewBanner';
+import { APP_TIME_ZONE } from '@/i18n/request';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -57,7 +58,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           <div className="aurora-blob-2" />
           <div className="aurora-blob-3" />
         </div>
-        <NextIntlClientProvider locale={locale} messages={messages}>
+        <NextIntlClientProvider locale={locale} messages={messages} timeZone={APP_TIME_ZONE}>
           {children}
         </NextIntlClientProvider>
       </body>

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -6,6 +6,11 @@ export const SUPPORTED_LOCALES = ['en', 'zh-CN'] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = 'en';
 
+// BPM sessions happen in Vancouver. Render all datetimes in that zone so
+// players see the actual clock time of the game, regardless of where they
+// (or the server) are.
+export const APP_TIME_ZONE = 'America/Vancouver';
+
 export function resolveLocale(
   cookieValue: string | undefined,
   acceptLanguage: string | undefined,
@@ -76,5 +81,5 @@ export default getRequestConfig(async () => {
 
   const messages = deepMerge(enMessages, localeMessages);
 
-  return { locale, messages };
+  return { locale, messages, timeZone: APP_TIME_ZONE };
 });


### PR DESCRIPTION
## Bug
HomeTab's WHEN card showed **Friday April 24, 03:00 AM** for a session stored as **Apr 23, 08:00 PM PDT**. That's the UTC value (20:00 PDT = 03:00 UTC next day) being rendered as if it were local.

## Root cause
`i18n/request.ts` returns `{ locale, messages }` without a `timeZone`. next-intl's `useFormatter` falls back to UTC when unspecified. Every component using `format.dateTime(...)` (HomeTab, PlayersTab, PrevPaymentReminder) inherits this.

## Fix
Set `timeZone: 'America/Vancouver'` on both:
- `getRequestConfig` server config (`i18n/request.ts`)
- `NextIntlClientProvider` in `app/layout.tsx`

Exported as `APP_TIME_ZONE` constant for future multi-tenant override.

## Test plan
- [x] 245 tests pass
- [ ] After deploy: HomeTab WHEN card shows **Thursday April 23, 08:00 PM** for the Apr 23 8pm session
- [ ] Admin dates unchanged (admin reads slice of ISO string, no formatter)
- [ ] zh-CN locale still renders 24-hour time (next-intl locale handling unchanged)

## Follow-up
After merge + verify on bpm-next, promote to stable as hotfix v1.0.1 via the deployment-model.md runbook.