### PR TITLE
fix(i18n): rewrite stats.cost.subtitle without the $ glyph

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -96,7 +96,7 @@
     },
     "cost": {
       "title": "Cost trend",
-      "subtitle": "$/person across recent sessions."
+      "subtitle": "Per-person price across recent sessions."
     },
     "partners": {
       "title": "Partner frequency",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -96,7 +96,7 @@
     },
     "cost": {
       "title": "费用趋势",
-      "subtitle": "近期每人每场的费用。"
+      "subtitle": "近期每人每场的费用分摊。"
     },
     "partners": {
       "title": "搭档频率",


### PR DESCRIPTION
next-intl was rendering the bare `$` in `stats.cost.subtitle` as `$$` on bpm-next. Swapped to "Per-person price across recent sessions." (EN) and a parallel zh-CN phrasing. Reads cleaner anyway.

Two lines, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)