### PR TITLE
fix(deploy): copy public/ into standalone bundle (404s on vnext)

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -41,7 +41,10 @@ jobs:
 
       - name: Package standalone build
         run: |
+          # Next.js standalone output excludes .next/static and public/ —
+          # both must be copied in manually before zipping.
           cp -r .next/static .next/standalone/.next/static
+          cp -r public .next/standalone/public
           cd .next/standalone
           zip -r ../../standalone-deploy.zip .
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -46,7 +46,10 @@ jobs:
 
       - name: Package standalone build
         run: |
+          # Next.js standalone output excludes .next/static and public/ —
+          # both must be copied in manually before zipping.
           cp -r .next/static .next/standalone/.next/static
+          cp -r public .next/standalone/public
           cd .next/standalone
           zip -r ../../standalone-deploy.zip .
 


### PR DESCRIPTION
## Summary

Every file under `public/` is 404ing on **bpm-next** and **bpm-stable** because the standalone-bundle packaging step copies `.next/static/` but not `public/`.

Confirmed live on bpm-next:
```
404  /bpm/brand                     (missing BPM logo + shuttlecock)
404  /bpm/changelog-unreleased.json (breaks admin ReleaseForm prefill)
```

## Why this happens

Next.js `output: 'standalone'` produces a self-contained server tree that **intentionally omits** both `.next/static/` and `public/` — the deployment pipeline is responsible for copying them in. ([Next.js docs](https://nextjs.org/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files))

Our workflow copies `.next/static/` but stops there:

```bash
# before
cp -r .next/static .next/standalone/.next/static
cd .next/standalone
zip -r ../../standalone-deploy.zip .
```

Adding a single line — `cp -r public .next/standalone/public` — fixes it.

## Scope of the bug

This pre-dates today's flag work. It has shipped on **every** standalone deploy. The user-visible impact:

- **Admin → Releases**: changelog prefill silently fails (`fetch('/bpm/changelog-unreleased.json')` 404s, no error surfaces in UI — the prefill just doesn't appear).
- **Brand assets**: `bpm-logo.svg`, `bpm-shuttlecock.png`, `shuttlecock.svg` all 404 if any component references them. Splash screen and aurora are inline so they work; anything that linked these would silently break.

## Test plan

- [x] Verified the bug live on bpm-next via `curl -I https://vnext-badminton-app.../bpm/changelog-unreleased.json` and `/bpm/brand` — both 404
- [x] Edits applied symmetrically to both workflows
- [ ] After merge: bpm-next auto-redeploys; verify `/bpm/changelog-unreleased.json` and `/bpm/brand/bpm-logo.svg` return 200
- [ ] When promoting to stable next: same verification on `bpm-stable`

## Files

| Path | Change |
| --- | --- |
| `.github/workflows/deploy-next.yml` | Add `cp -r public .next/standalone/public` to package step + explanatory comment |
| `.github/workflows/deploy-stable.yml` | Same |

🤖 Generated with [Claude Code](https://claude.com/claude-code)