### PR TITLE
fix(ci): wire NEXT_PUBLIC_FLAG_* env vars at build time

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -35,6 +35,10 @@ jobs:
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: next
           NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: 'true'
+          NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: 'true'
+          NEXT_PUBLIC_FLAG_STATS_ATTENDANCE: 'true'
+          NEXT_PUBLIC_FLAG_RECOVERY: 'true'
 
       - name: Package standalone build
         run: |

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -40,6 +40,10 @@ jobs:
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: stable
           NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
+          NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: 'false'
+          NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: 'false'
+          NEXT_PUBLIC_FLAG_STATS_ATTENDANCE: 'false'
+          NEXT_PUBLIC_FLAG_RECOVERY: 'false'
 
       - name: Package standalone build
         run: |


### PR DESCRIPTION
## Summary

- Add `NEXT_PUBLIC_FLAG_*` env vars to the `npm run build` step in both `deploy-next.yml` and `deploy-stable.yml`. Without these, every flag was inlined as `undefined` in the client bundle.
- bpm-next: all 4 flags set to `'true'` (preview surface).
- bpm-stable: all 4 flags set to `'false'` (friend-facing default — flip individually when promoting).

## Why

`NEXT_PUBLIC_*` env vars are baked into the client bundle by webpack during `next build` on the GitHub Actions runner. Setting flags in Azure App Service → Application Settings only affects the runtime container env, which webpack never sees. So **every flag in `lib/flags.ts` has been silently off on bpm-next since flags shipped** — including `NEXT_PUBLIC_FLAG_RECOVERY`, which is why the A2 Profile tab never appeared after the merge.

## Flag matrix

| Flag | bpm-next | bpm-stable |
|---|---|---|
| `STAGE0_NEW_NAV` | true | false |
| `DESIGN_PREVIEW` | true | false |
| `STATS_ATTENDANCE` | true | false |
| `RECOVERY` | true | false |

`NEXT_PUBLIC_FLAG_DEMO` excluded — `plannedRemoval: 2026-05-01` (3 days). Worth a separate cleanup PR.

## Test plan

- [ ] Merge → push triggers `deploy-next.yml`
- [ ] After deploy, visit bpm-next and confirm the **Profile** tab appears in the bottom nav (proves `RECOVERY` is on)
- [ ] Confirm `/bpm/design` is reachable (proves `DESIGN_PREVIEW` is on)
- [ ] Open Stats tab and confirm the live attendance heatmap renders (proves `STATS_ATTENDANCE` is on)
- [ ] bpm-stable unaffected until next manual `deploy-stable.yml` dispatch — and even then, all flags ship `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)