### PR TITLE
docs: refresh stale test counts and workflow filenames

### DIFF
--- a/AZURE.md
+++ b/AZURE.md
@@ -49,7 +49,12 @@ Node.js server under `.next/standalone/`. The deployment zip bundles:
 
 ### Deployment — GitHub Actions (primary)
 
-Every push to `main` triggers the workflow at `.github/workflows/main_badminton-app.yml`:
+Two workflows share the same build recipe but target different App Services. See `docs/deployment-model.md` for the full runbook.
+
+- **`.github/workflows/deploy-next.yml`** — auto-deploys `main` to `vnext-badminton-app` on every push (preview/testing).
+- **`.github/workflows/deploy-stable.yml`** — manual dispatch by tag only, deploys to `badminton-app` (friend-facing).
+
+Both run the same build steps:
 
 1. `npm ci` — install from lockfile
 2. `npm run build` — with `NEXT_PUBLIC_BASE_PATH=/bpm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,4 +50,4 @@ All infrastructure items above are behavioral no-ops on stable (PreviewBanner re
 
 *Items here live on `main`. They ship to stable when the next tag is cut.*
 
-_(empty)_
+*(empty)*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,4 +135,4 @@ npm test              # run all tests (vitest)
 npm run test:watch    # watch mode
 ```
 
-92 tests across 8 suites covering API routes (admin auth, player CRUD, player self-pay, members, sessions, session costs, birds, skills). Tests use the in-memory mock store — no DB needed. Test helpers in `__tests__/helpers.ts`. Each test gets a unique IP via `X-Client-IP` to avoid rate limiter collisions.
+245 tests across 29 suites covering API routes (admin auth, player CRUD, player self-pay, members, sessions, session costs, birds, skills), feature flags, i18n parity, and component rendering. Tests use the in-memory mock store — no DB needed. Test helpers in `__tests__/helpers.ts`. Each test gets a unique IP via `X-Client-IP` to avoid rate limiter collisions.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Live URL: `https://badminton-app-gzendxb6fzefafgm.canadacentral-01.azurewebsites
 - **Azure Cosmos DB** (NoSQL) — database: `badminton`, 7 containers at 400 RU/s shared throughput
 - **Anthropic Claude API** (`claude-sonnet-4-20250514`) — announcement polishing
 - **Azure App Service** — Canada Central, B1 Basic tier (Always On), `output: standalone`
-- **Vitest** — 85 tests, 8 suites, CI-gated before deploy
+- **Vitest** — 245 tests, 29 suites, CI-gated before deploy
 
 ---
 
@@ -144,15 +144,14 @@ When `COSMOS_CONNECTION_STRING` is not set, the app uses an in-memory mock store
 
 ## Deployment (Azure App Service)
 
-See `AZURE.md` for the full architecture and environment setup.
+Two Azure App Services run from the same `main` branch — `bpm-stable` (friend-facing, tag-promoted only) and `bpm-next` (preview, auto-deploys every push). See `docs/deployment-model.md` for the full runbook and `AZURE.md` for the architecture.
 
-Deployment is automatic via GitHub Actions — every push to `main` builds and deploys.
-
+```text
+git push  →  deploy-next.yml  →  bpm-next App Service (auto, always at HEAD)
+git tag + dispatch  →  deploy-stable.yml  →  bpm-stable App Service (manual, by tag)
 ```
-git push  →  GitHub Actions builds standalone →  deploys to Azure App Service
-```
 
-The workflow lives at `.github/workflows/main_badminton-app.yml`. It uses OIDC (federated credentials) — no long-lived secrets. All action SHAs are pinned for supply chain safety.
+Workflows live at `.github/workflows/deploy-next.yml` and `deploy-stable.yml`. The next pipeline uses a publish profile secret; the stable pipeline uses OIDC. All action SHAs are pinned for supply chain safety.
 
 ### Manual deploy (fallback only)
 


### PR DESCRIPTION
Follow-up to the hotfix session. Fixes factual drift in README / CLAUDE / AZURE / CHANGELOG.

## Changes
- README: 85 → 245 tests; workflow section updated to describe the two-deployment pipeline
- CLAUDE.md: 92 → 245 tests
- AZURE.md: workflow reference updated (both deploy-next.yml + deploy-stable.yml); added pointer to deployment-model.md
- CHANGELOG.md: tiny markdownlint fix (`_(empty)_` → `*(empty)*`)

## Not in this PR (follow-up)
- AZURE.md architecturally still describes one App Service — a fuller rewrite to cover both is queued.

## Test plan
- [x] 245 tests pass
- [x] No runtime code changed