### PR TITLE
UX polish batch: markdown, release edit, stats, birds, bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Something broke or looks wrong on the preview site.
+title: "[bug] "
+labels: ["bug", "next-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! The more you can tell us, the faster we can fix it.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do? What did you see?
+      placeholder: I tapped the sign-up button and nothing happened.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      placeholder: I expected to be added to the session.
+    validations:
+      required: false
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: The page you were on when it broke (auto-filled from the preview banner).
+      placeholder: https://next.grantzou.com/bpm/...
+    validations:
+      required: false
+  - type: input
+    id: sha
+    attributes:
+      label: Build SHA
+      description: Auto-filled from the preview banner — helps pin down which build broke.
+      placeholder: abcd123
+    validations:
+      required: false
+  - type: input
+    id: ua
+    attributes:
+      label: Device / browser
+      description: Auto-filled with your user-agent string.
+      placeholder: iPhone 17 Pro Max, Safari 18.x
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Paste or drag images here if you have any.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Email Grant (private / sensitive)
+    url: mailto:xyzou2012@gmail.com
+    about: For anything security-related, personal data, or things you'd rather keep off a public issue tracker.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,51 @@
+name: Feature idea
+description: Something the app should do that it doesn't, or could do better.
+title: "[idea] "
+labels: ["feature", "backlog"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Ideas welcome — doesn't matter how small.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What's the pain point? Who feels it?
+      placeholder: I keep forgetting which court we're on — would love a reminder.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: How might the app solve it?
+      description: Rough idea — doesn't have to be a full design.
+      placeholder: Add a court number to the home-screen session card.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Who would use this / when?
+      description: Any context helps — who, when, where, how often.
+    validations:
+      required: false
+  - type: input
+    id: url
+    attributes:
+      label: URL
+      description: The page you were on when this idea struck (auto-filled).
+    validations:
+      required: false
+  - type: input
+    id: sha
+    attributes:
+      label: Build SHA
+    validations:
+      required: false
+  - type: input
+    id: ua
+    attributes:
+      label: Device / browser
+    validations:
+      required: false

--- a/__tests__/announcements.test.ts
+++ b/__tests__/announcements.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET, POST } from '@/app/api/announcements/route';
+import {
+  resetMockStore,
+  setupAdminPin,
+  makeRequest,
+  makeAdminRequest,
+  seedPointer,
+  seedSession,
+} from './helpers';
+
+describe('POST /api/announcements — markdown round-trip', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+    seedPointer('session-2026-04-24');
+    seedSession('session-2026-04-24');
+  });
+
+  it('stores markdown text verbatim and returns it through GET unchanged', async () => {
+    const markdown = 'Heads up **tonight**\n\n- *Arrive early*\n- Bring water';
+
+    const postRes = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/announcements', { text: markdown }),
+    );
+    expect(postRes.status).toBe(201);
+
+    const getRes = await GET();
+    const list = await getRes.json();
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBe(1);
+    expect(list[0].text).toBe(markdown);
+  });
+
+  it('accepts up to 800 chars', async () => {
+    const longText = 'x'.repeat(800);
+    const res = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/announcements', { text: longText }),
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects over 800 chars', async () => {
+    const tooLong = 'x'.repeat(801);
+    const res = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/announcements', { text: tooLong }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-admin', async () => {
+    const res = await POST(
+      makeRequest('POST', 'http://localhost:3000/api/announcements', { text: 'hello' }),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/__tests__/birdBrand.test.ts
+++ b/__tests__/birdBrand.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { parseBirdName } from '@/lib/birdBrand';
+
+describe('parseBirdName', () => {
+  it('splits "Victor Master No.3" into Victor + Master No.3', () => {
+    expect(parseBirdName('Victor Master No.3')).toEqual({ brand: 'Victor', model: 'Master No.3' });
+  });
+
+  it('splits "Yonex AS-50" into Yonex + AS-50', () => {
+    expect(parseBirdName('Yonex AS-50')).toEqual({ brand: 'Yonex', model: 'AS-50' });
+  });
+
+  it('handles single-word input (brand only, empty model)', () => {
+    expect(parseBirdName('RSL')).toEqual({ brand: 'RSL', model: '' });
+  });
+
+  it('returns empty strings for empty input', () => {
+    expect(parseBirdName('')).toEqual({ brand: '', model: '' });
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(parseBirdName('  Victor   Master  ')).toEqual({ brand: 'Victor', model: 'Master' });
+  });
+
+  it('handles Chinese brand names', () => {
+    expect(parseBirdName('胜利 大师 No.3')).toEqual({ brand: '胜利', model: '大师 No.3' });
+  });
+});

--- a/__tests__/birdUsages.helpers.test.ts
+++ b/__tests__/birdUsages.helpers.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { tubesUsedAcross, avgTubesPerSession, runwayWeeks } from '@/lib/birdUsages';
+import type { Session, BirdUsage } from '@/lib/types';
+
+function mkSession(usages: Partial<BirdUsage>[] | null): Pick<Session, 'birdUsages'> {
+  if (!usages) return { birdUsages: undefined };
+  return {
+    birdUsages: usages.map((u, i) => ({
+      purchaseId: u.purchaseId ?? `p-${i}`,
+      purchaseName: u.purchaseName ?? 'Test',
+      tubes: u.tubes ?? 0,
+      costPerTube: u.costPerTube ?? 10,
+      totalBirdCost: u.totalBirdCost ?? (u.tubes ?? 0) * 10,
+    })),
+  };
+}
+
+describe('tubesUsedAcross', () => {
+  it('sums tubes across sessions, 0.5 increments supported', () => {
+    const sessions = [mkSession([{ tubes: 2 }]), mkSession([{ tubes: 1.5 }, { tubes: 0.5 }])];
+    expect(tubesUsedAcross(sessions)).toBe(4);
+  });
+
+  it('returns 0 for empty list', () => {
+    expect(tubesUsedAcross([])).toBe(0);
+  });
+
+  it('tolerates sessions with no birdUsages', () => {
+    expect(tubesUsedAcross([mkSession(null)])).toBe(0);
+  });
+});
+
+describe('avgTubesPerSession', () => {
+  it('averages the last `window` sessions with usage > 0', () => {
+    const sessions = [
+      mkSession([{ tubes: 2 }]),
+      mkSession([{ tubes: 3 }]),
+      mkSession([{ tubes: 1 }]),
+    ];
+    expect(avgTubesPerSession(sessions)).toBe(2);
+  });
+
+  it('excludes zero-usage sessions from the denominator', () => {
+    const sessions = [mkSession([]), mkSession([{ tubes: 2 }])];
+    expect(avgTubesPerSession(sessions)).toBe(2);
+  });
+
+  it('returns 0 when no sessions have usage', () => {
+    expect(avgTubesPerSession([mkSession([]), mkSession(null)])).toBe(0);
+  });
+
+  it('respects the window parameter', () => {
+    const sessions = Array.from({ length: 12 }, (_, i) => mkSession([{ tubes: i + 1 }]));
+    // window=3 → avg of last 3: (10+11+12)/3 = 11
+    expect(avgTubesPerSession(sessions, 3)).toBe(11);
+  });
+});
+
+describe('runwayWeeks', () => {
+  it('computes runway at current pace', () => {
+    expect(runwayWeeks(10, 2)).toBe(5);
+  });
+
+  it('returns 0 when stock is empty', () => {
+    expect(runwayWeeks(0, 2)).toBe(0);
+  });
+
+  it('returns Infinity when avg is 0 but stock remains', () => {
+    expect(runwayWeeks(10, 0)).toBe(Infinity);
+  });
+});

--- a/__tests__/components/BottomNav.test.tsx
+++ b/__tests__/components/BottomNav.test.tsx
@@ -22,7 +22,7 @@ describe('BottomNav — i18n', () => {
     renderWithLocale('en');
     expect(screen.getByRole('button', { name: 'Home' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Sign-Ups' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Coming Soon' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Stats' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Admin' })).toBeTruthy();
   });
 
@@ -30,26 +30,28 @@ describe('BottomNav — i18n', () => {
     renderWithLocale('zh-CN');
     expect(screen.getByRole('button', { name: '首页' })).toBeTruthy();
     expect(screen.getByRole('button', { name: '报名' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: '即将推出' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '数据' })).toBeTruthy();
     expect(screen.getByRole('button', { name: '管理' })).toBeTruthy();
   });
 
-  it('renders EN skills label as a single line — canonical spec (preview/19)', () => {
+  it('renders EN stats label as a single line', () => {
     renderWithLocale('en');
-    // Canonical spec dropped the whitespace-split "Coming Soon" stacking.
-    // Label is now a single <span> alongside the `school` icon.
-    const skillsBtn = screen.getByRole('button', { name: 'Coming Soon' });
-    // No `.block` children — the stacked rendering is removed.
+    const skillsBtn = screen.getByRole('button', { name: 'Stats' });
     expect(skillsBtn.querySelectorAll('span.block').length).toBe(0);
-    // The label text renders verbatim.
-    expect(skillsBtn.textContent).toContain('Coming Soon');
+    expect(skillsBtn.textContent).toContain('Stats');
   });
 
-  it('renders zh-CN skills label as a single line (verbatim, no whitespace split)', () => {
+  it('renders zh-CN stats label as a single line', () => {
     renderWithLocale('zh-CN');
-    const skillsBtn = screen.getByRole('button', { name: '即将推出' });
+    const skillsBtn = screen.getByRole('button', { name: '数据' });
     expect(skillsBtn.querySelectorAll('span.block').length).toBe(0);
-    expect(skillsBtn.textContent).toContain('即将推出');
+    expect(skillsBtn.textContent).toContain('数据');
+  });
+
+  it('uses bar_chart icon for stats tab', () => {
+    renderWithLocale('en');
+    const skillsBtn = screen.getByRole('button', { name: 'Stats' });
+    expect(skillsBtn.textContent).toContain('bar_chart');
   });
 
   it('hides admin tab when showAdmin is false', () => {

--- a/__tests__/components/PageHeaders.test.tsx
+++ b/__tests__/components/PageHeaders.test.tsx
@@ -30,24 +30,24 @@ describe('PageHeaders', () => {
     expect(heading.textContent).toBe('Sign-Up');
   });
 
-  it('SkillsTab (non-admin) renders "Learn" as an h1', () => {
+  it('SkillsTab (non-admin) renders "Your stats" as an h1', () => {
     render(
       <NextIntlClientProvider locale="en" messages={enMessages}>
         <SkillsTab isAdmin={false} />
       </NextIntlClientProvider>
     );
     const heading = screen.getByRole('heading', { level: 1 });
-    expect(heading.textContent).toBe('Learn');
+    expect(heading.textContent).toBe('Your stats');
   });
 
-  it('SkillsTab (admin) renders "Learn" as an h1', () => {
+  it('SkillsTab (admin) renders "Your stats" as an h1', () => {
     render(
       <NextIntlClientProvider locale="en" messages={enMessages}>
         <SkillsTab isAdmin={true} />
       </NextIntlClientProvider>
     );
     const heading = screen.getByRole('heading', { level: 1 });
-    expect(heading.textContent).toBe('Learn');
+    expect(heading.textContent).toBe('Your stats');
   });
 
   it('AdminTab renders "Admin" as an h1', () => {

--- a/__tests__/components/StatsPlaceholder.test.tsx
+++ b/__tests__/components/StatsPlaceholder.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import StatsPlaceholder from '../../components/stats/StatsPlaceholder';
+import enMessages from '../../messages/en.json';
+import zhMessages from '../../messages/zh-CN.json';
+
+function renderWithLocale(locale: 'en' | 'zh-CN') {
+  const messages = locale === 'en' ? enMessages : zhMessages;
+  return render(
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <StatsPlaceholder />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('StatsPlaceholder', () => {
+  afterEach(cleanup);
+
+  it('renders four skeleton cards with titles in English', () => {
+    renderWithLocale('en');
+    expect(screen.getByText('Skill progression')).toBeTruthy();
+    expect(screen.getByText('Attendance')).toBeTruthy();
+    expect(screen.getByText('Cost trend')).toBeTruthy();
+    expect(screen.getByText('Partner frequency')).toBeTruthy();
+  });
+
+  it('renders one "Coming soon" pill per card (4 total)', () => {
+    renderWithLocale('en');
+    const pills = screen.getAllByText(/Coming soon/i);
+    expect(pills.length).toBe(4);
+  });
+
+  it('renders the page heading', () => {
+    renderWithLocale('en');
+    expect(screen.getByRole('heading', { level: 1, name: 'Your stats' })).toBeTruthy();
+  });
+
+  it('renders Chinese titles when locale is zh-CN', () => {
+    renderWithLocale('zh-CN');
+    expect(screen.getByText('技能进展')).toBeTruthy();
+    expect(screen.getByText('出勤记录')).toBeTruthy();
+    expect(screen.getByText('费用趋势')).toBeTruthy();
+    expect(screen.getByText('搭档频率')).toBeTruthy();
+  });
+});

--- a/__tests__/design-preview-route.test.ts
+++ b/__tests__/design-preview-route.test.ts
@@ -31,7 +31,7 @@ describe('design preview route — flag + nav isolation', () => {
     expect(isFlagOn('NEXT_PUBLIC_FLAG_DESIGN_PREVIEW')).toBe(true);
   });
 
-  it('SUBPAGES lists the six specimen sub-pages', () => {
+  it('SUBPAGES lists all specimen sub-pages in order', () => {
     const hrefs = SUBPAGES.map((p) => p.href);
     expect(hrefs).toEqual([
       '/design/tokens',
@@ -40,6 +40,7 @@ describe('design preview route — flag + nav isolation', () => {
       '/design/fonts',
       '/design/backgrounds',
       '/design/perf',
+      '/design/stats',
     ]);
   });
 

--- a/__tests__/flags.test.ts
+++ b/__tests__/flags.test.ts
@@ -43,6 +43,14 @@ describe('feature flags', () => {
     expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(true);
     expect(isFlagOn('NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV')).toBe(false);
   });
+
+  it('recognizes NEXT_PUBLIC_FLAG_STATS_ATTENDANCE', () => {
+    delete process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE;
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_STATS_ATTENDANCE')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE = 'true';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_STATS_ATTENDANCE')).toBe(true);
+    delete process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE;
+  });
 });
 
 describe('environment detection', () => {

--- a/__tests__/miniMarkdown.test.tsx
+++ b/__tests__/miniMarkdown.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { renderMarkdown } from '@/lib/miniMarkdown';
+
+afterEach(cleanup);
+
+function html(node: ReturnType<typeof renderMarkdown>) {
+  const { container } = render(<div>{node}</div>);
+  return container.innerHTML;
+}
+
+describe('miniMarkdown', () => {
+  it('renders null for empty input', () => {
+    expect(renderMarkdown('')).toBeNull();
+  });
+
+  it('wraps plain text in a paragraph', () => {
+    expect(html(renderMarkdown('hello world'))).toContain('<p>');
+    expect(html(renderMarkdown('hello world'))).toContain('hello world');
+  });
+
+  it('renders bold with **text**', () => {
+    expect(html(renderMarkdown('hi **world** ok'))).toContain('<strong>world</strong>');
+  });
+
+  it('renders italic with *text*', () => {
+    expect(html(renderMarkdown('hi *world* ok'))).toContain('<em>world</em>');
+  });
+
+  it('renders bulleted list with -', () => {
+    const out = html(renderMarkdown('- one\n- two'));
+    expect(out).toContain('<ul>');
+    expect(out).toContain('<li>');
+    expect(out).toContain('one');
+    expect(out).toContain('two');
+  });
+
+  it('renders numbered list with 1.', () => {
+    const out = html(renderMarkdown('1. first\n2. second'));
+    expect(out).toContain('<ol>');
+    expect(out).toContain('first');
+    expect(out).toContain('second');
+  });
+
+  it('renders bold inside list items', () => {
+    const out = html(renderMarkdown('- hi **there**'));
+    expect(out).toContain('<strong>there</strong>');
+  });
+
+  it('escapes HTML in input (React JSX safety)', () => {
+    const out = html(renderMarkdown('<script>alert(1)</script>'));
+    expect(out).not.toContain('<script>');
+    expect(out).toContain('&lt;script&gt;');
+  });
+
+  it('tolerates mismatched asterisks without creating bold', () => {
+    const out = html(renderMarkdown('hi **there'));
+    expect(out).not.toContain('<strong>');
+    expect(out).toContain('there');
+    expect(out).toContain('*');
+  });
+
+  it('splits paragraphs on blank lines', () => {
+    const out = html(renderMarkdown('para one\n\npara two'));
+    const paragraphs = out.match(/<p>/g);
+    expect(paragraphs).not.toBeNull();
+    expect(paragraphs!.length).toBe(2);
+  });
+
+  it('renders single newlines inside paragraph as <br>', () => {
+    const out = html(renderMarkdown('line one\nline two'));
+    expect(out).toContain('<br>');
+  });
+});

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET, POST, PATCH, DELETE } from '@/app/api/releases/route';
+import {
+  resetMockStore,
+  setupAdminPin,
+  makeRequest,
+  makeAdminRequest,
+  makeGetRequest,
+} from './helpers';
+
+function releaseBody(version = 'v1.0.0') {
+  return {
+    version,
+    title: { en: 'Hello', 'zh-CN': '你好' },
+    body: { en: '• First bullet', 'zh-CN': '• 第一条' },
+  };
+}
+
+describe('POST /api/releases', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+  });
+
+  it('creates a release with env stamp when admin', async () => {
+    const res = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/releases', releaseBody()),
+    );
+    expect(res.status).toBe(200);
+    const rec = await res.json();
+    expect(rec.version).toBe('v1.0.0');
+    expect(rec.publishedAt).toBeTruthy();
+    expect(rec.id).toMatch(/^release-/);
+  });
+
+  it('rejects non-admin', async () => {
+    const res = await POST(
+      makeRequest('POST', 'http://localhost:3000/api/releases', releaseBody()),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /api/releases', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+  });
+
+  it('updates existing record and stamps editedAt', async () => {
+    const postRes = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/releases', releaseBody('v1.0.0')),
+    );
+    const created = await postRes.json();
+    expect(created.id).toBeTruthy();
+    expect(created.editedAt).toBeUndefined();
+
+    const patchRes = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/releases', {
+        id: created.id,
+        version: 'v1.0.0',
+        title: { en: 'Updated title', 'zh-CN': '更新标题' },
+        body: { en: '• fixed typo', 'zh-CN': '• 修正' },
+      }),
+    );
+    expect(patchRes.status).toBe(200);
+    const updated = await patchRes.json();
+    expect(updated.title.en).toBe('Updated title');
+    expect(updated.body.en).toBe('• fixed typo');
+    expect(updated.editedAt).toBeTruthy();
+    // publishedAt preserved
+    expect(updated.publishedAt).toBe(created.publishedAt);
+  });
+
+  it('rejects non-admin', async () => {
+    const res = await PATCH(
+      makeRequest('PATCH', 'http://localhost:3000/api/releases', {
+        id: 'whatever',
+        ...releaseBody(),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/releases', releaseBody()),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when record not found', async () => {
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/releases', {
+        id: 'release-does-not-exist',
+        ...releaseBody(),
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/releases after PATCH', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+  });
+
+  it('returns the edited version after PATCH', async () => {
+    const postRes = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/releases', releaseBody('v1.0.0')),
+    );
+    const created = await postRes.json();
+
+    await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/releases', {
+        id: created.id,
+        version: 'v1.0.0',
+        title: { en: 'Edited', 'zh-CN': '已编辑' },
+        body: { en: '• updated', 'zh-CN': '• 更新' },
+      }),
+    );
+
+    const listRes = await GET(makeGetRequest('http://localhost:3000/api/releases'));
+    const list = await listRes.json();
+    expect(list.length).toBe(1);
+    expect(list[0].title.en).toBe('Edited');
+  });
+});
+
+describe('DELETE /api/releases', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+  });
+
+  it('deletes a release when admin', async () => {
+    const postRes = await POST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/releases', releaseBody()),
+    );
+    const created = await postRes.json();
+    const res = await DELETE(
+      makeAdminRequest('DELETE', 'http://localhost:3000/api/releases', { id: created.id }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/session-bird-usage.test.ts
+++ b/__tests__/session-bird-usage.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PATCH } from '@/app/api/session/bird-usage/route';
+import {
+  resetMockStore,
+  setupAdminPin,
+  makeRequest,
+  makeAdminRequest,
+  seedPointer,
+  seedSession,
+  getStore,
+} from './helpers';
+
+function seedPurchase(id: string, name: string, tubes = 10, costPerTube = 12): void {
+  const store = getStore();
+  if (!store['birds']) store['birds'] = [];
+  store['birds'].push({
+    id,
+    name,
+    tubes,
+    totalCost: tubes * costPerTube,
+    costPerTube,
+    date: '2026-04-24',
+    createdAt: new Date().toISOString(),
+  });
+}
+
+describe('PATCH /api/session/bird-usage', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+    seedPointer('session-2026-04-24');
+    seedSession('session-2026-04-24');
+    seedPurchase('pur-yonex-1', 'Yonex AS-50');
+  });
+
+  it('rejects non-admin', async () => {
+    const res = await PATCH(
+      makeRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 2,
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('adds a usage entry on first assignment', async () => {
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 2,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const updated = await res.json();
+    expect(updated.birdUsages).toHaveLength(1);
+    expect(updated.birdUsages[0].purchaseId).toBe('pur-yonex-1');
+    expect(updated.birdUsages[0].tubes).toBe(2);
+    expect(updated.birdUsages[0].totalBirdCost).toBe(24); // 2 * 12
+  });
+
+  it('replaces existing entry rather than duplicating', async () => {
+    // First assignment
+    await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 2,
+      }),
+    );
+    // Second assignment with different tubes
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 3.5,
+      }),
+    );
+    const updated = await res.json();
+    expect(updated.birdUsages).toHaveLength(1);
+    expect(updated.birdUsages[0].tubes).toBe(3.5);
+  });
+
+  it('removes the entry when tubes === 0', async () => {
+    await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 2,
+      }),
+    );
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 0,
+      }),
+    );
+    const updated = await res.json();
+    expect(updated.birdUsages).toHaveLength(0);
+  });
+
+  it('rejects non-multiples of 0.25', async () => {
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-yonex-1',
+        tubes: 0.3,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for unknown session', async () => {
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-does-not-exist',
+        purchaseId: 'pur-yonex-1',
+        tubes: 2,
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for unknown purchase', async () => {
+    const res = await PATCH(
+      makeAdminRequest('PATCH', 'http://localhost:3000/api/session/bird-usage', {
+        sessionId: 'session-2026-04-24',
+        purchaseId: 'pur-does-not-exist',
+        tubes: 2,
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/stats-attendance.test.ts
+++ b/__tests__/stats-attendance.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET } from '@/app/api/stats/attendance/route';
+import {
+  resetMockStore,
+  seedSession,
+  seedPlayer,
+  makeRequest,
+} from './helpers';
+
+function isoForDaysAgo(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString();
+}
+
+function makeSessionIds(count: number): string[] {
+  // Most recent first — session-2026-04-24, session-2026-04-17, ...
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date();
+    d.setDate(d.getDate() - i * 7);
+    return `session-${d.toISOString().slice(0, 10)}`;
+  });
+}
+
+describe('GET /api/stats/attendance', () => {
+  beforeEach(() => {
+    resetMockStore();
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await GET(makeRequest('GET', 'http://localhost:3000/api/stats/attendance'));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns zero counts when no sessions exist', async () => {
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant'),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.attended).toBe(0);
+    expect(data.streak).toBe(0);
+    expect(data.history).toEqual([]);
+  });
+
+  it('counts attended sessions, excludes waitlisted and removed', async () => {
+    const ids = makeSessionIds(5);
+    ids.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7) }));
+
+    seedPlayer(ids[0], 'Grant');
+    seedPlayer(ids[1], 'Grant');
+    seedPlayer(ids[2], 'Grant', { waitlisted: true });
+    seedPlayer(ids[3], 'Grant', { removed: true });
+    // ids[4] — no player row
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=5'),
+    );
+    const data = await res.json();
+    expect(data.attended).toBe(2);
+    expect(data.history).toHaveLength(5);
+    expect(data.history[0].attended).toBe(true);
+    expect(data.history[1].attended).toBe(true);
+    expect(data.history[2].attended).toBe(false);
+    expect(data.history[3].attended).toBe(false);
+    expect(data.history[4].attended).toBe(false);
+  });
+
+  it('name matching is case-insensitive', async () => {
+    const ids = makeSessionIds(2);
+    ids.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7) }));
+    seedPlayer(ids[0], 'GRANT');
+    seedPlayer(ids[1], 'grant');
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=2'),
+    );
+    const data = await res.json();
+    expect(data.attended).toBe(2);
+  });
+
+  it('computes current streak from most-recent run', async () => {
+    const ids = makeSessionIds(5);
+    ids.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7) }));
+    seedPlayer(ids[0], 'Grant');
+    seedPlayer(ids[1], 'Grant');
+    seedPlayer(ids[2], 'Grant');
+    // missed ids[3]
+    seedPlayer(ids[4], 'Grant');
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=5'),
+    );
+    const data = await res.json();
+    expect(data.streak).toBe(3); // most-recent 3 in a row
+    expect(data.longestStreak).toBe(3);
+  });
+
+  it('longestStreak finds the best run even when current streak is shorter', async () => {
+    const ids = makeSessionIds(7);
+    ids.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7) }));
+    // Most-recent first: played, missed, played, played, played, played, missed
+    seedPlayer(ids[0], 'Grant');
+    seedPlayer(ids[2], 'Grant');
+    seedPlayer(ids[3], 'Grant');
+    seedPlayer(ids[4], 'Grant');
+    seedPlayer(ids[5], 'Grant');
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=7'),
+    );
+    const data = await res.json();
+    expect(data.streak).toBe(1); // only the latest, then a miss
+    expect(data.longestStreak).toBe(4);
+  });
+
+  it('respects the weeks window parameter', async () => {
+    const ids = makeSessionIds(20);
+    ids.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7) }));
+    ids.forEach((id) => seedPlayer(id, 'Grant'));
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=8'),
+    );
+    const data = await res.json();
+    expect(data.history).toHaveLength(8);
+    expect(data.attended).toBe(8);
+  });
+
+  it('clamps weeks to a reasonable range', async () => {
+    const ids = makeSessionIds(3);
+    ids.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7) }));
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=99999'),
+    );
+    const data = await res.json();
+    expect(data.weeks).toBeLessThanOrEqual(52);
+  });
+});

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -66,8 +66,8 @@ export async function PATCH(req: NextRequest) {
     if (!trimmed) {
       return NextResponse.json({ error: 'Text required' }, { status: 400 });
     }
-    if (trimmed.length > 500) {
-      return NextResponse.json({ error: 'Announcement too long (max 500 chars)' }, { status: 400 });
+    if (trimmed.length > 800) {
+      return NextResponse.json({ error: 'Announcement too long (max 800 chars)' }, { status: 400 });
     }
 
     const container = getContainer('announcements');
@@ -107,8 +107,8 @@ export async function POST(req: NextRequest) {
     if (!trimmed) {
       return NextResponse.json({ error: 'Text required' }, { status: 400 });
     }
-    if (trimmed.length > 500) {
-      return NextResponse.json({ error: 'Announcement too long (max 500 chars)' }, { status: 400 });
+    if (trimmed.length > 800) {
+      return NextResponse.json({ error: 'Announcement too long (max 800 chars)' }, { status: 400 });
     }
 
     const announcement = {

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -103,6 +103,48 @@ export async function POST(req: NextRequest) {
   }
 }
 
+export async function PATCH(req: NextRequest) {
+  if (!isAdminAuthed(req)) return unauthorized();
+  try {
+    await ensureReleasesContainer();
+    const raw = await req.json();
+    if (!raw || typeof raw !== 'object') {
+      return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+    }
+    const r = raw as Record<string, unknown>;
+    if (typeof r.id !== 'string' || !r.id) {
+      return NextResponse.json({ error: 'ID required' }, { status: 400 });
+    }
+    const validated = validateReleaseBody(r);
+    if (!validated) {
+      return NextResponse.json({ error: 'Missing or invalid required fields' }, { status: 400 });
+    }
+    const container = getContainer('releases');
+    const { resources } = await container.items
+      .query({
+        query: 'SELECT * FROM c WHERE c.id = @id',
+        parameters: [{ name: '@id', value: r.id }],
+      })
+      .fetchAll();
+    if (resources.length === 0) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    const existing = resources[0] as Record<string, unknown>;
+    const updated = {
+      ...existing,
+      version: validated.version,
+      title: validated.title,
+      body: validated.body,
+      editedAt: new Date().toISOString(),
+    };
+    const { resource } = await container.items.upsert(updated);
+    return NextResponse.json(resource);
+  } catch (error) {
+    console.error('PATCH releases error:', error);
+    return NextResponse.json({ error: 'Failed to update release' }, { status: 500 });
+  }
+}
+
 export async function DELETE(req: NextRequest) {
   if (!isAdminAuthed(req)) return unauthorized();
   try {

--- a/app/api/session/bird-usage/route.ts
+++ b/app/api/session/bird-usage/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@/lib/cosmos';
+import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { normalizeBirdUsages } from '@/lib/birdUsages';
+import type { BirdUsage, Session } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * PATCH /api/session/bird-usage — upsert a single purchase's usage into a
+ * specific session's `birdUsages` array. Unlike `PUT /api/session` which
+ * replaces the whole active session, this targets any session by id and
+ * only touches the one array entry, so admins can retro-assign tubes to
+ * archived sessions from the bird inventory page.
+ *
+ * Body: { sessionId: string, purchaseId: string, tubes: number (0–100, 0.25 steps) }
+ * - tubes === 0 removes the entry for that purchase (undo assignment).
+ */
+export async function PATCH(req: NextRequest) {
+  if (!isAdminAuthed(req)) return unauthorized();
+
+  try {
+    const body = await req.json();
+    const sessionId = typeof body?.sessionId === 'string' ? body.sessionId : '';
+    const purchaseId = typeof body?.purchaseId === 'string' ? body.purchaseId : '';
+    const tubes = Number(body?.tubes);
+
+    if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
+    if (!purchaseId) return NextResponse.json({ error: 'purchaseId required' }, { status: 400 });
+    if (!Number.isFinite(tubes) || tubes < 0 || tubes > 100) {
+      return NextResponse.json({ error: 'tubes must be between 0 and 100' }, { status: 400 });
+    }
+    if (Math.round(tubes * 4) !== tubes * 4) {
+      return NextResponse.json({ error: 'tubes must be in 0.25 increments' }, { status: 400 });
+    }
+
+    const sessionsContainer = getContainer('sessions');
+    const { resources } = await sessionsContainer.items
+      .query({
+        query: 'SELECT * FROM c WHERE c.id = @id',
+        parameters: [{ name: '@id', value: sessionId }],
+      })
+      .fetchAll();
+    const session = resources[0] as Session | undefined;
+    if (!session) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    const birdsContainer = getContainer('birds');
+    const { resource: purchase } = await birdsContainer.item(purchaseId, purchaseId).read();
+    if (!purchase) {
+      return NextResponse.json({ error: 'Purchase not found' }, { status: 404 });
+    }
+
+    // Existing usages; drop any entry for this purchase so we can re-insert cleanly.
+    const existing = normalizeBirdUsages(session).filter((u) => u.purchaseId !== purchaseId);
+
+    const next: BirdUsage[] = [...existing];
+    if (tubes > 0) {
+      next.push({
+        purchaseId: purchase.id,
+        purchaseName: purchase.name,
+        tubes,
+        costPerTube: purchase.costPerTube,
+        totalBirdCost: Math.round(tubes * purchase.costPerTube * 100) / 100,
+      });
+    }
+
+    const updated: Session = { ...session, birdUsages: next };
+    // Drop legacy single-object field so it doesn't shadow the array on future reads.
+    delete (updated as { birdUsage?: unknown }).birdUsage;
+
+    const { resource } = await sessionsContainer.items.upsert(updated);
+    return NextResponse.json(resource);
+  } catch (error) {
+    console.error('PATCH /api/session/bird-usage error:', error);
+    return NextResponse.json({ error: 'Failed to update usage' }, { status: 500 });
+  }
+}

--- a/app/api/stats/attendance/route.ts
+++ b/app/api/stats/attendance/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer, POINTER_ID } from '@/lib/cosmos';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/stats/attendance?name=<player-name>[&weeks=12]
+ *
+ * Returns the player's attendance over the last N weeks. Open to any visitor
+ * — no auth required. We only read session-scoped player rows by name, and
+ * the response contains no sensitive data (no tokens, no email).
+ *
+ * Response shape:
+ *   {
+ *     name: string,
+ *     weeks: number,
+ *     attended: number,        // count of sessions in window where they played
+ *     streak: number,          // consecutive most-recent sessions played
+ *     longestStreak: number,   // best run across the window
+ *     history: [                // one entry per session in window, newest first
+ *       { sessionId, datetime, attended }
+ *     ]
+ *   }
+ *
+ * "Attended" = player row exists for that session with removed !== true and
+ * waitlisted !== true. Promoted-from-waitlist counts as attendance.
+ */
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const name = url.searchParams.get('name')?.trim();
+  const weeksParam = Number(url.searchParams.get('weeks') ?? '12');
+  // Allow up to 5 years of history for the year-zoom heatmap. Clamp to 260.
+  const weeks = Number.isFinite(weeksParam) && weeksParam > 0 && weeksParam <= 260 ? Math.floor(weeksParam) : 12;
+
+  if (!name) {
+    return NextResponse.json({ error: 'name required' }, { status: 400 });
+  }
+
+  try {
+    const sessionsContainer = getContainer('sessions');
+    const playersContainer = getContainer('players');
+
+    const { resources: allSessions } = await sessionsContainer.items
+      .query({
+        query: 'SELECT * FROM c WHERE c.id != @pointerId AND c.id != @legacyId',
+        parameters: [
+          { name: '@pointerId', value: POINTER_ID },
+          { name: '@legacyId', value: 'current-session' },
+        ],
+      })
+      .fetchAll();
+
+    // Sort by datetime descending (most recent first). Sessions without a
+    // datetime sink to the bottom.
+    const sorted = (allSessions as Array<{ id: string; datetime?: string }>).slice().sort((a, b) => {
+      const da = a.datetime ?? '';
+      const db = b.datetime ?? '';
+      if (da === db) return 0;
+      if (!da) return 1;
+      if (!db) return -1;
+      return db.localeCompare(da);
+    });
+
+    const windowSessions = sorted.slice(0, weeks);
+    if (windowSessions.length === 0) {
+      return NextResponse.json({
+        name,
+        weeks,
+        attended: 0,
+        streak: 0,
+        longestStreak: 0,
+        history: [],
+      });
+    }
+
+    // Case-insensitive name match against `players` rows for each session.
+    // Batch into one query filtered by sessionIds to avoid N roundtrips.
+    const sessionIds = windowSessions.map((s) => s.id);
+    const placeholders = sessionIds.map((_, i) => `@sid${i}`).join(',');
+    const { resources: playerRows } = await playersContainer.items
+      .query({
+        query: `SELECT c.sessionId, c.name, c.removed, c.waitlisted FROM c WHERE c.sessionId IN (${placeholders}) AND LOWER(c.name) = LOWER(@name)`,
+        parameters: [
+          { name: '@name', value: name },
+          ...sessionIds.map((id, i) => ({ name: `@sid${i}`, value: id })),
+        ],
+      })
+      .fetchAll();
+
+    const attendedBySession = new Map<string, boolean>();
+    for (const row of playerRows as Array<{ sessionId: string; removed?: boolean; waitlisted?: boolean }>) {
+      if (row.removed === true) continue;
+      if (row.waitlisted === true) continue;
+      attendedBySession.set(row.sessionId, true);
+    }
+
+    const history = windowSessions.map((s) => ({
+      sessionId: s.id,
+      datetime: s.datetime ?? null,
+      attended: attendedBySession.has(s.id),
+    }));
+
+    const attended = history.filter((h) => h.attended).length;
+
+    // Current streak = consecutive attended sessions starting from most-recent.
+    let streak = 0;
+    for (const h of history) {
+      if (h.attended) streak += 1;
+      else break;
+    }
+
+    // Longest streak across the window.
+    let longestStreak = 0;
+    let run = 0;
+    for (const h of history) {
+      if (h.attended) {
+        run += 1;
+        if (run > longestStreak) longestStreak = run;
+      } else {
+        run = 0;
+      }
+    }
+
+    return NextResponse.json({
+      name,
+      weeks,
+      attended,
+      streak,
+      longestStreak,
+      history,
+    });
+  } catch (error) {
+    console.error('GET /api/stats/attendance error:', error);
+    return NextResponse.json({ error: 'Failed to compute attendance' }, { status: 500 });
+  }
+}

--- a/app/design/_nav.ts
+++ b/app/design/_nav.ts
@@ -7,4 +7,5 @@ export const SUBPAGES: DesignSubpage[] = [
   { href: '/design/fonts',       label: 'Type system', blurb: 'Locked pairing — Space Grotesk + JetBrains Mono' },
   { href: '/design/backgrounds', label: 'Backgrounds', blurb: '6 background directions — solid → contrail' },
   { href: '/design/perf',        label: 'Perf audit',  blurb: 'Findings re-tiered for iPhone 15 / Pixel 8 floor' },
+  { href: '/design/stats',       label: 'Stats playground', blurb: 'Three narrative arcs — your season · the club pulse · anatomy of Thursday' },
 ];

--- a/app/design/stats/page.tsx
+++ b/app/design/stats/page.tsx
@@ -1,0 +1,676 @@
+'use client';
+
+import Link from 'next/link';
+
+/* ────────────────────────────────────────────────────────────────────────
+   Stats playground — three narrative arcs, mocked, so we can pick an arc
+   to ship rather than cherry-picking isolated cards.
+
+   Arc 1 — Per-person "Your season so far"
+   Arc 2 — Per-group "The club pulse"
+   Arc 3 — Per-session "Anatomy of Thursday"
+
+   All data is fabricated. Charts are inline SVG — no recharts dep on this
+   route, so load is cheap.
+──────────────────────────────────────────────────────────────────────── */
+
+const ACCENT = 'var(--accent, #22c55e)';
+const MUTED = 'var(--text-muted)';
+const PRIMARY = 'var(--text-primary)';
+const DANGER = '#ef4444';
+const WARN = '#fbbf24';
+
+/* ═══════════════════════════════ PRIMITIVES ═══════════════════════════ */
+
+function Chip({ color, children }: { color: string; children: React.ReactNode }) {
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        padding: '3px 8px',
+        borderRadius: 100,
+        whiteSpace: 'nowrap',
+        fontWeight: 600,
+        letterSpacing: '0.04em',
+        textTransform: 'uppercase',
+        border: `1px solid ${color}`,
+        color,
+        background: 'transparent',
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Card({
+  icon, title, beat, children,
+}: { icon: string; title: string; beat: string; children: React.ReactNode }) {
+  return (
+    <div className="glass-card p-5 space-y-3">
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: ACCENT, marginTop: 2 }}>
+          {icon}
+        </span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <h3 style={{ fontSize: 15, fontWeight: 600, color: PRIMARY, margin: 0, lineHeight: 1.25 }}>{title}</h3>
+          <p style={{ fontSize: 12, color: MUTED, margin: 0, marginTop: 2, fontStyle: 'italic' }}>&ldquo;{beat}&rdquo;</p>
+        </div>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function Arc({
+  index, title, intro, audience, shipOrder, children,
+}: {
+  index: number;
+  title: string;
+  intro: string;
+  audience: string;
+  shipOrder: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ display: 'grid', gap: 14 }}>
+      <div
+        style={{
+          padding: '16px 18px',
+          borderLeft: `3px solid ${ACCENT}`,
+          background: 'color-mix(in oklab, var(--accent, #22c55e) 8%, transparent)',
+          borderRadius: 12,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
+          <span
+            style={{
+              width: 24, height: 24, borderRadius: '50%',
+              background: ACCENT, color: '#0a0a0a',
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              fontWeight: 700, fontSize: 12,
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            {index}
+          </span>
+          <h2 style={{ fontSize: 20, fontWeight: 700, color: PRIMARY, margin: 0 }}>{title}</h2>
+        </div>
+        <p style={{ fontSize: 13, color: PRIMARY, margin: 0, marginBottom: 4 }}>{intro}</p>
+        <p style={{ fontSize: 11, color: MUTED, margin: 0 }}>
+          <strong>Audience:</strong> {audience} &nbsp;·&nbsp; <strong>Ship order:</strong> {shipOrder}
+        </p>
+      </div>
+      <div style={{ display: 'grid', gap: 12 }}>{children}</div>
+    </section>
+  );
+}
+
+/* ═══════════════════════════════ VIZ — SHARED ═══════════════════════════ */
+
+function AttendanceStrip({ weeks, label }: { weeks: number[]; label?: string }) {
+  const total = weeks.filter((w) => w === 1).length;
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 26, fontWeight: 700, color: PRIMARY }}>
+        {total}<span style={{ fontSize: 13, fontWeight: 500, color: MUTED, marginLeft: 6 }}>of {weeks.length} weeks</span>
+      </p>
+      <div style={{ display: 'flex', gap: 3 }}>
+        {weeks.map((w, i) => (
+          <div
+            key={i}
+            title={`Week ${i + 1}: ${w ? 'played' : 'missed'}`}
+            style={{
+              flex: 1,
+              height: 24,
+              borderRadius: 4,
+              background: w ? ACCENT : 'var(--inner-card-bg)',
+              opacity: w ? 1 : 0.6,
+              border: `1px solid ${w ? 'transparent' : 'var(--inner-card-border)'}`,
+            }}
+          />
+        ))}
+      </div>
+      {label && <p style={{ margin: 0, fontSize: 11, color: MUTED }}>{label}</p>}
+    </div>
+  );
+}
+
+function PartnerBars({ data }: { data: { name: string; count: number }[] }) {
+  const max = Math.max(...data.map((d) => d.count));
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      {data.map((d) => (
+        <div key={d.name} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ width: 64, fontSize: 12, color: PRIMARY }}>{d.name}</span>
+          <div style={{ flex: 1, height: 10, borderRadius: 100, background: 'var(--inner-card-bg)', overflow: 'hidden' }}>
+            <div style={{ width: `${(d.count / max) * 100}%`, height: '100%', background: ACCENT, borderRadius: 100 }} />
+          </div>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: MUTED, minWidth: 24, textAlign: 'right' }}>
+            {d.count}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Sparkline({ points, suffix, label }: { points: number[]; suffix?: string; label?: string }) {
+  const W = 260, H = 60, pad = 10;
+  const max = Math.max(...points);
+  const min = Math.min(...points);
+  const stride = (W - pad * 2) / (points.length - 1);
+  const scale = (v: number) => H - pad - ((v - min) / (max - min || 1)) * (H - pad * 2);
+  const pts = points.map((v, i) => `${pad + i * stride},${scale(v)}`).join(' ');
+  const last = points[points.length - 1];
+  const avg = Math.round((points.reduce((a, b) => a + b, 0) / points.length) * 100) / 100;
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <div style={{ display: 'flex', gap: 14, alignItems: 'baseline' }}>
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 24, fontWeight: 700, color: PRIMARY }}>
+          {suffix === '$' ? '$' : ''}{last.toFixed(suffix === '$' ? 2 : 0)}{suffix && suffix !== '$' ? ` ${suffix}` : ''}
+        </p>
+        <p style={{ margin: 0, fontSize: 11, color: MUTED }}>
+          latest · avg <span style={{ fontFamily: 'var(--font-mono)' }}>{suffix === '$' ? '$' : ''}{avg.toFixed(suffix === '$' ? 2 : 0)}</span>
+        </p>
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%" role="img" aria-label={label ?? 'Trend'}>
+        <polyline points={pts} fill="none" stroke={ACCENT} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+        {points.map((v, i) => (
+          <circle key={i} cx={pad + i * stride} cy={scale(v)} r={i === points.length - 1 ? 4 : 2.5} fill={ACCENT} />
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function CircleProgress({ pct, label, context }: { pct: number; label: string; context: string }) {
+  const R = 26;
+  const C = 2 * Math.PI * R;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+      <svg width={64} height={64} viewBox="0 0 64 64">
+        <circle cx={32} cy={32} r={R} fill="none" stroke="var(--inner-card-bg)" strokeWidth={8} />
+        <circle
+          cx={32} cy={32} r={R}
+          fill="none" stroke={ACCENT} strokeWidth={8} strokeLinecap="round"
+          strokeDasharray={`${(pct / 100) * C} ${C}`}
+          transform="rotate(-90 32 32)"
+        />
+        <text x={32} y={37} textAnchor="middle" fontSize="13" fontWeight="700" fill={PRIMARY} fontFamily="var(--font-mono)">
+          {pct}%
+        </text>
+      </svg>
+      <div>
+        <p style={{ margin: 0, fontSize: 14, fontWeight: 600, color: PRIMARY }}>{label}</p>
+        <p style={{ margin: 0, fontSize: 12, color: MUTED }}>{context}</p>
+      </div>
+    </div>
+  );
+}
+
+function HeroNumber({ value, unit, caption }: { value: string; unit?: string; caption: string }) {
+  return (
+    <div>
+      <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 30, fontWeight: 700, color: PRIMARY, lineHeight: 1 }}>
+        {value}
+        {unit && <span style={{ fontSize: 14, fontWeight: 500, color: MUTED, marginLeft: 6 }}>{unit}</span>}
+      </p>
+      <p style={{ margin: 0, marginTop: 6, fontSize: 12, color: MUTED }}>{caption}</p>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════ ARC 1 — PER-PERSON ═══════════════════════════════ */
+
+function StreakBadge() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+      <div
+        style={{
+          width: 56, height: 56, borderRadius: '50%',
+          background: 'linear-gradient(135deg, #f59e0b, #ef4444)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+      >
+        <span style={{ fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: '#fff' }}>7</span>
+      </div>
+      <div>
+        <p style={{ margin: 0, fontSize: 15, fontWeight: 600, color: PRIMARY }}>7 weeks in a row</p>
+        <p style={{ margin: 0, fontSize: 12, color: MUTED }}>Longest: 9 weeks (Feb–Apr). You&rsquo;re close to it.</p>
+      </div>
+    </div>
+  );
+}
+
+function NextSession() {
+  return (
+    <div
+      style={{
+        background: 'color-mix(in oklab, var(--accent, #22c55e) 10%, transparent)',
+        border: `1px solid ${ACCENT}`,
+        borderRadius: 12,
+        padding: 14,
+        display: 'grid',
+        gap: 4,
+      }}
+    >
+      <p style={{ margin: 0, fontSize: 10, fontWeight: 600, letterSpacing: '0.08em', color: ACCENT, textTransform: 'uppercase' }}>
+        Next up
+      </p>
+      <p style={{ margin: 0, fontSize: 15, fontWeight: 600, color: PRIMARY }}>
+        Thursday · Marpole · 7:30 pm
+      </p>
+      <p style={{ margin: 0, fontSize: 12, color: MUTED }}>
+        8 signed up · 4 spots left · sign up before Wed 8pm
+      </p>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════ ARC 2 — PER-GROUP ═══════════════════════════════ */
+
+function FillTimeTrend() {
+  const times = [42, 28, 19, 15, 11, 8, 6];
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <div style={{ display: 'flex', gap: 14, alignItems: 'baseline' }}>
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 26, fontWeight: 700, color: ACCENT }}>
+          6<span style={{ fontSize: 13, fontWeight: 500, color: MUTED, marginLeft: 4 }}>min</span>
+        </p>
+        <Chip color={ACCENT}>Fastest ever</Chip>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'flex-end', gap: 4, height: 48 }}>
+        {times.map((t, i) => {
+          const h = Math.max(6, (t / Math.max(...times)) * 42);
+          return (
+            <div
+              key={i}
+              style={{
+                flex: 1,
+                height: h,
+                background: ACCENT,
+                opacity: 0.4 + (i / times.length) * 0.6,
+                borderRadius: 3,
+              }}
+            />
+          );
+        })}
+      </div>
+      <p style={{ margin: 0, fontSize: 11, color: MUTED }}>
+        Filling 6× faster than 7 weeks ago. Time to consider a 3rd court or split the night.
+      </p>
+    </div>
+  );
+}
+
+function WaitlistPressure() {
+  const names = [
+    { name: 'Alex',  times: 4 },
+    { name: 'Jamie', times: 3 },
+    { name: 'Mina',  times: 3 },
+    { name: 'Chen',  times: 2 },
+  ];
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <HeroNumber value="4" caption="regulars repeatedly on the waitlist — might churn if we don't make room" />
+      <div style={{ display: 'grid', gap: 4, marginTop: 4 }}>
+        {names.map((n) => (
+          <div key={n.name} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+            <span style={{ color: PRIMARY }}>{n.name}</span>
+            <span style={{ color: MUTED, fontFamily: 'var(--font-mono)' }}>
+              waitlisted {n.times}×
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CostPulse() {
+  return <Sparkline points={[9.5, 11.25, 10.75, 12, 10.5, 11.75, 13.25, 12]} suffix="$" label="Cost per person, last 8 sessions" />;
+}
+
+function BirdSupply() {
+  const remaining = 52;
+  const runway = 4;
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}>
+        <span className="material-icons" style={{ fontSize: 32, color: runway < 3 ? WARN : ACCENT }}>
+          inventory_2
+        </span>
+      </div>
+      <div>
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: PRIMARY }}>
+          {remaining}<span style={{ fontSize: 12, fontWeight: 500, color: MUTED }}> tubes</span>
+        </p>
+        <p style={{ margin: 0, fontSize: 12, color: MUTED }}>
+          ~{runway} weeks at current pace · reorder by mid-May
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AttendanceRoster() {
+  const top = [
+    { name: 'Grant',  count: 12, streak: 7 },
+    { name: 'Kevin',  count: 11, streak: 5 },
+    { name: 'Luna',   count: 10, streak: 3 },
+    { name: 'James',  count: 9,  streak: 2 },
+    { name: 'Anna',   count: 9,  streak: 2 },
+  ];
+  const inactive = [
+    { name: 'Rob',   last: '4 weeks ago' },
+    { name: 'Priya', last: '5 weeks ago' },
+    { name: 'Omar',  last: '6 weeks ago' },
+  ];
+  return (
+    <div style={{ display: 'grid', gap: 12 }}>
+      <div>
+        <p style={{ margin: 0, fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', color: ACCENT, textTransform: 'uppercase' }}>
+          Anchors
+        </p>
+        <div style={{ display: 'grid', gap: 4, marginTop: 4 }}>
+          {top.map((p) => (
+            <div key={p.name} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+              <span style={{ color: PRIMARY }}>{p.name}</span>
+              <span style={{ color: MUTED, fontFamily: 'var(--font-mono)' }}>
+                {p.count} sessions · {p.streak}-week streak
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div>
+        <p style={{ margin: 0, fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', color: WARN, textTransform: 'uppercase' }}>
+          Drifting — send a nudge?
+        </p>
+        <div style={{ display: 'grid', gap: 4, marginTop: 4 }}>
+          {inactive.map((p) => (
+            <div key={p.name} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+              <span style={{ color: PRIMARY }}>{p.name}</span>
+              <span style={{ color: MUTED }}>{p.last}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BirdValueScatter() {
+  const points = [
+    { name: 'Yonex AS-50',     x: 4.2, y: 9.5,  good: true },
+    { name: 'Victor Master',   x: 3.8, y: 7.2,  good: true,  star: true },
+    { name: 'RSL Classic',     x: 4.5, y: 5.1,  good: true },
+    { name: 'No-brand',        x: 2.1, y: 3.2,  good: false },
+    { name: 'Yonex Aerosensa', x: 4.8, y: 14.5, good: true },
+  ];
+  const W = 260, H = 120, pad = 24;
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <svg viewBox={`0 0 ${W} ${H}`} width="100%">
+        <line x1={pad} x2={W - pad} y1={H - pad} y2={H - pad} stroke={MUTED} strokeOpacity={0.2} />
+        <line x1={pad} x2={pad} y1={pad} y2={H - pad} stroke={MUTED} strokeOpacity={0.2} />
+        <text x={pad + 4} y={pad + 8} fontSize="9" fill={MUTED}>$/tube</text>
+        <text x={W - pad - 28} y={H - pad + 12} fontSize="9" fill={MUTED}>Quality</text>
+        {points.map((p, i) => {
+          const cx = pad + (p.x / 5) * (W - pad * 2);
+          const cy = H - pad - (p.y / 16) * (H - pad * 2);
+          return (
+            <g key={i}>
+              <circle cx={cx} cy={cy} r={p.star ? 8 : 5} fill={p.good ? ACCENT : DANGER} fillOpacity={p.star ? 0.9 : 0.6} stroke={p.good ? ACCENT : DANGER} />
+              {p.star && <circle cx={cx} cy={cy} r={12} fill="none" stroke={ACCENT} strokeOpacity={0.4} strokeDasharray="2 2" />}
+            </g>
+          );
+        })}
+      </svg>
+      <p style={{ margin: 0, fontSize: 11, color: MUTED }}>
+        Victor Master is the sweet spot — high quality at a reasonable $/tube. Buy more of those.
+      </p>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════ ARC 3 — PER-SESSION ═══════════════════════════════ */
+
+function SessionSetting() {
+  return (
+    <div style={{ display: 'grid', gap: 4 }}>
+      <p style={{ margin: 0, fontSize: 18, fontWeight: 700, color: PRIMARY }}>
+        Thursday · April 24 · 7:30–9:30 pm
+      </p>
+      <p style={{ margin: 0, fontSize: 12, color: MUTED }}>
+        Marpole Community Centre · 2 courts · 12 players
+      </p>
+    </div>
+  );
+}
+
+function DemandSignal() {
+  return (
+    <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+      <div>
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: PRIMARY }}>14 min</p>
+        <p style={{ margin: 0, fontSize: 11, color: MUTED }}>to fill</p>
+      </div>
+      <div style={{ width: 1, height: 36, background: 'var(--inner-card-border)' }} />
+      <div>
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: WARN }}>3</p>
+        <p style={{ margin: 0, fontSize: 11, color: MUTED }}>waitlisted at start</p>
+      </div>
+    </div>
+  );
+}
+
+function SessionReceipt() {
+  return (
+    <div style={{ display: 'grid', gap: 4, fontSize: 13 }}>
+      <Row k="Courts" v="2 × $45 = $90.00" />
+      <Row k="Birds" v="2 tubes Yonex AS-50 · $28.00" />
+      <Row k="Total" v="$118.00" strong />
+      <div style={{ height: 1, background: 'var(--inner-card-border)', margin: '6px 0' }} />
+      <Row k="Per person" v="$11.80 (10 paid)" strong accent />
+    </div>
+  );
+}
+
+function Row({ k, v, strong, accent }: { k: string; v: string; strong?: boolean; accent?: boolean }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <span style={{ color: MUTED }}>{k}</span>
+      <span
+        style={{
+          color: accent ? ACCENT : PRIMARY,
+          fontWeight: strong ? 600 : 400,
+          fontFamily: 'var(--font-mono)',
+        }}
+      >
+        {v}
+      </span>
+    </div>
+  );
+}
+
+function SessionRoster() {
+  const played = ['Grant', 'Kevin', 'Luna', 'James', 'Anna', 'Daiyu', 'Min', 'Chen', 'Tara', 'Nate'];
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+      {played.map((name) => (
+        <span
+          key={name}
+          style={{
+            fontSize: 11,
+            padding: '4px 10px',
+            borderRadius: 100,
+            background: 'var(--inner-card-bg)',
+            border: '1px solid var(--inner-card-border)',
+            color: PRIMARY,
+          }}
+        >
+          {name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function PaymentLoopClose() {
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <div style={{ display: 'flex', gap: 2, height: 8, borderRadius: 100, overflow: 'hidden' }}>
+        <div style={{ flex: 10, background: ACCENT }} />
+        <div style={{ flex: 2, background: 'var(--inner-card-border)' }} />
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+        <span style={{ color: ACCENT }}>10 paid</span>
+        <span style={{ color: MUTED }}>2 still owe $11.80</span>
+      </div>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════ PAGE ═══════════════════════════════ */
+
+export default function StatsPlaygroundPage() {
+  return (
+    <main style={{ maxWidth: 720, margin: '0 auto', padding: '2rem 1rem', display: 'grid', gap: 36 }}>
+      <div>
+        <Link
+          href="/design"
+          style={{ color: MUTED, fontSize: 13, textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+        >
+          <span className="material-icons" style={{ fontSize: 16 }}>arrow_back</span>
+          Design index
+        </Link>
+        <h1 className="bpm-h1" style={{ marginTop: 12, marginBottom: 6 }}>Stats — three narratives</h1>
+        <p className="bpm-body" style={{ color: MUTED, marginTop: 0 }}>
+          Each arc is a sequence of cards with an emotional beat. Pick an arc to ship; cherry-picking single cards across
+          arcs dilutes the story. All cards here are derivable today — no schema changes.
+        </p>
+      </div>
+
+      {/* ── ARC 1 ────────────────────────────────────────────────────── */}
+      <Arc
+        index={1}
+        title="Your season so far"
+        intro="A self-portrait. Opens proud, lands practical. Works for any member, logged in or not."
+        audience="Every player"
+        shipOrder="First — biggest retention pull"
+      >
+        <Card icon="local_fire_department" title="7 weeks in a row" beat="I show up.">
+          <StreakBadge />
+        </Card>
+        <Card icon="calendar_today" title="Played 9 of 12 weeks" beat="The club is part of my life.">
+          <AttendanceStrip weeks={[1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 1]} label="2 misses in a row mid-March — travel week" />
+        </Card>
+        <Card icon="groups" title="Kevin, Luna, James" beat="These are my people.">
+          <PartnerBars data={[
+            { name: 'Kevin', count: 9 },
+            { name: 'Luna',  count: 7 },
+            { name: 'James', count: 5 },
+            { name: 'Anna',  count: 3 },
+            { name: 'Daiyu', count: 2 },
+          ]} />
+        </Card>
+        <Card icon="schedule" title="24.5 hours on court" beat="I&rsquo;ve invested real time.">
+          <HeroNumber value="24.5" unit="hrs" caption="This quarter · 11 sessions × 2.2h avg · ~1h/week" />
+        </Card>
+        <Card icon="verified" title="Paid on time 92%" beat="I&rsquo;m reliable.">
+          <CircleProgress pct={92} label="11 of 12 cleared" context="before the next session started" />
+        </Card>
+        <Card icon="payments" title="$136.50 this quarter" beat="Here&rsquo;s what it costs.">
+          <Sparkline points={[11, 12.5, 11.25, 13, 11.75, 12.25, 13.5, 11.80]} suffix="$" label="My $/session" />
+        </Card>
+        <Card icon="event" title="Thursday @ Marpole" beat="I know where I&rsquo;m going next.">
+          <NextSession />
+        </Card>
+      </Arc>
+
+      {/* ── ARC 2 ────────────────────────────────────────────────────── */}
+      <Arc
+        index={2}
+        title="The club pulse"
+        intro="Diagnostic. Ordered by decision urgency — each card sets up a &lsquo;so what should I do&rsquo; prompt for the admin."
+        audience="Admin only"
+        shipOrder="Third — highest-leverage, needs the most polish"
+      >
+        <Card icon="bolt" title="Filled in 6 minutes" beat="Demand is ahead of capacity. Open another court?">
+          <FillTimeTrend />
+        </Card>
+        <Card icon="hourglass_empty" title="4 regulars keep hitting the waitlist" beat="These names may churn if we don&rsquo;t make room.">
+          <WaitlistPressure />
+        </Card>
+        <Card icon="payments" title="$12.50 avg per session · stable" beat="Cost isn&rsquo;t drifting. Nothing to fix.">
+          <CostPulse />
+        </Card>
+        <Card icon="inventory_2" title="52 tubes left · 4-week runway" beat="Time to reorder.">
+          <BirdSupply />
+        </Card>
+        <Card icon="groups" title="Anchors and drifters" beat="Know who to thank and who to nudge back.">
+          <AttendanceRoster />
+        </Card>
+        <Card icon="science" title="Bird value — Victor Master wins" beat="Next reorder should lean this way.">
+          <BirdValueScatter />
+        </Card>
+      </Arc>
+
+      {/* ── ARC 3 ────────────────────────────────────────────────────── */}
+      <Arc
+        index={3}
+        title="Anatomy of Thursday"
+        intro="A post-session recap. Works on the Home tab the morning after, or as an archive view. Short and shareable."
+        audience="Everyone who played"
+        shipOrder="Second — closes the loop on the week that just happened"
+      >
+        <Card icon="event" title="The setting" beat="Where and when we gathered.">
+          <SessionSetting />
+        </Card>
+        <Card icon="bolt" title="Demand signal" beat="How badly people wanted in.">
+          <DemandSignal />
+        </Card>
+        <Card icon="receipt_long" title="The receipt" beat="What the night actually cost.">
+          <SessionReceipt />
+        </Card>
+        <Card icon="groups" title="Who showed up" beat="The people you shared a court with.">
+          <SessionRoster />
+        </Card>
+        <Card icon="verified" title="Payment loop" beat="Closing the week.">
+          <PaymentLoopClose />
+        </Card>
+      </Arc>
+
+      {/* ── RECOMMENDATION ─────────────────────────────────────────────── */}
+      <section
+        className="glass-card"
+        style={{ padding: 20, display: 'grid', gap: 10, borderLeft: `3px solid ${ACCENT}` }}
+      >
+        <p style={{ margin: 0, fontSize: 12, color: ACCENT, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+          Proposed ship order
+        </p>
+        <ol style={{ margin: 0, paddingLeft: 18, display: 'grid', gap: 6, fontSize: 13, color: PRIMARY }}>
+          <li>
+            <strong>Arc 1 · Your season so far</strong> — the Stats tab turns into a personal recap. Biggest retention pull,
+            every member benefits, no admin gate.
+          </li>
+          <li>
+            <strong>Arc 3 · Anatomy of Thursday</strong> — add a compact post-session recap card to the Home tab once the session ends.
+            Closes the loop on the week. Shareable in WhatsApp.
+          </li>
+          <li>
+            <strong>Arc 2 · The club pulse</strong> — land on the Admin dashboard last. Real decisions, but highest-polish bar,
+            and it&rsquo;s fine without it for now.
+          </li>
+        </ol>
+        <p style={{ margin: 0, fontSize: 12, color: MUTED }}>
+          Every card on this page is derivable from what we already collect. Skill progression stays &ldquo;Coming soon&rdquo; until we
+          start writing <code className="bpm-mono" style={{ color: ACCENT }}>skillsHistory</code> rows — bank that data now,
+          ship the card later.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1250,3 +1250,33 @@ html[data-hydrated="true"] .splash {
     transition: none;
   }
 }
+
+/* ── Announcement body (miniMarkdown output) ────────────────────────── */
+.announcement-body {
+  white-space: normal;
+}
+.announcement-body p {
+  margin: 0;
+}
+.announcement-body p + p,
+.announcement-body ul + p,
+.announcement-body ol + p,
+.announcement-body p + ul,
+.announcement-body p + ol {
+  margin-top: 0.5rem;
+}
+.announcement-body ul,
+.announcement-body ol {
+  padding-left: 1.25rem;
+  margin: 0;
+}
+.announcement-body li {
+  margin: 0.15rem 0;
+}
+.announcement-body strong {
+  color: var(--text-primary, #fff);
+  font-weight: 600;
+}
+.announcement-body em {
+  font-style: italic;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -85,7 +85,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         {/* Material Symbols Rounded — subsetted to the ~35 glyphs actually used.
             Replaces the old full Material Icons webfont (~100 KB → ~15–20 KB). */}
         <link
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=add,admin_panel_settings,arrow_back,auto_fix_high,calendar_today,campaign,celebration,check_circle,chevron_left,chevron_right,close,dark_mode,delete,delete_forever,delete_outline,delete_sweep,download,edit,error,error_outline,expand_less,expand_more,group,group_add,home,hourglass_empty,hourglass_top,how_to_reg,inventory_2,light_mode,lock,lock_clock,logout,more_vert,person_remove,remove,restore,schedule,school,science,shield,sports_tennis,translate,watch_later&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=add,admin_panel_settings,arrow_back,auto_fix_high,bar_chart,bolt,calendar_today,campaign,celebration,check_circle,chevron_left,chevron_right,close,dark_mode,delete,delete_forever,delete_outline,delete_sweep,download,edit,emoji_events,error,error_outline,event,expand_less,expand_more,format_list_bulleted,format_list_numbered,group,group_add,groups,home,hourglass_empty,hourglass_top,how_to_reg,inventory_2,light_mode,local_fire_department,lock,lock_clock,logout,more_vert,paid,payments,person_remove,radio_button_unchecked,receipt_long,remove,restore,schedule,school,science,shield,sports_tennis,star,subdirectory_arrow_left,translate,trending_up,verified,visibility,watch_later&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -26,7 +26,7 @@ export default function BottomNav({ activeTab, onTabChange, showAdmin }: Props) 
   const tabs: NavItem[] = [
     { id: 'home',    label: t('home'),    icon: 'home' },
     { id: 'players', label: t('signups'), icon: 'group' },
-    { id: 'skills',  label: t('skills'),  icon: 'school' },
+    { id: 'skills',  label: t('skills'),  icon: 'bar_chart' },
     { id: 'admin',   label: t('admin'),   icon: 'admin_panel_settings' },
   ];
   const visibleTabs = tabs.filter((tab) => tab.id !== 'admin' || showAdmin);

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -12,6 +12,7 @@ import PrevPaymentReminder from '@/components/PrevPaymentReminder';
 import ReleaseNotesTrigger from './ReleaseNotesTrigger';
 import ReleaseNotesSheet from './ReleaseNotesSheet';
 import WelcomeCard from './WelcomeCard';
+import { renderMarkdown } from '@/lib/miniMarkdown';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -311,7 +312,9 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
       {effectiveAnnouncement && (
         <div className="glass-card p-5 space-y-2">
           <p className="section-label">{t('announcement.label')}</p>
-          <p className="text-sm text-gray-200 leading-relaxed">{effectiveAnnouncement.text}</p>
+          <div className="announcement-body text-sm text-gray-200 leading-relaxed">
+            {renderMarkdown(effectiveAnnouncement.text)}
+          </div>
         </div>
       )}
 

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { isPreviewEnv } from '@/lib/flags';
 
 const BANNER_HEIGHT = 28;
-const REPORT_EMAIL = 'xyzou2012@gmail.com';
+const REPO = 'grantxyzou/badminton-app';
+const FEEDBACK_EMAIL = 'xyzou2012@gmail.com';
 
 export default function PreviewBanner() {
   const show = isPreviewEnv();
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
     if (!show) return;
@@ -17,24 +19,29 @@ export default function PreviewBanner() {
     };
   }, [show]);
 
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setPickerOpen(false);
+    }
+    window.addEventListener('keydown', onEsc);
+    return () => window.removeEventListener('keydown', onEsc);
+  }, [pickerOpen]);
+
   if (!show) return null;
 
   const sha = (process.env.NEXT_PUBLIC_GIT_SHA ?? 'dev').slice(0, 7);
 
-  function handleReportClick(e: React.MouseEvent<HTMLAnchorElement>) {
-    e.preventDefault();
-    const subject = `bpm-next bug report · ${sha}`;
-    const body = [
-      `URL: ${window.location.href}`,
-      `SHA: ${sha}`,
-      `UA: ${navigator.userAgent}`,
-      '',
-      'What went wrong:',
-      '',
-    ].join('\n');
-    window.location.href = `mailto:${REPORT_EMAIL}?subject=${encodeURIComponent(
-      subject,
-    )}&body=${encodeURIComponent(body)}`;
+  function issueUrl(template: 'bug.yml' | 'feature.yml') {
+    const url = typeof window !== 'undefined' ? window.location.href : '';
+    const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+    const params = new URLSearchParams({
+      template,
+      url,
+      sha,
+      ua,
+    });
+    return `https://github.com/${REPO}/issues/new?${params.toString()}`;
   }
 
   return (
@@ -59,15 +66,127 @@ export default function PreviewBanner() {
         }}
       >
         preview bpm vnext · {sha} not the stable site ·{' '}
-        <a
-          href={`mailto:${REPORT_EMAIL}`}
-          onClick={handleReportClick}
-          style={{ color: '#111', textDecoration: 'underline' }}
+        <button
+          type="button"
+          onClick={() => setPickerOpen((p) => !p)}
+          aria-haspopup="menu"
+          aria-expanded={pickerOpen}
+          style={{
+            color: '#111',
+            textDecoration: 'underline',
+            background: 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            font: 'inherit',
+            padding: 0,
+          }}
         >
-          report a bug
-        </a>
+          report a bug / idea
+        </button>
       </div>
       <div style={{ height: BANNER_HEIGHT }} aria-hidden="true" />
+
+      {pickerOpen && (
+        <>
+          <div
+            onClick={() => setPickerOpen(false)}
+            aria-hidden="true"
+            style={{
+              position: 'fixed',
+              inset: 0,
+              zIndex: 9998,
+              background: 'rgba(0,0,0,0.4)',
+            }}
+          />
+          <div
+            role="menu"
+            aria-label="Report options"
+            style={{
+              position: 'fixed',
+              top: BANNER_HEIGHT + 8,
+              right: 12,
+              zIndex: 10000,
+              background: 'var(--bg-elevated, #1a1a1a)',
+              border: '1px solid rgba(255,255,255,0.12)',
+              borderRadius: 12,
+              padding: 8,
+              boxShadow: '0 10px 30px rgba(0,0,0,0.5)',
+              minWidth: 220,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 4,
+            }}
+          >
+            <a
+              role="menuitem"
+              href={issueUrl('bug.yml')}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setPickerOpen(false)}
+              style={{
+                padding: '10px 12px',
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                color: 'var(--text-primary, #fff)',
+                textDecoration: 'none',
+                borderRadius: 8,
+                fontSize: 14,
+              }}
+            >
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: '#ef4444' }}>
+                error
+              </span>
+              Report a bug
+            </a>
+            <a
+              role="menuitem"
+              href={issueUrl('feature.yml')}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setPickerOpen(false)}
+              style={{
+                padding: '10px 12px',
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                color: 'var(--text-primary, #fff)',
+                textDecoration: 'none',
+                borderRadius: 8,
+                fontSize: 14,
+              }}
+            >
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: 'var(--accent, #22c55e)' }}>
+                auto_fix_high
+              </span>
+              Suggest a feature
+            </a>
+            <a
+              role="menuitem"
+              href={`mailto:${FEEDBACK_EMAIL}?subject=${encodeURIComponent(`bpm-next feedback · ${sha}`)}`}
+              onClick={() => setPickerOpen(false)}
+              style={{
+                padding: '10px 12px',
+                minHeight: 44,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                color: 'var(--text-muted, #aaa)',
+                textDecoration: 'none',
+                borderRadius: 8,
+                fontSize: 13,
+              }}
+            >
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 18 }}>
+                schedule
+              </span>
+              Private email instead
+            </a>
+          </div>
+        </>
+      )}
     </>
   );
 }

--- a/components/SkillsTab.tsx
+++ b/components/SkillsTab.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { useTranslations } from 'next-intl';
 import dynamic from 'next/dynamic';
 import type { PlayerSkills as PersistedPlayerSkills } from '@/lib/types';
 import type { PlayerSkills } from '@/components/SkillsRadar';
 import ShuttleLoader from '@/components/ShuttleLoader';
+import StatsPlaceholder from '@/components/stats/StatsPlaceholder';
+import AttendanceCardLive from '@/components/stats/cards/AttendanceCardLive';
+import StatsStreakHero from '@/components/stats/StatsStreakHero';
+import { isFlagOn } from '@/lib/flags';
 
 const SkillsRadar = dynamic(() => import('@/components/SkillsRadar'), { ssr: false });
 
@@ -16,7 +19,6 @@ function toRadarShape(records: PersistedPlayerSkills[]): PlayerSkills[] {
 }
 
 export default function SkillsTab({ isAdmin }: { isAdmin?: boolean }) {
-  const pageT = useTranslations('pages.learn');
   const [loading, setLoading] = useState(true);
   const [players, setPlayers] = useState<PlayerSkills[]>([]);
 
@@ -79,58 +81,37 @@ export default function SkillsTab({ isAdmin }: { isAdmin?: boolean }) {
     }
   }
 
+  const attendanceOn = isFlagOn('NEXT_PUBLIC_FLAG_STATS_ATTENDANCE');
+  const attendanceContent = attendanceOn ? <AttendanceCardLive /> : undefined;
+  const heroSlot = attendanceOn ? <StatsStreakHero /> : undefined;
+
   if (!isAdmin) {
-    return (
-      <div className="space-y-5">
-        <h1 className="text-3xl font-bold text-gray-200 leading-tight px-2">
-          {pageT('title')}
-        </h1>
-        <div
-          className="flex items-center justify-center"
-          style={{ minHeight: 'calc(100vh - 16rem)' }}
-        >
-          <p className="text-2xl font-semibold text-center" style={{ color: 'var(--text-muted)' }}>
-            Progress together?
-          </p>
-        </div>
-      </div>
-    );
+    return <StatsPlaceholder attendanceContent={attendanceContent} heroSlot={heroSlot} />;
   }
 
   if (loading) {
     return (
-      <div className="space-y-5">
-        <h1 className="text-3xl font-bold text-gray-200 leading-tight px-2">
-          {pageT('title')}
-        </h1>
-        <ShuttleLoader text="Loading skills..." />
-      </div>
+      <StatsPlaceholder
+        skillProgressionContent={<ShuttleLoader text="Loading skills..." />}
+        attendanceContent={attendanceContent}
+        heroSlot={heroSlot}
+      />
     );
   }
 
-  return (
-    <div className="space-y-5">
-      <h1 className="text-3xl font-bold text-gray-200 leading-tight px-2">
-        {pageT('title')}
-      </h1>
-      <div className="space-y-4">
+  const skillProgressionContent = (
+    <div className="space-y-4">
       {players.length === 0 ? (
-        <div
-          className="flex items-center justify-center"
-          style={{ minHeight: '20vh' }}
-        >
-          <p className="text-sm text-center" style={{ color: 'var(--text-muted)' }}>
-            No skill profiles yet. Add a player below to create one.
-          </p>
-        </div>
+        <p className="text-sm text-center py-4" style={{ color: 'var(--text-muted)' }}>
+          No skill profiles yet. Add a player below to create one.
+        </p>
       ) : (
         <SkillsRadar players={players} onScoresChanged={refresh} />
       )}
 
-      {/* Add player form — placed at the bottom so its submit button is
-          in the thumb zone for one-handed use. */}
-      <form onSubmit={handleAddPlayer} className="glass-card p-5 space-y-3">
-        <h3 className="section-label">ADD PLAYER</h3>
+      {/* Inline add-player form — only shown to admins inside the live card. */}
+      <form onSubmit={handleAddPlayer} className="inner-card p-3 space-y-2">
+        <p className="section-label">ADD PLAYER</p>
         <div className="flex gap-2">
           <input
             id="skills-player-name"
@@ -160,7 +141,14 @@ export default function SkillsTab({ isAdmin }: { isAdmin?: boolean }) {
           </p>
         )}
       </form>
-      </div>
     </div>
+  );
+
+  return (
+    <StatsPlaceholder
+      skillProgressionContent={skillProgressionContent}
+      attendanceContent={attendanceContent}
+      heroSlot={heroSlot}
+    />
   );
 }

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -14,6 +14,8 @@ import BirdInventoryView from './BirdInventoryView';
 import AdvanceSessionForm from './AdvanceSessionForm';
 import ReleasesView from './ReleasesView';
 import { useAnnouncements } from './hooks/useAnnouncements';
+import AnnouncementComposer from './AnnouncementComposer';
+import { renderMarkdown } from '@/lib/miniMarkdown';
 import { useSessionNavigation } from './hooks/useSessionNavigation';
 import { usePlayerManagement } from './hooks/usePlayerManagement';
 
@@ -117,17 +119,7 @@ function Dashboard({ onLogout, refreshKey, setView }: DashboardProps) {
         {/* Compose */}
         <div className="glass-card p-5 space-y-3">
           <h3 className="section-label">ANNOUNCEMENTS</h3>
-          <textarea
-            id="admin-announcement-draft"
-            name="announcementDraft"
-            rows={3}
-            placeholder="Type your announcement\u2026"
-            aria-label="Announcement text"
-            value={anno.draft}
-            onChange={(e) => anno.setDraft(e.target.value)}
-            maxLength={500}
-          />
-          <p className="text-right text-xs text-gray-500">{anno.draft.length}/500</p>
+          <AnnouncementComposer draft={anno.draft} setDraft={anno.setDraft} />
           <button
             onClick={anno.handlePolish}
             disabled={anno.polishing || !anno.draft.trim()}
@@ -176,13 +168,13 @@ function Dashboard({ onLogout, refreshKey, setView }: DashboardProps) {
                   <div key={a.id} className="inner-card p-3 space-y-2">
                     <textarea
                       name="announcementEdit"
-                      rows={3}
+                      rows={4}
                       value={anno.editAnnoText}
                       onChange={(e) => anno.setEditAnnoText(e.target.value)}
-                      maxLength={500}
+                      maxLength={800}
                       className="w-full text-sm"
                     />
-                    <p className="text-right text-xs text-gray-500">{anno.editAnnoText.length}/500</p>
+                    <p className="text-right text-xs text-gray-500">{anno.editAnnoText.length}/800</p>
                     {anno.editAnnoError && <p className="text-red-400 text-xs">{anno.editAnnoError}</p>}
                     <div className="flex gap-2">
                       <button
@@ -200,7 +192,7 @@ function Dashboard({ onLogout, refreshKey, setView }: DashboardProps) {
                 ) : (
                   <div key={a.id} className="inner-card p-3">
                     <div className="flex items-start justify-between gap-2">
-                      <p className="text-sm text-gray-200 flex-1">{a.text}</p>
+                      <div className="announcement-body text-sm text-gray-200 flex-1">{renderMarkdown(a.text)}</div>
                       <div className="flex gap-3 shrink-0">
                         <button
                           onClick={() => anno.startEditAnno(a)}

--- a/components/admin/AnnouncementComposer.tsx
+++ b/components/admin/AnnouncementComposer.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { renderMarkdown } from '@/lib/miniMarkdown';
+
+interface Props {
+  draft: string;
+  setDraft: (value: string) => void;
+  maxLength?: number;
+}
+
+type WrapKind = 'bold' | 'italic' | 'ul' | 'ol' | 'br';
+
+const PLACEHOLDER = [
+  "Type your announcement…",
+  '',
+  'Try formatting it:',
+  '  **bold**   *italic*',
+  '  - a list item',
+  '  1. numbered',
+].join('\n');
+
+function applyFormat(text: string, start: number, end: number, kind: WrapKind): { next: string; nextStart: number; nextEnd: number } {
+  const before = text.slice(0, start);
+  const selected = text.slice(start, end);
+  const after = text.slice(end);
+
+  if (kind === 'bold' || kind === 'italic') {
+    const marker = kind === 'bold' ? '**' : '*';
+    const content = selected || (kind === 'bold' ? 'bold text' : 'italic text');
+    const next = `${before}${marker}${content}${marker}${after}`;
+    const markerLen = marker.length;
+    return {
+      next,
+      nextStart: before.length + markerLen,
+      nextEnd: before.length + markerLen + content.length,
+    };
+  }
+
+  if (kind === 'br') {
+    const next = `${before}\n\n${after}`;
+    const pos = before.length + 2;
+    return { next, nextStart: pos, nextEnd: pos };
+  }
+
+  const lines = (selected || 'list item').split('\n');
+  const prefixed = lines
+    .map((line, i) => (kind === 'ul' ? `- ${line}` : `${i + 1}. ${line}`))
+    .join('\n');
+  const prefix = before.length > 0 && !before.endsWith('\n') ? '\n' : '';
+  const next = `${before}${prefix}${prefixed}${after}`;
+  const startPos = before.length + prefix.length;
+  return {
+    next,
+    nextStart: startPos,
+    nextEnd: startPos + prefixed.length,
+  };
+}
+
+export default function AnnouncementComposer({ draft, setDraft, maxLength = 800 }: Props) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [mode, setMode] = useState<'write' | 'preview'>('write');
+  const isPreview = mode === 'preview';
+
+  function handleFormat(kind: WrapKind) {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart ?? draft.length;
+    const end = el.selectionEnd ?? draft.length;
+    const { next, nextStart, nextEnd } = applyFormat(draft, start, end, kind);
+    if (next.length > maxLength) return;
+    setDraft(next);
+    requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(nextStart, nextEnd);
+    });
+  }
+
+  const tabStyle = (active: boolean): React.CSSProperties => ({
+    padding: '8px 14px',
+    minHeight: 36,
+    fontSize: 12,
+    fontWeight: 600,
+    letterSpacing: '0.02em',
+    background: active ? 'var(--inner-card-green-bg, rgba(34,197,94,0.15))' : 'transparent',
+    color: active ? 'var(--accent, #22c55e)' : 'var(--text-muted)',
+    border: `1px solid ${active ? 'var(--accent, #22c55e)' : 'var(--inner-card-border, rgba(255,255,255,0.08))'}`,
+    borderRadius: 10,
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+  });
+
+  const formatBtnStyle: React.CSSProperties = {
+    minHeight: 44,
+    minWidth: 44,
+    padding: '0 10px',
+    borderRadius: 10,
+    border: '1px solid var(--inner-card-border, rgba(255,255,255,0.08))',
+    background: 'var(--inner-card-bg, rgba(255,255,255,0.03))',
+    color: 'var(--text-primary, #fff)',
+    cursor: 'pointer',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Write / Preview tabs */}
+      <div role="tablist" aria-label="Composer mode" style={{ display: 'flex', gap: 6 }}>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={!isPreview}
+          onClick={() => setMode('write')}
+          style={tabStyle(!isPreview)}
+        >
+          Write
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={isPreview}
+          onClick={() => setMode('preview')}
+          style={tabStyle(isPreview)}
+        >
+          Preview
+        </button>
+      </div>
+
+      {/* Formatting toolbar — only in Write mode */}
+      {!isPreview && (
+        <div
+          role="toolbar"
+          aria-label="Formatting"
+          style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}
+        >
+          <button type="button" onClick={() => handleFormat('bold')} aria-label="Bold (**text**)" title="Bold — wraps selection in **" style={{ ...formatBtnStyle, fontWeight: 700 }}>
+            B
+          </button>
+          <button type="button" onClick={() => handleFormat('italic')} aria-label="Italic (*text*)" title="Italic — wraps selection in *" style={{ ...formatBtnStyle, fontStyle: 'italic' }}>
+            I
+          </button>
+          <button type="button" onClick={() => handleFormat('ul')} aria-label="Bulleted list (- item)" title="Bulleted list — prefixes each line with -" style={formatBtnStyle}>
+            <span className="material-icons" style={{ fontSize: 20 }}>format_list_bulleted</span>
+          </button>
+          <button type="button" onClick={() => handleFormat('ol')} aria-label="Numbered list (1. item)" title="Numbered list — prefixes each line with 1. 2. …" style={formatBtnStyle}>
+            <span className="material-icons" style={{ fontSize: 20 }}>format_list_numbered</span>
+          </button>
+          <button type="button" onClick={() => handleFormat('br')} aria-label="Paragraph break (blank line)" title="Paragraph break — inserts a blank line" style={formatBtnStyle}>
+            <span className="material-icons" style={{ fontSize: 20 }}>subdirectory_arrow_left</span>
+          </button>
+        </div>
+      )}
+
+      {/* Editor / Preview pane */}
+      {isPreview ? (
+        <div
+          className="announcement-body text-sm text-gray-200 leading-relaxed glass-card p-4"
+          style={{ minHeight: '5rem' }}
+          aria-label="Announcement preview"
+        >
+          {draft.trim() ? renderMarkdown(draft) : <p className="text-gray-500">Nothing to preview yet.</p>}
+        </div>
+      ) : (
+        <textarea
+          ref={textareaRef}
+          id="admin-announcement-draft"
+          name="announcementDraft"
+          rows={6}
+          placeholder={PLACEHOLDER}
+          aria-label="Announcement text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          maxLength={maxLength}
+        />
+      )}
+      <p className="text-right text-xs text-gray-500">{draft.length}/{maxLength}</p>
+    </div>
+  );
+}

--- a/components/admin/AssignUsageSheet.tsx
+++ b/components/admin/AssignUsageSheet.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useEffect, useState, useCallback, useMemo } from 'react';
+import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
+import type { BirdPurchase, Session } from '@/lib/types';
+import { normalizeBirdUsages } from '@/lib/birdUsages';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  purchase: BirdPurchase | null;
+  /** Called after at least one successful PATCH so parent can refresh hero stats. */
+  onSaved: () => void;
+}
+
+interface Row {
+  sessionId: string;
+  datetime?: string;
+  title?: string;
+  tubes: number; // current value in form state
+  initial: number; // server-side value at load time
+}
+
+function fmtSessionDate(datetime?: string): string {
+  if (!datetime) return '—';
+  try {
+    return new Date(datetime).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return datetime;
+  }
+}
+
+export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: Props) {
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  const loadSessions = useCallback(async () => {
+    if (!purchase) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch(`${BASE}/api/sessions`, { cache: 'no-store' });
+      if (!res.ok) {
+        setError('Failed to load sessions');
+        return;
+      }
+      const list = (await res.json()) as Session[];
+      const top = list.slice(0, 10);
+      setRows(
+        top.map((s) => {
+          const match = normalizeBirdUsages(s).find((u) => u.purchaseId === purchase.id);
+          const tubes = match?.tubes ?? 0;
+          return {
+            sessionId: s.id,
+            datetime: s.datetime,
+            title: s.title,
+            tubes,
+            initial: tubes,
+          };
+        }),
+      );
+    } catch {
+      setError('Network error');
+    } finally {
+      setLoading(false);
+    }
+  }, [purchase]);
+
+  useEffect(() => {
+    if (open) loadSessions();
+  }, [open, loadSessions]);
+
+  const dirty = useMemo(() => rows.some((r) => r.tubes !== r.initial), [rows]);
+
+  function bump(sessionId: string, delta: number) {
+    setRows((prev) =>
+      prev.map((r) =>
+        r.sessionId === sessionId
+          ? { ...r, tubes: Math.max(0, Math.min(20, Math.round((r.tubes + delta) * 4) / 4)) }
+          : r,
+      ),
+    );
+  }
+
+  async function handleSave() {
+    if (!purchase) return;
+    const changed = rows.filter((r) => r.tubes !== r.initial);
+    if (changed.length === 0) {
+      onClose();
+      return;
+    }
+    setSaving(true);
+    setError('');
+    try {
+      for (const row of changed) {
+        const res = await fetch(`${BASE}/api/session/bird-usage`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId: row.sessionId,
+            purchaseId: purchase.id,
+            tubes: row.tubes,
+          }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          throw new Error(data.error ?? `Failed to update ${row.sessionId}`);
+        }
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} ariaLabel="Assign tubes to sessions">
+      <BottomSheetHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+              Assign to session
+            </h2>
+            {purchase && (
+              <p className="text-xs mt-1" style={{ color: 'var(--text-muted)' }}>
+                {purchase.name} · ${purchase.costPerTube.toFixed(2)}/tube
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            style={{
+              minHeight: 44,
+              minWidth: 44,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'transparent',
+              border: 'none',
+              color: 'var(--text-muted)',
+            }}
+          >
+            <span className="material-icons">close</span>
+          </button>
+        </div>
+      </BottomSheetHeader>
+
+      <BottomSheetBody>
+        {loading && <p className="text-sm text-gray-400 p-3">Loading sessions…</p>}
+
+        {!loading && rows.length === 0 && (
+          <p className="text-sm text-gray-400 p-3">No sessions yet.</p>
+        )}
+
+        {!loading && rows.length > 0 && (
+          <div className="space-y-2">
+            {rows.map((r) => (
+              <div key={r.sessionId} className="inner-card p-3 flex items-center justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                    {r.title ?? 'Session'}
+                  </p>
+                  <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                    {fmtSessionDate(r.datetime)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => bump(r.sessionId, -0.5)}
+                    aria-label="Decrease tubes"
+                    disabled={r.tubes <= 0}
+                    style={{
+                      minWidth: 44,
+                      minHeight: 44,
+                      borderRadius: 10,
+                      border: '1px solid var(--inner-card-border)',
+                      background: 'var(--inner-card-bg)',
+                      color: 'var(--text-primary)',
+                      fontSize: 18,
+                      opacity: r.tubes <= 0 ? 0.4 : 1,
+                    }}
+                  >
+                    −
+                  </button>
+                  <span
+                    className="tabular-nums"
+                    style={{
+                      minWidth: 48,
+                      textAlign: 'center',
+                      fontFamily: 'var(--font-mono)',
+                      fontWeight: 600,
+                      color: r.tubes > 0 ? 'var(--accent)' : 'var(--text-muted)',
+                    }}
+                  >
+                    {r.tubes}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => bump(r.sessionId, 0.5)}
+                    aria-label="Increase tubes"
+                    style={{
+                      minWidth: 44,
+                      minHeight: 44,
+                      borderRadius: 10,
+                      border: '1px solid var(--inner-card-border)',
+                      background: 'var(--inner-card-bg)',
+                      color: 'var(--text-primary)',
+                      fontSize: 18,
+                    }}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {error && <p className="text-red-400 text-xs mt-2" role="alert">{error}</p>}
+
+        <div className="flex gap-2 mt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="flex-1"
+            style={{
+              minHeight: 44,
+              borderRadius: 10,
+              background: 'var(--inner-card-bg)',
+              border: '1px solid var(--inner-card-border)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || !dirty}
+            className="btn-primary flex-1"
+            style={{ minHeight: 44 }}
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </BottomSheetBody>
+    </BottomSheet>
+  );
+}

--- a/components/admin/BirdInventoryView.tsx
+++ b/components/admin/BirdInventoryView.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import type { BirdPurchase } from '@/lib/types';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import type { BirdPurchase, Session } from '@/lib/types';
 import { ShimmerLoader } from '../ShuttleLoader';
 import AdminBackHeader from './AdminBackHeader';
+import AssignUsageSheet from './AssignUsageSheet';
+import { parseBirdName } from '@/lib/birdBrand';
+import { avgTubesPerSession, runwayWeeks, tubesUsedAcross } from '@/lib/birdUsages';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -16,9 +19,43 @@ function Label({ text, children }: { text: string; children: React.ReactNode }) 
   );
 }
 
+interface BrandGroup {
+  brand: string;
+  tubesBought: number;
+  tubesUsed: number;
+  remaining: number;
+  totalSpend: number;
+  count: number;
+}
+
+function groupByBrand(purchases: BirdPurchase[], usedByPurchase: Map<string, number>): BrandGroup[] {
+  const groups = new Map<string, BrandGroup>();
+  for (const p of purchases) {
+    const { brand } = parseBirdName(p.name);
+    const key = brand || '—';
+    const existing = groups.get(key) ?? {
+      brand: key,
+      tubesBought: 0,
+      tubesUsed: 0,
+      remaining: 0,
+      totalSpend: 0,
+      count: 0,
+    };
+    const used = usedByPurchase.get(p.id) ?? 0;
+    existing.tubesBought += p.tubes;
+    existing.tubesUsed += used;
+    existing.remaining += Math.max(0, p.tubes - used);
+    existing.totalSpend += p.totalCost;
+    existing.count += 1;
+    groups.set(key, existing);
+  }
+  return Array.from(groups.values()).sort((a, b) => b.remaining - a.remaining);
+}
+
 export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
   const [purchases, setPurchases] = useState<BirdPurchase[]>([]);
   const [currentStock, setCurrentStock] = useState(0);
+  const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [shuttleName, setShuttleName] = useState('');
   const [tubes, setTubes] = useState(0);
@@ -34,15 +71,23 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
   const [editForm, setEditForm] = useState<Partial<BirdPurchase>>({});
   const [editError, setEditError] = useState('');
   const [savingEdit, setSavingEdit] = useState(false);
+  const [assignPurchase, setAssignPurchase] = useState<BirdPurchase | null>(null);
+  const [expandedBrand, setExpandedBrand] = useState<string | null>(null);
 
-  const loadPurchases = useCallback(async () => {
+  const loadAll = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`${BASE}/api/birds`, { cache: 'no-store' });
-      if (res.ok) {
-        const data = await res.json();
+      const [birdsRes, sessionsRes] = await Promise.all([
+        fetch(`${BASE}/api/birds`, { cache: 'no-store' }),
+        fetch(`${BASE}/api/sessions`, { cache: 'no-store' }),
+      ]);
+      if (birdsRes.ok) {
+        const data = await birdsRes.json();
         setPurchases(data.purchases ?? []);
         setCurrentStock(data.currentStock ?? 0);
+      }
+      if (sessionsRes.ok) {
+        setSessions((await sessionsRes.json()) as Session[]);
       }
     } catch {
       /* ignore */
@@ -51,7 +96,33 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
     }
   }, []);
 
-  useEffect(() => { loadPurchases(); }, [loadPurchases]);
+  useEffect(() => { loadAll(); }, [loadAll]);
+
+  // Derived: tubes used per purchase across all sessions.
+  const usedByPurchase = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const s of sessions) {
+      const usages = Array.isArray(s.birdUsages) ? s.birdUsages : [];
+      for (const u of usages) {
+        map.set(u.purchaseId, (map.get(u.purchaseId) ?? 0) + (u.tubes ?? 0));
+      }
+    }
+    return map;
+  }, [sessions]);
+
+  const avgPerSession = useMemo(() => avgTubesPerSession(sessions, 8), [sessions]);
+  const totalUsed = useMemo(() => tubesUsedAcross(sessions), [sessions]);
+  const runway = useMemo(() => runwayWeeks(currentStock, avgPerSession), [currentStock, avgPerSession]);
+  const brandGroups = useMemo(() => groupByBrand(purchases, usedByPurchase), [purchases, usedByPurchase]);
+
+  const runwayColor =
+    currentStock <= 0 ? '#ef4444' :
+    runway < 2 ? '#fbbf24' :
+    'var(--accent)';
+  const runwayLabel =
+    currentStock <= 0 ? 'out of stock' :
+    runway === Infinity ? 'unlimited (no usage logged)' :
+    `~${runway} week${runway === 1 ? '' : 's'} at current pace`;
 
   async function handleAddPurchase(e: React.FormEvent) {
     e.preventDefault();
@@ -76,7 +147,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
         setSpeed('');
         setGroupRating(0);
         setBirdNotes('');
-        loadPurchases();
+        loadAll();
       } else {
         const data = await res.json().catch(() => ({}));
         setAddError(data.error ?? 'Failed to add purchase.');
@@ -96,7 +167,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ id }),
       });
-      loadPurchases();
+      loadAll();
     } catch {
       /* ignore */
     } finally {
@@ -126,7 +197,6 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
       if (editForm.tubes !== undefined) payload.tubes = editForm.tubes;
       if (editForm.totalCost !== undefined) payload.totalCost = editForm.totalCost;
       if (editForm.date !== undefined) payload.date = editForm.date;
-      // Send null to clear optional fields the user removed (API uses 'in body' check)
       payload.speed = editForm.speed ?? null;
       payload.qualityRating = editForm.qualityRating ?? null;
       payload.notes = editForm.notes ?? null;
@@ -138,7 +208,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
       });
       if (res.ok) {
         cancelEdit();
-        loadPurchases();
+        loadAll();
       } else {
         const data = await res.json().catch(() => ({}));
         setEditError(data.error ?? 'Failed to save.');
@@ -154,20 +224,125 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
     <div className="animate-slideInRight space-y-4">
       <AdminBackHeader onBack={onBack} title="Bird Inventory" />
 
-      {/* Stock indicator */}
+      {/* Hero card — stock, avg per session, runway */}
       {!loading && (
-        <div className="glass-card p-4">
-          <div className="inner-card p-3 flex items-center gap-3">
+        <div className="glass-card p-5 space-y-3">
+          <div className="flex items-baseline gap-2">
+            <span
+              className="tabular-nums"
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: 42,
+                fontWeight: 700,
+                lineHeight: 1,
+                color: runwayColor,
+              }}
+            >
+              {currentStock}
+            </span>
+            <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+              tube{currentStock === 1 ? '' : 's'} remaining
+            </span>
+          </div>
+          <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
             <span
               className="material-icons"
-              style={{ fontSize: 20, color: currentStock >= 2 ? 'var(--accent)' : '#fbbf24' }}
+              aria-hidden="true"
+              style={{ fontSize: 16, color: runwayColor }}
             >
-              inventory_2
+              trending_up
             </span>
-            <p className="text-sm font-medium" style={{ color: currentStock >= 2 ? 'var(--accent)' : '#fbbf24' }}>
-              {currentStock} tube{currentStock !== 1 ? 's' : ''} remaining
-            </p>
+            <span style={{ color: runwayColor }}>{runwayLabel}</span>
           </div>
+          <div className="grid grid-cols-3 gap-2 pt-2" style={{ borderTop: '1px solid var(--inner-card-border)' }}>
+            <div>
+              <p className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>Avg/session</p>
+              <p className="text-base font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+                {avgPerSession || '—'}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>Total used</p>
+              <p className="text-base font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+                {totalUsed}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>Brands</p>
+              <p className="text-base font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+                {brandGroups.length}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Per-brand breakdown */}
+      {!loading && brandGroups.length > 0 && (
+        <div className="glass-card p-5 space-y-2">
+          <p className="section-label">BY BRAND</p>
+          {brandGroups.map((g) => {
+            const expanded = expandedBrand === g.brand;
+            const purchasesOfBrand = purchases.filter((p) => parseBirdName(p.name).brand === (g.brand === '—' ? '' : g.brand));
+            return (
+              <div key={g.brand} className="inner-card p-3">
+                <button
+                  type="button"
+                  onClick={() => setExpandedBrand(expanded ? null : g.brand)}
+                  aria-expanded={expanded}
+                  style={{
+                    width: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    background: 'transparent',
+                    border: 'none',
+                    color: 'var(--text-primary)',
+                    padding: 0,
+                    cursor: 'pointer',
+                    minHeight: 44,
+                  }}
+                >
+                  <div style={{ textAlign: 'left' }}>
+                    <p className="text-sm font-semibold">{g.brand}</p>
+                    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                      <span className="tabular-nums" style={{ fontFamily: 'var(--font-mono)' }}>
+                        {g.remaining}
+                      </span>
+                      {' of '}
+                      <span className="tabular-nums" style={{ fontFamily: 'var(--font-mono)' }}>
+                        {g.tubesBought}
+                      </span>
+                      {' tubes · $'}
+                      <span className="tabular-nums" style={{ fontFamily: 'var(--font-mono)' }}>
+                        {g.totalSpend.toFixed(2)}
+                      </span>
+                      {' total'}
+                    </p>
+                  </div>
+                  <span className="material-icons" aria-hidden="true" style={{ fontSize: 20, color: 'var(--text-muted)' }}>
+                    {expanded ? 'expand_less' : 'expand_more'}
+                  </span>
+                </button>
+                {expanded && (
+                  <div className="mt-2 pt-2 space-y-1" style={{ borderTop: '1px solid var(--inner-card-border)' }}>
+                    {purchasesOfBrand.map((p) => {
+                      const used = usedByPurchase.get(p.id) ?? 0;
+                      const remaining = Math.max(0, p.tubes - used);
+                      return (
+                        <div key={p.id} className="text-xs flex justify-between" style={{ color: 'var(--text-muted)' }}>
+                          <span>{parseBirdName(p.name).model || p.name}</span>
+                          <span className="tabular-nums" style={{ fontFamily: 'var(--font-mono)' }}>
+                            {remaining}/{p.tubes}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 
@@ -179,161 +354,174 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
       ) : purchases.length > 0 ? (
         <div className="glass-card p-5 space-y-3">
           <p className="section-label">PURCHASE HISTORY</p>
-          {purchases.map((p) => (
-            <div key={p.id} className="inner-card p-3">
-              {editingId === p.id ? (
-                <div className="space-y-3">
-                  <Label text="Shuttle">
-                    <input
-                      id="bird-edit-name"
-                      name="birdName"
-                      type="text"
-                      value={editForm.name ?? ''}
-                      onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                      maxLength={100}
-                      autoComplete="off"
-                    />
-                  </Label>
-                  <div className="grid grid-cols-3 gap-3">
-                    <Label text="Tubes">
+          {purchases.map((p) => {
+            const used = usedByPurchase.get(p.id) ?? 0;
+            return (
+              <div key={p.id} className="inner-card p-3">
+                {editingId === p.id ? (
+                  <div className="space-y-3">
+                    <Label text="Shuttle">
                       <input
-                        id="bird-edit-tubes"
-                        name="tubes"
-                        type="number"
-                        min={1}
-                        value={editForm.tubes || ''}
-                        onChange={(e) => setEditForm({ ...editForm, tubes: parseInt(e.target.value) || 0 })}
+                        id="bird-edit-name"
+                        name="birdName"
+                        type="text"
+                        value={editForm.name ?? ''}
+                        onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
+                        maxLength={100}
+                        autoComplete="off"
                       />
                     </Label>
-                    <Label text="Total ($)">
-                      <input
-                        id="bird-edit-total-cost"
-                        name="totalCost"
-                        type="number"
-                        min={0}
-                        step={0.01}
-                        value={editForm.totalCost || ''}
-                        onChange={(e) => setEditForm({ ...editForm, totalCost: parseFloat(e.target.value) || 0 })}
+                    <div className="grid grid-cols-3 gap-3">
+                      <Label text="Tubes">
+                        <input
+                          id="bird-edit-tubes"
+                          name="tubes"
+                          type="number"
+                          min={1}
+                          value={editForm.tubes || ''}
+                          onChange={(e) => setEditForm({ ...editForm, tubes: parseInt(e.target.value) || 0 })}
+                        />
+                      </Label>
+                      <Label text="Total ($)">
+                        <input
+                          id="bird-edit-total-cost"
+                          name="totalCost"
+                          type="number"
+                          min={0}
+                          step={0.01}
+                          value={editForm.totalCost || ''}
+                          onChange={(e) => setEditForm({ ...editForm, totalCost: parseFloat(e.target.value) || 0 })}
+                        />
+                      </Label>
+                      <Label text="Speed">
+                        <input
+                          id="bird-edit-speed"
+                          name="speed"
+                          type="number"
+                          min={1}
+                          value={editForm.speed ?? ''}
+                          onChange={(e) => setEditForm({ ...editForm, speed: e.target.value ? parseInt(e.target.value) : undefined })}
+                        />
+                      </Label>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <Label text="Date">
+                        <input
+                          id="bird-edit-date"
+                          name="date"
+                          type="date"
+                          value={editForm.date ?? ''}
+                          onChange={(e) => setEditForm({ ...editForm, date: e.target.value })}
+                        />
+                      </Label>
+                      <Label text="Quality Rating">
+                        <div className="flex gap-1 items-center pt-1">
+                          {[1, 2, 3, 4, 5].map(n => (
+                            <button
+                              key={n}
+                              type="button"
+                              onClick={() => setEditForm({ ...editForm, qualityRating: (editForm.qualityRating === n ? undefined : n) })}
+                              className="flex items-center justify-center transition-all"
+                              style={{
+                                width: 36, height: 36, borderRadius: 8,
+                                background: n <= (editForm.qualityRating ?? 0) ? 'var(--inner-card-green-bg)' : 'var(--inner-card-bg)',
+                                border: `1px solid ${n <= (editForm.qualityRating ?? 0) ? 'var(--inner-card-green-border)' : 'var(--inner-card-border)'}`,
+                                color: n <= (editForm.qualityRating ?? 0) ? 'var(--accent)' : 'var(--text-muted)',
+                                fontSize: 13, fontWeight: 600,
+                              }}
+                            >
+                              {n}
+                            </button>
+                          ))}
+                        </div>
+                      </Label>
+                    </div>
+                    <Label text="Notes">
+                      <textarea
+                        id="bird-edit-notes"
+                        name="notes"
+                        value={editForm.notes ?? ''}
+                        onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
+                        maxLength={500}
+                        rows={2}
+                        style={{ resize: 'none' }}
                       />
                     </Label>
-                    <Label text="Speed">
-                      <input
-                        id="bird-edit-speed"
-                        name="speed"
-                        type="number"
-                        min={1}
-                        value={editForm.speed ?? ''}
-                        onChange={(e) => setEditForm({ ...editForm, speed: e.target.value ? parseInt(e.target.value) : undefined })}
-                      />
-                    </Label>
+                    {editError && <p className="text-red-400 text-xs" role="alert">{editError}</p>}
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleSaveEdit}
+                        disabled={savingEdit || !editForm.name?.trim() || !editForm.tubes || editForm.tubes <= 0 || !editForm.totalCost || editForm.totalCost <= 0}
+                        className="btn-primary flex-1"
+                        style={{ minHeight: 44 }}
+                      >
+                        {savingEdit ? 'Saving...' : 'Save'}
+                      </button>
+                      <button
+                        onClick={cancelEdit}
+                        disabled={savingEdit}
+                        className="flex-1"
+                        style={{ minHeight: 44, borderRadius: 10, background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)', color: 'var(--text-secondary)', fontWeight: 500 }}
+                      >
+                        Cancel
+                      </button>
+                    </div>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
-                    <Label text="Date">
-                      <input
-                        id="bird-edit-date"
-                        name="date"
-                        type="date"
-                        value={editForm.date ?? ''}
-                        onChange={(e) => setEditForm({ ...editForm, date: e.target.value })}
-                      />
-                    </Label>
-                    <Label text="Quality Rating">
-                      <div className="flex gap-1 items-center pt-1">
-                        {[1, 2, 3, 4, 5].map(n => (
-                          <button
-                            key={n}
-                            type="button"
-                            onClick={() => setEditForm({ ...editForm, qualityRating: (editForm.qualityRating === n ? undefined : n) })}
-                            className="flex items-center justify-center transition-all"
-                            style={{
-                              width: 36, height: 36, borderRadius: 8,
-                              background: n <= (editForm.qualityRating ?? 0) ? 'var(--inner-card-green-bg)' : 'var(--inner-card-bg)',
-                              border: `1px solid ${n <= (editForm.qualityRating ?? 0) ? 'var(--inner-card-green-border)' : 'var(--inner-card-border)'}`,
-                              color: n <= (editForm.qualityRating ?? 0) ? 'var(--accent)' : 'var(--text-muted)',
-                              fontSize: 13, fontWeight: 600,
-                            }}
-                          >
-                            {n}
-                          </button>
-                        ))}
-                      </div>
-                    </Label>
+                ) : (
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{p.name}</p>
+                      <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                        {new Date(p.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                        {' · '}
+                        {p.tubes} tube{p.tubes !== 1 ? 's' : ''} bought
+                        {used > 0 && ` · ${used} used`}
+                        {p.costPerTube > 0 && ` · $${p.costPerTube.toFixed(2)}/tube`}
+                        {p.speed && ` · Spd ${p.speed}`}
+                        {p.qualityRating && ` · ${p.qualityRating}/5`}
+                      </p>
+                      {p.notes && (
+                        <p className="text-xs mt-0.5 italic" style={{ color: 'var(--text-muted)' }}>{p.notes}</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      {p.totalCost > 0 && (
+                        <span className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>${p.totalCost.toFixed(2)}</span>
+                      )}
+                      <button
+                        onClick={() => setAssignPurchase(p)}
+                        className="hover:opacity-70 transition-opacity"
+                        aria-label={`Assign ${p.name} to a session`}
+                        title="Assign to session"
+                        style={{ color: 'var(--accent)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                      >
+                        <span className="material-icons" style={{ fontSize: 18 }}>add</span>
+                      </button>
+                      <button
+                        onClick={() => startEdit(p)}
+                        className="hover:opacity-70 transition-opacity"
+                        aria-label={`Edit purchase of ${p.name}`}
+                        style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                      >
+                        <span className="material-icons" style={{ fontSize: 16 }}>edit</span>
+                      </button>
+                      <button
+                        onClick={() => handleDelete(p.id)}
+                        disabled={deletingId === p.id}
+                        className="hover:text-red-400 transition-colors"
+                        aria-label={`Delete purchase of ${p.name}`}
+                        style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                      >
+                        <span className="material-icons" style={{ fontSize: 16 }}>
+                          {deletingId === p.id ? 'hourglass_empty' : 'delete'}
+                        </span>
+                      </button>
+                    </div>
                   </div>
-                  <Label text="Notes">
-                    <textarea
-                      id="bird-edit-notes"
-                      name="notes"
-                      value={editForm.notes ?? ''}
-                      onChange={(e) => setEditForm({ ...editForm, notes: e.target.value })}
-                      maxLength={500}
-                      rows={2}
-                      style={{ resize: 'none' }}
-                    />
-                  </Label>
-                  {editError && <p className="text-red-400 text-xs" role="alert">{editError}</p>}
-                  <div className="flex gap-2">
-                    <button
-                      onClick={handleSaveEdit}
-                      disabled={savingEdit || !editForm.name?.trim() || !editForm.tubes || editForm.tubes <= 0 || !editForm.totalCost || editForm.totalCost <= 0}
-                      className="btn-primary flex-1"
-                      style={{ minHeight: 44 }}
-                    >
-                      {savingEdit ? 'Saving...' : 'Save'}
-                    </button>
-                    <button
-                      onClick={cancelEdit}
-                      disabled={savingEdit}
-                      className="flex-1"
-                      style={{ minHeight: 44, borderRadius: 10, background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)', color: 'var(--text-secondary)', fontWeight: 500 }}
-                    >
-                      Cancel
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{p.name}</p>
-                    <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                      {new Date(p.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
-                      {' · '}
-                      {p.tubes} tube{p.tubes !== 1 ? 's' : ''}
-                      {p.costPerTube > 0 && ` · $${p.costPerTube.toFixed(2)}/tube`}
-                      {p.speed && ` · Spd ${p.speed}`}
-                      {p.qualityRating && ` · ${p.qualityRating}/5`}
-                    </p>
-                    {p.notes && (
-                      <p className="text-xs mt-0.5 italic" style={{ color: 'var(--text-muted)' }}>{p.notes}</p>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1 shrink-0">
-                    {p.totalCost > 0 && (
-                      <span className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>${p.totalCost.toFixed(2)}</span>
-                    )}
-                    <button
-                      onClick={() => startEdit(p)}
-                      className="hover:opacity-70 transition-opacity"
-                      aria-label={`Edit purchase of ${p.name}`}
-                      style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                    >
-                      <span className="material-icons" style={{ fontSize: 16 }}>edit</span>
-                    </button>
-                    <button
-                      onClick={() => handleDelete(p.id)}
-                      disabled={deletingId === p.id}
-                      className="hover:text-red-400 transition-colors"
-                      aria-label={`Delete purchase of ${p.name}`}
-                      style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                    >
-                      <span className="material-icons" style={{ fontSize: 16 }}>
-                        {deletingId === p.id ? 'hourglass_empty' : 'delete'}
-                      </span>
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          ))}
+                )}
+              </div>
+            );
+          })}
         </div>
       ) : (
         <div className="glass-card p-5">
@@ -449,6 +637,13 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
           </button>
         </div>
       </form>
+
+      <AssignUsageSheet
+        open={assignPurchase !== null}
+        onClose={() => setAssignPurchase(null)}
+        purchase={assignPurchase}
+        onSaved={loadAll}
+      />
     </div>
   );
 }

--- a/components/admin/ReleaseForm.tsx
+++ b/components/admin/ReleaseForm.tsx
@@ -13,7 +13,8 @@ function nextPatchVersion(current: string | undefined): string {
 }
 
 interface ReleaseFormProps {
-  latestVersion: string | undefined;
+  latestVersion?: string;
+  initialRecord?: Release;
   onPublished: (release: Release) => void;
   onCancel: () => void;
 }
@@ -26,9 +27,10 @@ interface ChangelogUnreleased {
   text: string;
 }
 
-export default function ReleaseForm({ latestVersion, onPublished, onCancel }: ReleaseFormProps) {
+export default function ReleaseForm({ latestVersion, initialRecord, onPublished, onCancel }: ReleaseFormProps) {
   const t = useTranslations('admin.releases');
-  const [version, setVersion] = useState(() => nextPatchVersion(latestVersion));
+  const isEdit = !!initialRecord;
+  const [version, setVersion] = useState(() => initialRecord?.version ?? nextPatchVersion(latestVersion));
   const [rawNotes, setRawNotes] = useState('');
   // Tracks when the Unreleased section was baked at build time, so the admin
   // can see at a glance whether the pre-filled bullets are current.
@@ -36,6 +38,7 @@ export default function ReleaseForm({ latestVersion, onPublished, onCancel }: Re
 
   // Pull the CHANGELOG Unreleased section baked by scripts/extract-unreleased.mjs
   // and pre-fill the form. Admin can edit before running the AI draft.
+  // Skipped in edit mode — editing existing copy shouldn't be overwritten by the changelog.
   const loadFromChangelog = useCallback(async () => {
     try {
       const res = await fetch(`${BASE}/changelog-unreleased.json`, { cache: 'no-store' });
@@ -50,12 +53,12 @@ export default function ReleaseForm({ latestVersion, onPublished, onCancel }: Re
   }, []);
 
   useEffect(() => {
-    loadFromChangelog();
-  }, [loadFromChangelog]);
-  const [titleEn, setTitleEn] = useState('');
-  const [titleZh, setTitleZh] = useState('');
-  const [bodyEn, setBodyEn] = useState('');
-  const [bodyZh, setBodyZh] = useState('');
+    if (!isEdit) loadFromChangelog();
+  }, [loadFromChangelog, isEdit]);
+  const [titleEn, setTitleEn] = useState(initialRecord?.title.en ?? '');
+  const [titleZh, setTitleZh] = useState(initialRecord?.title['zh-CN'] ?? '');
+  const [bodyEn, setBodyEn] = useState(initialRecord?.body.en ?? '');
+  const [bodyZh, setBodyZh] = useState(initialRecord?.body['zh-CN'] ?? '');
   const [drafting, setDrafting] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState('');
@@ -107,7 +110,7 @@ ${rawNotes}`;
     }
   }
 
-  async function publish() {
+  async function save() {
     if (!version.trim() || !titleEn.trim() || !titleZh.trim() || !bodyEn.trim() || !bodyZh.trim()) {
       setError('All fields required before publish.');
       return;
@@ -115,18 +118,20 @@ ${rawNotes}`;
     setPublishing(true);
     setError('');
     try {
+      const payload = {
+        version: version.trim(),
+        title: { en: titleEn.trim(), 'zh-CN': titleZh.trim() },
+        body: { en: bodyEn.trim(), 'zh-CN': bodyZh.trim() },
+        ...(isEdit && initialRecord ? { id: initialRecord.id } : {}),
+      };
       const res = await fetch(`${BASE}/api/releases`, {
-        method: 'POST',
+        method: isEdit ? 'PATCH' : 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          version: version.trim(),
-          title: { en: titleEn.trim(), 'zh-CN': titleZh.trim() },
-          body: { en: bodyEn.trim(), 'zh-CN': bodyZh.trim() },
-        }),
+        body: JSON.stringify(payload),
       });
       const data = await res.json();
       if (!res.ok) {
-        setError(data.error ?? 'Publish failed');
+        setError(data.error ?? (isEdit ? 'Save failed' : 'Publish failed'));
         return;
       }
       onPublished(data);
@@ -155,43 +160,47 @@ ${rawNotes}`;
         />
       </div>
 
-      <div>
-        <div className="flex items-center justify-between mb-1">
-          <label htmlFor="release-raw-notes" className="block text-xs text-gray-400">Raw notes</label>
-          <button
-            type="button"
-            onClick={loadFromChangelog}
-            className="text-[11px]"
-            style={{ color: 'var(--accent)', background: 'transparent', border: 'none', padding: '2px 6px', cursor: 'pointer' }}
-            aria-label="Refresh from CHANGELOG.md Unreleased section"
-            title="Re-pull the Unreleased bullets from CHANGELOG.md"
-          >
-            ↻ from CHANGELOG
-          </button>
+      {!isEdit && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <label htmlFor="release-raw-notes" className="block text-xs text-gray-400">Raw notes</label>
+            <button
+              type="button"
+              onClick={loadFromChangelog}
+              className="text-[11px]"
+              style={{ color: 'var(--accent)', background: 'transparent', border: 'none', padding: '2px 6px', cursor: 'pointer' }}
+              aria-label="Refresh from CHANGELOG.md Unreleased section"
+              title="Re-pull the Unreleased bullets from CHANGELOG.md"
+            >
+              ↻ from CHANGELOG
+            </button>
+          </div>
+          <textarea
+            id="release-raw-notes"
+            name="rawNotes"
+            value={rawNotes}
+            onChange={(e) => setRawNotes(e.target.value)}
+            className="input w-full min-h-[120px]"
+            placeholder="Paste commit messages, rough notes, bullet points..."
+          />
+          {changelogFreshness && (
+            <p className="text-[10px] mt-1" style={{ color: 'var(--text-muted)' }}>
+              Pre-filled from CHANGELOG.md Unreleased (baked {changelogFreshness}). Edit freely — AI will polish on next step.
+            </p>
+          )}
         </div>
-        <textarea
-          id="release-raw-notes"
-          name="rawNotes"
-          value={rawNotes}
-          onChange={(e) => setRawNotes(e.target.value)}
-          className="input w-full min-h-[120px]"
-          placeholder="Paste commit messages, rough notes, bullet points..."
-        />
-        {changelogFreshness && (
-          <p className="text-[10px] mt-1" style={{ color: 'var(--text-muted)' }}>
-            Pre-filled from CHANGELOG.md Unreleased (baked {changelogFreshness}). Edit freely — AI will polish on next step.
-          </p>
-        )}
-      </div>
+      )}
 
-      <button
-        type="button"
-        onClick={draftWithAI}
-        disabled={drafting}
-        className="btn-secondary w-full"
-      >
-        {drafting ? 'Drafting…' : t('draftWithAI')}
-      </button>
+      {!isEdit && (
+        <button
+          type="button"
+          onClick={draftWithAI}
+          disabled={drafting}
+          className="btn-secondary w-full"
+        >
+          {drafting ? 'Drafting…' : t('draftWithAI')}
+        </button>
+      )}
 
       <div className="grid grid-cols-2 gap-3">
         <div>
@@ -218,8 +227,8 @@ ${rawNotes}`;
 
       <div className="flex gap-2">
         <button type="button" onClick={onCancel} className="btn-ghost flex-1">Cancel</button>
-        <button type="button" onClick={publish} disabled={publishing} className="btn-primary flex-1">
-          {publishing ? 'Publishing…' : t('publish')}
+        <button type="button" onClick={save} disabled={publishing} className="btn-primary flex-1">
+          {publishing ? (isEdit ? 'Saving…' : 'Publishing…') : (isEdit ? 'Save changes' : t('publish'))}
         </button>
       </div>
     </div>

--- a/components/admin/ReleasesView.tsx
+++ b/components/admin/ReleasesView.tsx
@@ -12,11 +12,13 @@ interface Props {
   onBack: () => void;
 }
 
+type FormMode = { kind: 'hidden' } | { kind: 'new' } | { kind: 'edit'; record: Release };
+
 export default function ReleasesView({ onBack }: Props) {
   const t = useTranslations('admin.releases');
   const [releases, setReleases] = useState<Release[]>([]);
   const [loading, setLoading] = useState(true);
-  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<FormMode>({ kind: 'hidden' });
   const [error, setError] = useState('');
 
   async function load() {
@@ -50,17 +52,18 @@ export default function ReleasesView({ onBack }: Props) {
     <div className="space-y-4">
       <AdminBackHeader onBack={onBack} title="Releases" />
 
-      {showForm ? (
+      {form.kind !== 'hidden' ? (
         <ReleaseForm
           latestVersion={releases[0]?.version}
-          onPublished={() => { setShowForm(false); load(); }}
-          onCancel={() => setShowForm(false)}
+          initialRecord={form.kind === 'edit' ? form.record : undefined}
+          onPublished={() => { setForm({ kind: 'hidden' }); load(); }}
+          onCancel={() => setForm({ kind: 'hidden' })}
         />
       ) : (
         <>
           <button
             type="button"
-            onClick={() => setShowForm(true)}
+            onClick={() => setForm({ kind: 'new' })}
             className="btn-primary w-full"
           >
             {t('newButton')}
@@ -77,16 +80,33 @@ export default function ReleasesView({ onBack }: Props) {
                 <li key={r.id} className="glass-card p-3 flex justify-between items-start">
                   <div>
                     <p className="text-sm font-semibold text-white">{r.version} · {r.title.en}</p>
-                    <p className="text-xs text-gray-400">{new Date(r.publishedAt).toLocaleDateString()}</p>
+                    <p className="text-xs text-gray-400">
+                      {new Date(r.publishedAt).toLocaleDateString()}
+                      {r.editedAt && <> · edited {new Date(r.editedAt).toLocaleDateString()}</>}
+                    </p>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(r.id)}
-                    className="text-red-400 text-xs"
-                    aria-label={`Delete ${r.version}`}
-                  >
-                    Delete
-                  </button>
+                  <div className="flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => setForm({ kind: 'edit', record: r })}
+                      className="text-gray-300 hover:text-white"
+                      style={{ minWidth: 44, minHeight: 44, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+                      aria-label={`Edit ${r.version}`}
+                      title="Edit"
+                    >
+                      <span className="material-icons" style={{ fontSize: 18 }}>edit</span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(r.id)}
+                      className="text-red-400 hover:text-red-300"
+                      style={{ minWidth: 44, minHeight: 44, display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
+                      aria-label={`Delete ${r.version}`}
+                      title="Delete"
+                    >
+                      <span className="material-icons" style={{ fontSize: 18 }}>delete</span>
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/components/stats/StatsPlaceholder.tsx
+++ b/components/stats/StatsPlaceholder.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+interface CompactCardProps {
+  icon: string;
+  title: string;
+  subtitle: string;
+  comingSoon: string;
+}
+
+function CompactComingSoonCard({ icon, title, subtitle, comingSoon }: CompactCardProps) {
+  return (
+    <div
+      className="glass-card"
+      style={{
+        padding: 14,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        minHeight: 112,
+        opacity: 0.85,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <span
+          className="material-icons"
+          aria-hidden="true"
+          style={{ fontSize: 20, color: 'var(--accent, #22c55e)' }}
+        >
+          {icon}
+        </span>
+        <span
+          style={{
+            fontSize: 9,
+            padding: '2px 7px',
+            borderRadius: 100,
+            whiteSpace: 'nowrap',
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+            border: '1px solid var(--inner-card-border)',
+            color: 'var(--text-muted)',
+          }}
+        >
+          {comingSoon}
+        </span>
+      </div>
+      <h3 style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', margin: 0, lineHeight: 1.25 }}>
+        {title}
+      </h3>
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: 0, lineHeight: 1.35 }}>{subtitle}</p>
+    </div>
+  );
+}
+
+interface LiveCardProps {
+  icon: string;
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}
+
+function LiveCard({ icon, title, subtitle, children }: LiveCardProps) {
+  return (
+    <div className="glass-card p-5 space-y-3">
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span
+            className="material-icons"
+            aria-hidden="true"
+            style={{ fontSize: 22, color: 'var(--accent, #22c55e)' }}
+          >
+            {icon}
+          </span>
+          <div>
+            <h3 style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-primary)', margin: 0, lineHeight: 1.2 }}>
+              {title}
+            </h3>
+            <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0, marginTop: 2 }}>{subtitle}</p>
+          </div>
+        </div>
+        <span
+          style={{
+            fontSize: 10,
+            padding: '3px 8px',
+            borderRadius: 100,
+            whiteSpace: 'nowrap',
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+            textTransform: 'uppercase',
+            border: '1px solid var(--accent, #22c55e)',
+            color: 'var(--accent, #22c55e)',
+          }}
+        >
+          Live
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+interface Props {
+  /** Optional live content to render inside the Skill Progression card.
+   *  When provided, the card renders full-width at the bottom of the page.
+   *  Admins get this (SkillsRadar + inline Add Player). */
+  skillProgressionContent?: React.ReactNode;
+  /** Optional live content for the Attendance card — gated behind
+   *  NEXT_PUBLIC_FLAG_STATS_ATTENDANCE. Renders prominent up top. */
+  attendanceContent?: React.ReactNode;
+  /** Optional hero slot — rendered between the page heading and the
+   *  primary live section. Used for the attendance streak hero. */
+  heroSlot?: React.ReactNode;
+}
+
+export default function StatsPlaceholder({
+  skillProgressionContent,
+  attendanceContent,
+  heroSlot,
+}: Props = {}) {
+  const t = useTranslations('stats');
+  const comingSoon = t('comingSoon');
+  const attendanceLive = !!attendanceContent;
+  const skillLive = !!skillProgressionContent;
+
+  return (
+    <div className="space-y-5 w-full animate-fadeIn">
+      <div className="px-2">
+        <h1 className="text-3xl font-bold text-gray-200 leading-tight">{t('heading')}</h1>
+        <p className="text-sm text-gray-400 mt-1">{t('subhead')}</p>
+      </div>
+
+      {heroSlot}
+
+      {/* ── Primary: live content ──────────────────────────────────── */}
+      {attendanceLive && (
+        <LiveCard
+          icon="calendar_today"
+          title={t('attendance.title')}
+          subtitle={t('attendance.subtitle')}
+        >
+          {attendanceContent}
+        </LiveCard>
+      )}
+
+      {/* ── Secondary: everything not yet live, compact 2-col grid ─── */}
+      <div className="px-2" style={{ paddingTop: 4 }}>
+        <p
+          className="section-label"
+          style={{
+            fontSize: 10,
+            letterSpacing: '0.08em',
+            color: 'var(--text-muted)',
+            textTransform: 'uppercase',
+            margin: 0,
+          }}
+        >
+          More coming
+        </p>
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+          gap: 12,
+        }}
+      >
+        {!attendanceLive && (
+          <CompactComingSoonCard
+            icon="calendar_today"
+            title={t('attendance.title')}
+            subtitle={t('attendance.subtitle')}
+            comingSoon={comingSoon}
+          />
+        )}
+        <CompactComingSoonCard
+          icon="payments"
+          title={t('cost.title')}
+          subtitle={t('cost.subtitle')}
+          comingSoon={comingSoon}
+        />
+        <CompactComingSoonCard
+          icon="groups"
+          title={t('partners.title')}
+          subtitle={t('partners.subtitle')}
+          comingSoon={comingSoon}
+        />
+        {!skillLive && (
+          <CompactComingSoonCard
+            icon="trending_up"
+            title={t('progression.title')}
+            subtitle={t('progression.subtitle')}
+            comingSoon={comingSoon}
+          />
+        )}
+      </div>
+
+      {/* ── Live skill progression (admin only, needs its own width) ── */}
+      {skillLive && (
+        <LiveCard
+          icon="trending_up"
+          title={t('progression.title')}
+          subtitle={t('progression.subtitle')}
+        >
+          {skillProgressionContent}
+        </LiveCard>
+      )}
+    </div>
+  );
+}

--- a/components/stats/StatsStreakHero.tsx
+++ b/components/stats/StatsStreakHero.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getIdentity } from '@/lib/identity';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const STATS_NAME_KEY = 'badminton_stats_preview_name';
+const ACCENT = 'var(--accent, #22c55e)';
+const MUTED = 'var(--text-muted)';
+const PRIMARY = 'var(--text-primary)';
+
+interface HeroData {
+  name: string;
+  streak: number;
+  longestStreak: number;
+}
+
+function resolveActiveName(): string | null {
+  const id = getIdentity();
+  if (id?.name) return id.name;
+  try {
+    const stored = localStorage.getItem(STATS_NAME_KEY);
+    if (stored && stored.trim()) return stored.trim();
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+/**
+ * Attendance streak hero. Renders only when an active name is known AND the
+ * current streak is at least 1. Kept intentionally light — the full heatmap
+ * and breakdown live in the Attendance card below.
+ */
+export default function StatsStreakHero() {
+  const [data, setData] = useState<HeroData | null>(null);
+
+  useEffect(() => {
+    const name = resolveActiveName();
+    if (!name) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `${BASE}/api/stats/attendance?name=${encodeURIComponent(name)}&weeks=52`,
+          { cache: 'no-store' },
+        );
+        if (!res.ok) return;
+        const payload = await res.json();
+        if (cancelled) return;
+        setData({
+          name: payload.name,
+          streak: payload.streak ?? 0,
+          longestStreak: payload.longestStreak ?? 0,
+        });
+      } catch {
+        /* silent — hero just won't appear */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!data || data.streak < 1) return null;
+
+  const { streak, longestStreak, name } = data;
+  const onPersonalBest = streak >= longestStreak && streak >= 3;
+
+  return (
+    <div
+      className="glass-card"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        padding: 16,
+        borderLeft: `3px solid ${ACCENT}`,
+      }}
+      aria-label={`${streak} week attendance streak for ${name}`}
+    >
+      <div
+        style={{
+          width: 56,
+          height: 56,
+          borderRadius: '50%',
+          background: onPersonalBest
+            ? 'linear-gradient(135deg, #f59e0b, #ef4444)'
+            : 'color-mix(in oklab, var(--accent, #22c55e) 24%, transparent)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-mono)',
+            fontSize: 22,
+            fontWeight: 700,
+            color: onPersonalBest ? '#fff' : ACCENT,
+            lineHeight: 1,
+          }}
+        >
+          {streak}
+        </span>
+      </div>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: PRIMARY, lineHeight: 1.25 }}>
+          {streak === 1 ? '1 week streak' : `${streak} weeks in a row`}
+        </p>
+        <p style={{ margin: 0, fontSize: 12, color: MUTED, marginTop: 2 }}>
+          {onPersonalBest
+            ? `Personal best — tied or beating your longest run of ${longestStreak}.`
+            : `Longest run: ${longestStreak} week${longestStreak === 1 ? '' : 's'}. Keep showing up.`}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/stats/cards/AttendanceCardLive.tsx
+++ b/components/stats/cards/AttendanceCardLive.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import { useEffect, useState, useMemo } from 'react';
+import { getIdentity } from '@/lib/identity';
+import AttendanceHeatmap from './AttendanceHeatmap';
+
+type Zoom = { label: string; weeks: number };
+const ZOOMS: Zoom[] = [
+  { label: '3M', weeks: 13 },
+  { label: '6M', weeks: 26 },
+  { label: '1Y', weeks: 52 },
+];
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const STATS_NAME_KEY = 'badminton_stats_preview_name';
+const ACCENT = 'var(--accent, #22c55e)';
+const MUTED = 'var(--text-muted)';
+const PRIMARY = 'var(--text-primary)';
+
+interface AttendanceResponse {
+  name: string;
+  weeks: number;
+  attended: number;
+  streak: number;
+  longestStreak: number;
+  history: Array<{ sessionId: string; datetime: string | null; attended: boolean }>;
+}
+
+function resolveActiveName(): string | null {
+  const id = getIdentity();
+  if (id?.name) return id.name;
+  try {
+    const stored = localStorage.getItem(STATS_NAME_KEY);
+    if (stored && stored.trim()) return stored.trim();
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export default function AttendanceCardLive() {
+  const [activeName, setActiveName] = useState<string | null>(null);
+  const [resolved, setResolved] = useState(false);
+  const [zoomIdx, setZoomIdx] = useState(0); // default 3M
+  const [data, setData] = useState<AttendanceResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [members, setMembers] = useState<string[]>([]);
+  const [pickerValue, setPickerValue] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const weeks = ZOOMS[zoomIdx].weeks;
+
+  // Resolve active name once from localStorage.
+  useEffect(() => {
+    setActiveName(resolveActiveName());
+    setResolved(true);
+  }, []);
+
+  // Load member names for autocomplete (public endpoint, no auth needed).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${BASE}/api/members`, { cache: 'no-store' });
+        if (!res.ok) return;
+        const payload = await res.json();
+        const list = Array.isArray(payload?.members) ? payload.members : payload;
+        if (cancelled) return;
+        const names = (list as Array<{ name?: string }>)
+          .map((m) => m?.name)
+          .filter((n): n is string => typeof n === 'string' && n.length > 0);
+        setMembers(names);
+      } catch {
+        /* autocomplete is optional */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Fetch attendance whenever the active name changes.
+  useEffect(() => {
+    if (!activeName) return;
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await fetch(
+          `${BASE}/api/stats/attendance?name=${encodeURIComponent(activeName)}&weeks=${weeks}`,
+          { cache: 'no-store' },
+        );
+        if (!res.ok) {
+          if (!cancelled) setData(null);
+          return;
+        }
+        const payload = (await res.json()) as AttendanceResponse;
+        if (!cancelled) setData(payload);
+      } catch {
+        if (!cancelled) setData(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeName, weeks]);
+
+  const suggestions = useMemo(() => {
+    const q = pickerValue.trim().toLowerCase();
+    if (!q) return members.slice(0, 6);
+    return members.filter((n) => n.toLowerCase().includes(q)).slice(0, 6);
+  }, [members, pickerValue]);
+
+  function confirmName(name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      localStorage.setItem(STATS_NAME_KEY, trimmed);
+    } catch {
+      /* ignore */
+    }
+    setActiveName(trimmed);
+    setPickerValue('');
+    setShowSuggestions(false);
+  }
+
+  function clearPickedName() {
+    try {
+      localStorage.removeItem(STATS_NAME_KEY);
+    } catch {
+      /* ignore */
+    }
+    setActiveName(null);
+    setData(null);
+  }
+
+  if (!resolved) {
+    return <LoadingStrip weeks={weeks} />;
+  }
+
+  // No active name — show picker.
+  if (!activeName) {
+    return (
+      <div style={{ display: 'grid', gap: 8, position: 'relative' }}>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center', flexWrap: 'wrap' }}>
+          <label htmlFor="stats-name-picker" style={{ fontSize: 12, color: MUTED }}>
+            View attendance for:
+          </label>
+          <div style={{ position: 'relative', flex: 1, minWidth: 140 }}>
+            <input
+              id="stats-name-picker"
+              name="statsName"
+              type="text"
+              autoComplete="off"
+              placeholder="Type a player name…"
+              value={pickerValue}
+              onChange={(e) => { setPickerValue(e.target.value); setShowSuggestions(true); }}
+              onFocus={() => setShowSuggestions(true)}
+              onBlur={() => setTimeout(() => setShowSuggestions(false), 120)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); confirmName(pickerValue); }
+              }}
+              style={{ width: '100%', minHeight: 40, padding: '0 10px' }}
+            />
+            {showSuggestions && suggestions.length > 0 && (
+              <ul
+                role="listbox"
+                style={{
+                  listStyle: 'none',
+                  margin: 0,
+                  padding: 4,
+                  position: 'absolute',
+                  top: 'calc(100% + 4px)',
+                  left: 0,
+                  right: 0,
+                  maxHeight: 180,
+                  overflowY: 'auto',
+                  background: 'var(--bg-elevated, #1a1a1a)',
+                  border: '1px solid var(--inner-card-border)',
+                  borderRadius: 10,
+                  zIndex: 5,
+                }}
+              >
+                {suggestions.map((s) => (
+                  <li key={s}>
+                    <button
+                      type="button"
+                      onMouseDown={() => confirmName(s)}
+                      style={{
+                        width: '100%',
+                        textAlign: 'left',
+                        padding: '8px 10px',
+                        minHeight: 40,
+                        background: 'transparent',
+                        border: 'none',
+                        color: PRIMARY,
+                        fontSize: 13,
+                        cursor: 'pointer',
+                        borderRadius: 6,
+                      }}
+                    >
+                      {s}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => confirmName(pickerValue)}
+            disabled={!pickerValue.trim()}
+            className="btn-primary"
+            style={{ minHeight: 40, padding: '0 14px' }}
+          >
+            View
+          </button>
+        </div>
+        <p style={{ margin: 0, fontSize: 11, color: MUTED }}>
+          Or sign up for a session — your name is saved automatically after that.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading && !data) return <LoadingStrip weeks={weeks} />;
+  if (!data) {
+    return (
+      <p style={{ margin: 0, fontSize: 12, color: MUTED }} role="alert">
+        Couldn’t load attendance.
+      </p>
+    );
+  }
+
+  const { attended, streak, longestStreak, weeks: w } = data;
+  const isPreviewPick = getIdentity()?.name?.toLowerCase() !== activeName.toLowerCase();
+
+  return (
+    <div style={{ display: 'grid', gap: 8 }}>
+      <div style={{ display: 'flex', gap: 14, alignItems: 'baseline', flexWrap: 'wrap' }}>
+        <p style={{ margin: 0, fontFamily: 'var(--font-mono)', fontSize: 26, fontWeight: 700, color: PRIMARY }}>
+          {attended}
+          <span style={{ fontSize: 13, fontWeight: 500, color: MUTED, marginLeft: 6 }}>of {w} weeks</span>
+        </p>
+        {isPreviewPick && (
+          <span style={{ fontSize: 11, color: MUTED }}>
+            viewing as <strong style={{ color: PRIMARY }}>{activeName}</strong>{' '}
+            <button
+              type="button"
+              onClick={clearPickedName}
+              style={{ background: 'transparent', border: 'none', color: ACCENT, cursor: 'pointer', padding: 0, fontSize: 11 }}
+            >
+              change
+            </button>
+          </span>
+        )}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 4 }} role="tablist" aria-label="Time window">
+        {ZOOMS.map((z, i) => {
+          const active = i === zoomIdx;
+          return (
+            <button
+              key={z.label}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setZoomIdx(i)}
+              style={{
+                minHeight: 28,
+                padding: '2px 10px',
+                borderRadius: 100,
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: '0.04em',
+                border: `1px solid ${active ? ACCENT : 'var(--inner-card-border)'}`,
+                background: active ? 'color-mix(in oklab, var(--accent, #22c55e) 15%, transparent)' : 'transparent',
+                color: active ? ACCENT : MUTED,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              {z.label}
+            </button>
+          );
+        })}
+      </div>
+      <AttendanceHeatmap history={data.history} weeks={w} />
+      {buildSubText(attended, w, streak, longestStreak) && (
+        <p style={{ margin: 0, fontSize: 11, color: MUTED }}>{buildSubText(attended, w, streak, longestStreak)}</p>
+      )}
+    </div>
+  );
+}
+
+function LoadingStrip({ weeks }: { weeks: number }) {
+  const totalDays = weeks * 7;
+  return (
+    <div style={{ display: 'grid', gap: 8, opacity: 0.4 }}>
+      <div style={{ height: 26, background: 'var(--inner-card-bg)', borderRadius: 4, width: '40%' }} />
+      <div style={{ display: 'grid', gridTemplateColumns: `repeat(${weeks}, 1fr)`, gap: 2 }}>
+        {Array.from({ length: totalDays }).map((_, i) => (
+          <div key={i} style={{ aspectRatio: '1 / 1', background: 'var(--inner-card-bg)', borderRadius: 2 }} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function buildSubText(attended: number, weeks: number, streak: number, longest: number): string {
+  if (attended === 0) return 'No sessions played yet in this window.';
+  if (streak === weeks) return 'Perfect attendance — every session.';
+  if (longest > streak && longest > 2) return `Longest run: ${longest} in a row.`;
+  if (streak >= 3) return `${streak} sessions in a row — keep it going.`;
+  return '';
+}

--- a/components/stats/cards/AttendanceHeatmap.tsx
+++ b/components/stats/cards/AttendanceHeatmap.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+/**
+ * GitHub-style attendance heatmap. 7 rows (day-of-week) × N columns (weeks).
+ * Cells are colored by state:
+ *   - empty   → no session that day
+ *   - missed  → session existed but player didn't attend (outlined)
+ *   - played  → session attended (solid accent)
+ *
+ * Width is 100% of container via viewBox; cell size scales with weeks.
+ * Month labels render above columns where the month changes.
+ */
+
+const ACCENT = 'var(--accent, #22c55e)';
+const MUTED = 'var(--text-muted)';
+
+const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+
+interface HistoryEntry {
+  sessionId: string;
+  datetime: string | null;
+  attended: boolean;
+}
+
+interface Props {
+  history: HistoryEntry[];
+  weeks: number; // 13 | 26 | 52
+}
+
+interface Cell {
+  date: Date;
+  state: 'empty' | 'missed' | 'played';
+  title: string;
+}
+
+function startOfDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function toKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth()).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+export default function AttendanceHeatmap({ history, weeks }: Props) {
+  // Build a lookup: day-key → attendance state.
+  const sessionDays = new Map<string, { attended: boolean }>();
+  for (const h of history) {
+    if (!h.datetime) continue;
+    const d = startOfDay(new Date(h.datetime));
+    sessionDays.set(toKey(d), { attended: h.attended });
+  }
+
+  // Compute the grid. Columns = weeks ending today. Each column is 7 days
+  // (Sun at row 0 through Sat at row 6). The rightmost column contains today
+  // and runs backward. We align to the current week end so the latest session
+  // sits in the last column.
+  const today = startOfDay(new Date());
+  // Pull the end of this week (Saturday) as the grid's last day.
+  const lastDay = new Date(today);
+  lastDay.setDate(lastDay.getDate() + (6 - lastDay.getDay()));
+
+  const totalDays = weeks * 7;
+  const firstDay = new Date(lastDay);
+  firstDay.setDate(firstDay.getDate() - (totalDays - 1));
+
+  const columns: Cell[][] = [];
+  const cursor = new Date(firstDay);
+  for (let w = 0; w < weeks; w++) {
+    const col: Cell[] = [];
+    for (let d = 0; d < 7; d++) {
+      const date = new Date(cursor);
+      const key = toKey(date);
+      const session = sessionDays.get(key);
+      const isPast = date <= today;
+      let state: Cell['state'] = 'empty';
+      let title = date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+      if (session && isPast) {
+        state = session.attended ? 'played' : 'missed';
+        title += session.attended ? ' — played' : ' — missed';
+      }
+      col.push({ date, state, title });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    columns.push(col);
+  }
+
+  // Sizing: scale cell size to weeks so the grid fills the width.
+  const gap = 2;
+  const leftLabelW = 22;
+  const topLabelH = 14;
+  // Target overall width ~320 (will scale via viewBox to container).
+  const targetW = 320;
+  const cell = Math.max(4, Math.floor((targetW - leftLabelW - (weeks - 1) * gap) / weeks));
+  const gridW = weeks * cell + (weeks - 1) * gap;
+  const gridH = 7 * cell + 6 * gap;
+  const svgW = leftLabelW + gridW;
+  const svgH = topLabelH + gridH;
+
+  // Month labels along the top.
+  const monthTicks: { x: number; label: string }[] = [];
+  let lastMonth = -1;
+  columns.forEach((col, i) => {
+    const m = col[0].date.getMonth();
+    if (m !== lastMonth) {
+      monthTicks.push({ x: leftLabelW + i * (cell + gap), label: MONTHS_SHORT[m] });
+      lastMonth = m;
+    }
+  });
+
+  return (
+    <svg
+      viewBox={`0 0 ${svgW} ${svgH}`}
+      width="100%"
+      role="img"
+      aria-label="Attendance heatmap"
+      style={{ display: 'block' }}
+    >
+      {/* Month labels */}
+      {monthTicks.map((t, i) => (
+        <text
+          key={i}
+          x={t.x}
+          y={10}
+          fontSize={9}
+          fill={MUTED}
+          style={{ fontFamily: 'var(--font-mono)' }}
+        >
+          {t.label}
+        </text>
+      ))}
+
+      {/* Day-of-week labels */}
+      {DAY_LABELS.map((label, row) =>
+        label ? (
+          <text
+            key={row}
+            x={0}
+            y={topLabelH + row * (cell + gap) + cell * 0.75}
+            fontSize={9}
+            fill={MUTED}
+            style={{ fontFamily: 'var(--font-mono)' }}
+          >
+            {label}
+          </text>
+        ) : null,
+      )}
+
+      {/* Grid */}
+      {columns.map((col, w) =>
+        col.map((c, d) => {
+          const x = leftLabelW + w * (cell + gap);
+          const y = topLabelH + d * (cell + gap);
+          let fill = 'var(--inner-card-bg)';
+          let stroke = 'var(--inner-card-border)';
+          let strokeWidth = 0.5;
+          let opacity = 0.9;
+          if (c.state === 'played') {
+            fill = ACCENT;
+            stroke = 'transparent';
+            strokeWidth = 0;
+            opacity = 1;
+          } else if (c.state === 'missed') {
+            fill = 'transparent';
+            stroke = ACCENT;
+            strokeWidth = 1;
+            opacity = 0.55;
+          }
+          return (
+            <rect
+              key={`${w}-${d}`}
+              x={x}
+              y={y}
+              width={cell}
+              height={cell}
+              rx={Math.max(1, Math.min(2, cell / 4))}
+              fill={fill}
+              stroke={stroke}
+              strokeWidth={strokeWidth}
+              opacity={opacity}
+            >
+              <title>{c.title}</title>
+            </rect>
+          );
+        }),
+      )}
+    </svg>
+  );
+}

--- a/components/stats/skeletons/AttendanceBars.tsx
+++ b/components/stats/skeletons/AttendanceBars.tsx
@@ -1,0 +1,19 @@
+export default function AttendanceBars() {
+  const heights = [30, 55, 42, 70, 38, 60, 48, 80];
+  return (
+    <svg viewBox="0 0 200 80" width="100%" role="img" aria-label="Attendance bar chart placeholder">
+      {heights.map((h, i) => (
+        <rect
+          key={i}
+          x={i * 24 + 6}
+          y={78 - h}
+          width={18}
+          height={h}
+          rx={3}
+          fill="var(--accent, #22c55e)"
+          fillOpacity={0.18 + (i / heights.length) * 0.4}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/components/stats/skeletons/CostSparkline.tsx
+++ b/components/stats/skeletons/CostSparkline.tsx
@@ -1,0 +1,29 @@
+export default function CostSparkline() {
+  const points = [12, 18, 14, 20, 24, 19, 26, 22];
+  const stride = 26;
+  const offsetX = 8;
+  const pathPoints = points.map((v, i) => `${offsetX + i * stride},${70 - v * 2}`).join(' ');
+  return (
+    <svg viewBox="0 0 220 80" width="100%" role="img" aria-label="Cost trend placeholder">
+      <polyline
+        points={pathPoints}
+        fill="none"
+        stroke="var(--accent, #22c55e)"
+        strokeWidth={2}
+        strokeOpacity={0.7}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {points.map((v, i) => (
+        <circle
+          key={i}
+          cx={offsetX + i * stride}
+          cy={70 - v * 2}
+          r={3}
+          fill="var(--accent, #22c55e)"
+          fillOpacity={0.85}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/components/stats/skeletons/PartnerChips.tsx
+++ b/components/stats/skeletons/PartnerChips.tsx
@@ -1,0 +1,41 @@
+const INITIALS = ['LM', 'KT', 'JZ', 'AR', 'DW'];
+
+export default function PartnerChips() {
+  return (
+    <div role="img" aria-label="Partner chips placeholder" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ display: 'flex' }}>
+        {INITIALS.map((txt, i) => (
+          <div
+            key={i}
+            style={{
+              width: 34,
+              height: 34,
+              borderRadius: '50%',
+              background: 'color-mix(in oklab, var(--accent, #22c55e) 30%, transparent)',
+              color: 'var(--text-primary, #fff)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 11,
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              border: '1.5px solid var(--bg-surface, #1a1a1a)',
+              marginLeft: i === 0 ? 0 : -10,
+            }}
+          >
+            {txt}
+          </div>
+        ))}
+      </div>
+      <div
+        style={{
+          marginLeft: 8,
+          height: 6,
+          flex: 1,
+          borderRadius: 100,
+          background: 'linear-gradient(90deg, color-mix(in oklab, var(--accent, #22c55e) 55%, transparent), transparent)',
+        }}
+      />
+    </div>
+  );
+}

--- a/components/stats/skeletons/RadarSkeleton.tsx
+++ b/components/stats/skeletons/RadarSkeleton.tsx
@@ -1,0 +1,24 @@
+export default function RadarSkeleton() {
+  return (
+    <svg viewBox="0 0 200 120" width="100%" role="img" aria-label="Radar chart placeholder">
+      {[0.3, 0.5, 0.75, 1].map((scale, i) => (
+        <polygon
+          key={i}
+          points={`100,${60 - 42 * scale} ${100 + 39 * scale},${60 - 18 * scale} ${100 + 28 * scale},${60 + 34 * scale} ${100 - 28 * scale},${60 + 34 * scale} ${100 - 39 * scale},${60 - 18 * scale}`}
+          fill="none"
+          stroke="var(--accent, #22c55e)"
+          strokeOpacity={0.22}
+          strokeWidth={1}
+        />
+      ))}
+      <polygon
+        points="100,26 133,45 122,88 78,88 67,45"
+        fill="var(--accent, #22c55e)"
+        fillOpacity={0.18}
+        stroke="var(--accent, #22c55e)"
+        strokeOpacity={0.55}
+        strokeWidth={1.5}
+      />
+    </svg>
+  );
+}

--- a/lib/birdBrand.ts
+++ b/lib/birdBrand.ts
@@ -1,0 +1,21 @@
+/**
+ * Splits a combined brand+model string (e.g. "Victor Master No.3") into
+ * `{ brand, model }` for display grouping. Heuristic: first whitespace-
+ * delimited token is the brand; the rest is the model. Single-word inputs
+ * become their own brand with an empty model. Empty input returns empty
+ * strings.
+ *
+ * This is display-only — `BirdPurchase.name` stays as a single string on
+ * the Cosmos side, so no migration is needed.
+ */
+export function parseBirdName(name: string): { brand: string; model: string } {
+  if (!name || typeof name !== 'string') return { brand: '', model: '' };
+  const trimmed = name.trim();
+  if (!trimmed) return { brand: '', model: '' };
+  const firstSpace = trimmed.search(/\s/);
+  if (firstSpace === -1) return { brand: trimmed, model: '' };
+  return {
+    brand: trimmed.slice(0, firstSpace),
+    model: trimmed.slice(firstSpace + 1).trim(),
+  };
+}

--- a/lib/birdUsages.ts
+++ b/lib/birdUsages.ts
@@ -28,3 +28,49 @@ export function totalBirdCost(usages: BirdUsage[]): number {
   const raw = usages.reduce((sum, u) => sum + (u.totalBirdCost ?? 0), 0);
   return Math.round(raw * 100) / 100;
 }
+
+/**
+ * Sums tubes used across the given sessions. Accepts either full sessions
+ * (reads via `normalizeBirdUsages`) or already-normalized usage arrays.
+ */
+export function tubesUsedAcross(sessions: Array<Pick<Session, 'birdUsage' | 'birdUsages'>>): number {
+  let sum = 0;
+  for (const s of sessions) {
+    for (const u of normalizeBirdUsages(s)) sum += u.tubes ?? 0;
+  }
+  return Math.round(sum * 10) / 10;
+}
+
+/**
+ * Average tubes used per session over the most recent `window` sessions
+ * that actually had bird usage recorded. Sessions with zero tubes are
+ * excluded from the denominator (they'd drag the average toward zero and
+ * make the runway overly optimistic).
+ */
+export function avgTubesPerSession(
+  sessions: Array<Pick<Session, 'birdUsage' | 'birdUsages'>>,
+  window = 8,
+): number {
+  const perSession = sessions
+    .map((s) => {
+      const tubes = normalizeBirdUsages(s).reduce((sum, u) => sum + (u.tubes ?? 0), 0);
+      return tubes;
+    })
+    .filter((t) => t > 0)
+    .slice(-window);
+  if (perSession.length === 0) return 0;
+  const sum = perSession.reduce((a, b) => a + b, 0);
+  return Math.round((sum / perSession.length) * 10) / 10;
+}
+
+/**
+ * Runway in weeks at the current usage pace. Assumes one session per week
+ * (matches the app's cadence — one session per weekly friend game). Returns
+ * Infinity when avg is zero and there's still stock (nothing to deplete);
+ * 0 when stock is zero.
+ */
+export function runwayWeeks(remainingTubes: number, avgPerSession: number): number {
+  if (remainingTubes <= 0) return 0;
+  if (avgPerSession <= 0) return Infinity;
+  return Math.round((remainingTubes / avgPerSession) * 10) / 10;
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -18,7 +18,8 @@
 export type FlagName =
   | 'NEXT_PUBLIC_FLAG_DEMO'
   | 'NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV'
-  | 'NEXT_PUBLIC_FLAG_DESIGN_PREVIEW';
+  | 'NEXT_PUBLIC_FLAG_DESIGN_PREVIEW'
+  | 'NEXT_PUBLIC_FLAG_STATS_ATTENDANCE';
 
 interface FlagMeta {
   description: string;
@@ -42,6 +43,11 @@ export const FLAGS: Record<FlagName, FlagMeta> = {
     owner: 'grant',
     plannedRemoval: 'after design system decisions (logo / fonts / background) finalize',
   },
+  NEXT_PUBLIC_FLAG_STATS_ATTENDANCE: {
+    description: 'Replaces the Stats tab "Attendance" skeleton card with a live 12-week attendance strip derived from /api/stats/attendance. First of the Arc 1 cards to go live — off on bpm-stable, on for bpm-next + dev.',
+    owner: 'grant',
+    plannedRemoval: 'two weeks after promotion — retire once all Arc 1 cards are live on stable',
+  },
 };
 
 function readFlag(name: FlagName): string | undefined {
@@ -52,6 +58,8 @@ function readFlag(name: FlagName): string | undefined {
       return process.env.NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV;
     case 'NEXT_PUBLIC_FLAG_DESIGN_PREVIEW':
       return process.env.NEXT_PUBLIC_FLAG_DESIGN_PREVIEW;
+    case 'NEXT_PUBLIC_FLAG_STATS_ATTENDANCE':
+      return process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE;
   }
 }
 

--- a/lib/miniMarkdown.tsx
+++ b/lib/miniMarkdown.tsx
@@ -1,0 +1,131 @@
+import type { ReactNode } from 'react';
+
+type InlineToken =
+  | { kind: 'text'; value: string }
+  | { kind: 'bold'; value: string }
+  | { kind: 'italic'; value: string };
+
+function tokenizeInline(line: string): InlineToken[] {
+  const out: InlineToken[] = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line.startsWith('**', i)) {
+      const close = line.indexOf('**', i + 2);
+      if (close > i + 2) {
+        out.push({ kind: 'bold', value: line.slice(i + 2, close) });
+        i = close + 2;
+        continue;
+      }
+    }
+    if (line[i] === '*' && line[i + 1] !== '*') {
+      const close = line.indexOf('*', i + 1);
+      if (close > i + 1) {
+        out.push({ kind: 'italic', value: line.slice(i + 1, close) });
+        i = close + 1;
+        continue;
+      }
+    }
+    const nextSpecial = findNextSpecial(line, i + 1);
+    out.push({ kind: 'text', value: line.slice(i, nextSpecial) });
+    i = nextSpecial;
+  }
+  return out;
+}
+
+function findNextSpecial(line: string, from: number): number {
+  for (let i = from; i < line.length; i++) {
+    if (line[i] === '*') return i;
+  }
+  return line.length;
+}
+
+function renderInline(line: string, keyPrefix: string): ReactNode[] {
+  return tokenizeInline(line).map((tok, i) => {
+    const key = `${keyPrefix}-${i}`;
+    if (tok.kind === 'bold') return <strong key={key}>{tok.value}</strong>;
+    if (tok.kind === 'italic') return <em key={key}>{tok.value}</em>;
+    return <span key={key}>{tok.value}</span>;
+  });
+}
+
+type Block =
+  | { kind: 'para'; lines: string[] }
+  | { kind: 'ul'; items: string[] }
+  | { kind: 'ol'; items: string[] };
+
+const UL_PATTERN = /^\s*[-*]\s+(.+)$/;
+const OL_PATTERN = /^\s*\d+\.\s+(.+)$/;
+
+function parseBlocks(text: string): Block[] {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  const blocks: Block[] = [];
+  let current: Block | null = null;
+
+  for (const raw of lines) {
+    const line = raw.trimEnd();
+    const ulMatch = line.match(UL_PATTERN);
+    const olMatch = line.match(OL_PATTERN);
+
+    if (ulMatch) {
+      if (current?.kind === 'ul') current.items.push(ulMatch[1]);
+      else {
+        if (current) blocks.push(current);
+        current = { kind: 'ul', items: [ulMatch[1]] };
+      }
+    } else if (olMatch) {
+      if (current?.kind === 'ol') current.items.push(olMatch[1]);
+      else {
+        if (current) blocks.push(current);
+        current = { kind: 'ol', items: [olMatch[1]] };
+      }
+    } else if (line === '') {
+      if (current) {
+        blocks.push(current);
+        current = null;
+      }
+    } else {
+      if (current?.kind === 'para') current.lines.push(line);
+      else {
+        if (current) blocks.push(current);
+        current = { kind: 'para', lines: [line] };
+      }
+    }
+  }
+  if (current) blocks.push(current);
+  return blocks;
+}
+
+export function renderMarkdown(text: string): ReactNode {
+  if (!text) return null;
+  const blocks = parseBlocks(text);
+  return blocks.map((block, bi) => {
+    if (block.kind === 'ul') {
+      return (
+        <ul key={`b-${bi}`}>
+          {block.items.map((item, i) => (
+            <li key={i}>{renderInline(item, `${bi}-${i}`)}</li>
+          ))}
+        </ul>
+      );
+    }
+    if (block.kind === 'ol') {
+      return (
+        <ol key={`b-${bi}`}>
+          {block.items.map((item, i) => (
+            <li key={i}>{renderInline(item, `${bi}-${i}`)}</li>
+          ))}
+        </ol>
+      );
+    }
+    return (
+      <p key={`b-${bi}`}>
+        {block.lines.map((line, li) => (
+          <span key={li}>
+            {li > 0 && <br />}
+            {renderInline(line, `${bi}-${li}`)}
+          </span>
+        ))}
+      </p>
+    );
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -104,4 +104,6 @@ export interface Release {
   };
   publishedAt: string;
   publishedBy: 'admin';
+  editedAt?: string;
+  env?: 'stable' | 'next' | 'dev';
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -79,8 +79,29 @@
   "nav": {
     "home": "Home",
     "signups": "Sign-Ups",
-    "skills": "Coming Soon",
+    "skills": "Stats",
     "admin": "Admin"
+  },
+  "stats": {
+    "heading": "Your stats",
+    "subhead": "Soon — a quick read on how you're playing, paying, and showing up.",
+    "comingSoon": "Coming soon",
+    "progression": {
+      "title": "Skill progression",
+      "subtitle": "Your ACE scores over time."
+    },
+    "attendance": {
+      "title": "Attendance",
+      "subtitle": "Sessions played this month."
+    },
+    "cost": {
+      "title": "Cost trend",
+      "subtitle": "$/person across recent sessions."
+    },
+    "partners": {
+      "title": "Partner frequency",
+      "subtitle": "Who you play with most."
+    }
   },
   "players": {
     "loading": "Loading players...",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -79,8 +79,29 @@
   "nav": {
     "home": "首页",
     "signups": "报名",
-    "skills": "即将推出",
+    "skills": "数据",
     "admin": "管理"
+  },
+  "stats": {
+    "heading": "你的数据",
+    "subhead": "即将上线 — 了解你的打球、付款和出勤情况。",
+    "comingSoon": "即将推出",
+    "progression": {
+      "title": "技能进展",
+      "subtitle": "你的 ACE 分数随时间变化。"
+    },
+    "attendance": {
+      "title": "出勤记录",
+      "subtitle": "本月参加的场次。"
+    },
+    "cost": {
+      "title": "费用趋势",
+      "subtitle": "近期每人每场的费用。"
+    },
+    "partners": {
+      "title": "搭档频率",
+      "subtitle": "你最常一起打球的人。"
+    }
   },
   "players": {
     "loading": "正在加载报名名单…",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Six streams landed together because they share surface area (admin dashboard, stats tab, bottom nav) and bundling avoids per-PR churn on `messages/*.json` and `app/layout.tsx` (Material Symbols URL). All on bpm-next only until individually promoted.

- **Announcement markdown** — Write/Preview tabs, bold/italic/lists formatting buttons. 500→800 char cap.
- **Release notes editable** — pencil icon per row, PATCH preserves publishedAt, AI polish stays opt-in.
- **Stats tab, live Attendance** — Skills→Stats rename, new i18n keys. GitHub-style heatmap with 3M/6M/1Y zoom. Streak hero above the cards. Remaining cards compact in 2-col grid at bottom. Gated behind `NEXT_PUBLIC_FLAG_STATS_ATTENDANCE`.
- **Bird inventory rebuild** — hero with runway weeks, per-brand grouping, `PATCH /api/session/bird-usage` endpoint, AssignUsageSheet for assigning tubes to archived sessions.
- **Bug link → GitHub Issues** — preview banner opens picker (Bug / Feature / Private email), new `.github/ISSUE_TEMPLATE/` folder. Depends on repo-public flip to actually work for filers.
- **/design/stats playground** — three narrative arcs (per-person, per-group, per-session) for visual decision-making on future stats cards.

**Tests:** 316 passing, up from 251. Build clean.

## Test plan

- [ ] Announcement: type `**bold**` / `*italic*` / `- list` / `1. numbered`, check Home renders formatted
- [ ] Release: Admin → Releases → pencil → edit title → save → row updates, editedAt shown
- [ ] Stats tab (flag on, signed up): heatmap renders, zoom pills switch 3M/6M/1Y, streak hero appears at top
- [ ] Stats tab (flag on, anonymous): "View attendance for:" picker with member autocomplete
- [ ] Stats tab (flag off): all 4 cards show "Coming soon" in 2-col grid, admin still sees SkillsRadar card at bottom
- [ ] Birds: hero shows remaining + runway, brand groups expand, + button on purchase row opens sheet, assign 1.5 tubes to a session → hero recalculates
- [ ] Preview banner: click "report a bug / idea" → picker with Bug / Feature / Private email
- [ ] `npm test` passes locally (316 tests)

## Deferred

- Repo-public flip (pre-req for Stream 7 to actually work E2E; security audit notes in `/Users/gz-mac/.claude/plans/we-have-a-new-vast-sutton.md`)
- Next live stats card (Cost trend is the natural follow-up — same rollup pattern as Attendance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)