### PR TITLE
chore(flags): remove dead FLAG_DEMO + FLAG_STAGE0_NEW_NAV

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -35,7 +35,6 @@ jobs:
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: next
           NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
-          NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: 'true'
           NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: 'true'
           NEXT_PUBLIC_FLAG_STATS_ATTENDANCE: 'true'
           NEXT_PUBLIC_FLAG_RECOVERY: 'true'

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -40,7 +40,6 @@ jobs:
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: stable
           NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
-          NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: 'false'
           NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: 'false'
           NEXT_PUBLIC_FLAG_STATS_ATTENDANCE: 'false'
           NEXT_PUBLIC_FLAG_RECOVERY: 'false'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Canonical bundle mirrored at `docs/design-system/` (43 files — tokens, 28 spec
 
 The repo runs two Azure deployments from a single `main` branch: **`bpm-stable`** (friend-facing, updates only when a git tag is promoted) and **`bpm-next`** (auto-deploys every push to `main`). Stage-by-stage rollout is gated by feature flags so `main` can ship unfinished work to `next` without touching stable.
 
-- **Flag convention**: `NEXT_PUBLIC_FLAG_<STAGE>_<FEATURE>` (e.g., `NEXT_PUBLIC_FLAG_DESIGN_PREVIEW`, `NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV`). Must be registered in `lib/flags.ts` `FLAGS` registry — the typed `FlagName` union prevents typo'd lookups.
+- **Flag convention**: `NEXT_PUBLIC_FLAG_<STAGE>_<FEATURE>` (e.g., `NEXT_PUBLIC_FLAG_DESIGN_PREVIEW`, `NEXT_PUBLIC_FLAG_RECOVERY`). Must be registered in `lib/flags.ts` `FLAGS` registry — the typed `FlagName` union prevents typo'd lookups.
 - **Reading flags**: always `isFlagOn('NEXT_PUBLIC_FLAG_X')` from `lib/flags.ts`. Never `process.env.NEXT_PUBLIC_FLAG_X` directly — Next.js only inlines literal accesses, and the helper's switch statement guarantees each flag is inlined.
 - **Canonical value**: only the literal string `'true'` means on. `'1'`, `'yes'`, `'TRUE'` all read as off. Prevents accidental enablement from typo'd Azure App Settings.
 - **Server vs client**: for flags that gate API response shape or DB writes, read the flag on the server only. Client flags can't protect the database — a user with devtools can flip bundle flags but cannot flip server env vars.

--- a/README.md
+++ b/README.md
@@ -148,8 +148,7 @@ Players get a random `deleteToken` (16-byte hex) once at sign-up, stored in `loc
 | `NEXT_PUBLIC_ENV` | — | `stable` / `next` / `dev` — drives preview banner + flag defaults |
 | `NEXT_PUBLIC_FLAG_DESIGN_PREVIEW` | — | Set to `"true"` to expose `/bpm/design` |
 | `NEXT_PUBLIC_FLAG_STATS_ATTENDANCE` | — | Set to `"true"` to flip the Stats-tab Attendance card from skeleton to live heatmap |
-| `NEXT_PUBLIC_FLAG_DEMO` | — | End-to-end promotion test flag |
-| `NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV` | — | Stage 0a: new bottom nav labels |
+| `NEXT_PUBLIC_FLAG_RECOVERY` | — | Set to `"true"` to enable A2 identity recovery (opt-in PIN + admin-mediated 6-digit code) |
 
 All `NEXT_PUBLIC_*` vars are **baked at build time** — changes require a rebuild + redeploy.
 

--- a/__tests__/flags.test.ts
+++ b/__tests__/flags.test.ts
@@ -5,8 +5,9 @@ const originalEnv = { ...process.env };
 
 describe('feature flags', () => {
   beforeEach(() => {
-    delete process.env.NEXT_PUBLIC_FLAG_DEMO;
-    delete process.env.NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV;
+    delete process.env.NEXT_PUBLIC_FLAG_RECOVERY;
+    delete process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE;
+    delete process.env.NEXT_PUBLIC_FLAG_DESIGN_PREVIEW;
     delete process.env.NEXT_PUBLIC_ENV;
   });
 
@@ -15,41 +16,39 @@ describe('feature flags', () => {
   });
 
   it('returns false when flag is unset', () => {
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(false);
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(false);
   });
 
   it('returns false when flag is explicitly "false"', () => {
-    process.env.NEXT_PUBLIC_FLAG_DEMO = 'false';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'false';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(false);
   });
 
   it('returns true only when flag is exactly "true"', () => {
-    process.env.NEXT_PUBLIC_FLAG_DEMO = 'true';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(true);
+    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'true';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(true);
   });
 
   it('treats non-"true" truthy-looking values as off (prevents accidental enablement)', () => {
-    process.env.NEXT_PUBLIC_FLAG_DEMO = '1';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(false);
-    process.env.NEXT_PUBLIC_FLAG_DEMO = 'yes';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(false);
-    process.env.NEXT_PUBLIC_FLAG_DEMO = 'TRUE';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_RECOVERY = '1';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'yes';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'TRUE';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(false);
   });
 
   it('each flag is read independently', () => {
-    process.env.NEXT_PUBLIC_FLAG_DEMO = 'true';
-    process.env.NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV = 'false';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_DEMO')).toBe(true);
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'true';
+    process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE = 'false';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')).toBe(true);
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_STATS_ATTENDANCE')).toBe(false);
   });
 
-  it('recognizes NEXT_PUBLIC_FLAG_STATS_ATTENDANCE', () => {
-    delete process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE;
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_STATS_ATTENDANCE')).toBe(false);
-    process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE = 'true';
-    expect(isFlagOn('NEXT_PUBLIC_FLAG_STATS_ATTENDANCE')).toBe(true);
-    delete process.env.NEXT_PUBLIC_FLAG_STATS_ATTENDANCE;
+  it('recognizes NEXT_PUBLIC_FLAG_DESIGN_PREVIEW', () => {
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_DESIGN_PREVIEW')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_DESIGN_PREVIEW = 'true';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_DESIGN_PREVIEW')).toBe(true);
   });
 });
 

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -4,7 +4,7 @@
  * at build time, so changing a flag requires a redeploy (same as any
  * `NEXT_PUBLIC_*` var — see CLAUDE.md).
  *
- * Convention: `NEXT_PUBLIC_FLAG_<STAGE>_<FEATURE>` (e.g. `NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV`).
+ * Convention: `NEXT_PUBLIC_FLAG_<STAGE>_<FEATURE>` (e.g. `NEXT_PUBLIC_FLAG_RECOVERY`).
  *
  * Retirement rule: every flag entry below has a `plannedRemoval` date. Two
  * weeks after a stage promotes and is stable, delete the flag and its `off`
@@ -16,8 +16,6 @@
  */
 
 export type FlagName =
-  | 'NEXT_PUBLIC_FLAG_DEMO'
-  | 'NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV'
   | 'NEXT_PUBLIC_FLAG_DESIGN_PREVIEW'
   | 'NEXT_PUBLIC_FLAG_STATS_ATTENDANCE'
   | 'NEXT_PUBLIC_FLAG_RECOVERY';
@@ -29,16 +27,6 @@ interface FlagMeta {
 }
 
 export const FLAGS: Record<FlagName, FlagMeta> = {
-  NEXT_PUBLIC_FLAG_DEMO: {
-    description: 'End-to-end promotion test flag. Delete after first successful promotion.',
-    owner: 'grant',
-    plannedRemoval: '2026-05-01',
-  },
-  NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: {
-    description: 'Stage 0a: new bottom nav (Home · Games · Stats · You). Admin moves to overflow.',
-    owner: 'grant',
-    plannedRemoval: 'two weeks after Stage 0a promotes',
-  },
   NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: {
     description: 'Exposes the /design preview route with the formalized BPM design-system specimen cards, logo candidates, font pairings, and background variants. Off on bpm-stable; on for bpm-next + dev.',
     owner: 'grant',
@@ -58,10 +46,6 @@ export const FLAGS: Record<FlagName, FlagMeta> = {
 
 function readFlag(name: FlagName): string | undefined {
   switch (name) {
-    case 'NEXT_PUBLIC_FLAG_DEMO':
-      return process.env.NEXT_PUBLIC_FLAG_DEMO;
-    case 'NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV':
-      return process.env.NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV;
     case 'NEXT_PUBLIC_FLAG_DESIGN_PREVIEW':
       return process.env.NEXT_PUBLIC_FLAG_DESIGN_PREVIEW;
     case 'NEXT_PUBLIC_FLAG_STATS_ATTENDANCE':


### PR DESCRIPTION
## Summary

- **`NEXT_PUBLIC_FLAG_DEMO`** — registered, baked into neither workflow, **0 call sites**. `plannedRemoval: 2026-05-01` (4 days from this PR).
- **`NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV`** — registered, baked into both workflows (`true` on next, `false` on stable), **0 call sites**. The Stage 0a nav rollout it was meant to gate either became the default or was never implemented.

A flag with zero call sites but a baked workflow value is worse than no flag at all — it implies a missing branch and rots quietly. Audit caught both today; both retire cleanly.

## Why now

Both surfaced during the bpm-next ship audit after PR #32 merged. `lib/flags.ts` is the single source of truth for the typed `FlagName` union, so removing them tightens the contract and forces any future re-introduction to go through the `FLAGS` registry deliberately.

## Changes

| File | Change |
| --- | --- |
| `lib/flags.ts` | Drop both names from `FlagName` union, `FLAGS` registry, and `readFlag` switch. Update convention example in docstring. |
| `__tests__/flags.test.ts` | Rewrite to use `NEXT_PUBLIC_FLAG_RECOVERY` and `NEXT_PUBLIC_FLAG_STATS_ATTENDANCE` as the example flags (they're the active ones with real call sites). |
| `.github/workflows/deploy-next.yml` | Remove `NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: 'true'` |
| `.github/workflows/deploy-stable.yml` | Remove `NEXT_PUBLIC_FLAG_STAGE0_NEW_NAV: 'false'` |
| `README.md` | Replace dead flag rows in the env table with `NEXT_PUBLIC_FLAG_RECOVERY` |
| `CLAUDE.md` | Convention example uses `FLAG_RECOVERY` instead of `FLAG_STAGE0_NEW_NAV` |

## Test plan

- [x] `npm test` — **377/377** still passing (no count change; the rewritten flags.test.ts covers the same matrix using a real flag)
- [x] Final grep confirms zero remaining references to either name in active source/config (excluding historical plan docs under `docs/superpowers/`)
- [ ] Reviewer: confirm no hidden references in `.env.local` notes you keep locally that would now be ignored as typos

## Out of scope

- Historical plan doc at `docs/superpowers/plans/2026-04-27-a2-identity-recovery.md` references `FLAG_STAGE0_NEW_NAV` for context — left as-is. Plans are dated artifacts; rewriting them lies about history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)