### PR TITLE
ci(claude-review): grant write on pull-requests + issues

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # Write access so the review bot can post PR review comments.
+      # Previously `read` which silently swallowed review output.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
Fixes the bug where claude-review runs on PR #22 completed with zero review comments — the workflow had `pull-requests: read` + `issues: read`, so the bot had no way to post what it generated. One-line permissions change, no other edits.