### PR TITLE
docs: log v1.0.1 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,29 @@ First tagged baseline of the stable production site, before the SaaS transformat
 
 ---
 
+## v1.0.1 — Timezone hotfix + two-deployment pipeline (2026-04-22)
+
+Shipped as a hotfix via the new `deploy-stable.yml` manual-dispatch workflow. First end-to-end exercise of the tag-based promotion runbook documented in `docs/deployment-model.md`.
+
+### Fixed
+
+- **Session times rendered in UTC instead of Vancouver time** — the HomeTab WHEN card showed e.g. "Friday, April 24 · 03:00 AM" for a session stored as Apr 23 8:00 PM PDT. `next-intl`'s `useFormatter` defaults to UTC when no `timeZone` is set. Now configured to `America/Vancouver` on both server (`i18n/request.ts`) and client (`NextIntlClientProvider`). All player-facing datetime surfaces (HomeTab, PlayersTab, PrevPaymentReminder) corrected. (#19)
+
+### Added (infrastructure, invisible to stable users)
+
+- Two-deployment pipeline: `bpm-next` auto-deploys every push to `main`, `bpm-stable` deploys only on manual tag dispatch. Shared Cosmos DB, split workflows. (#13, #14, #15)
+- Feature flag system with typed registry and `isFlagOn` helper. (#13)
+- Preview banner (orange strip on `bpm-next` only, hidden on stable) showing git SHA and a mailto bug-report link pre-filled with URL + SHA + user agent. (#13, #16, #18)
+- Deployment model runbook at `docs/deployment-model.md` with promotion + hotfix + rollback procedures. (#17)
+
+### Notes
+
+All infrastructure items above are behavioral no-ops on stable (PreviewBanner returns `null` when `NEXT_PUBLIC_ENV` is unset; CSS `--banner-offset` var defaults to 0). The only user-visible change for the friend group is the timezone fix.
+
+---
+
 ## Unreleased — `bpm-next` only
 
-*Items here live on `main` behind feature flags. They ship to stable when the next tag is cut.*
+*Items here live on `main`. They ship to stable when the next tag is cut.*
 
-### Added
-
-- Feature flag scaffold (`lib/flags.ts`)
-- Preview banner for the `bpm-next` environment
+_(empty)_


### PR DESCRIPTION
Simple bookkeeping follow-up to the hotfix we just shipped. Moves items from Unreleased into a proper v1.0.1 entry.

Structure:
- **Fixed:** the one user-visible change (timezone)
- **Added (infrastructure, invisible to stable users):** pipeline, flags, banner, runbook
- **Notes:** explicit that infra items are no-ops on stable, only timezone fix actually affects friend group

No runtime change. Next unreleased section empty.