### PR TITLE
fix(admin): release form — add explainer + repair Draft button

### DIFF
--- a/components/admin/ReleaseForm.tsx
+++ b/components/admin/ReleaseForm.tsx
@@ -148,6 +148,11 @@ ${rawNotes}`;
 
   return (
     <div className="space-y-4">
+      {!isEdit && (
+        <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+          {t('howItWorks')}
+        </p>
+      )}
       <div>
         <label htmlFor="release-version" className="block text-xs text-gray-400 mb-1">Version</label>
         <input
@@ -196,7 +201,7 @@ ${rawNotes}`;
           type="button"
           onClick={draftWithAI}
           disabled={drafting}
-          className="btn-secondary w-full"
+          className="btn-ghost w-full"
         >
           {drafting ? 'Drafting…' : t('draftWithAI')}
         </button>

--- a/messages/en.json
+++ b/messages/en.json
@@ -166,7 +166,8 @@
     "releases": {
       "newButton": "New release",
       "draftWithAI": "Draft with AI",
-      "publish": "Publish"
+      "publish": "Publish",
+      "howItWorks": "Paste raw notes (or refresh from CHANGELOG), draft bilingual copy with AI, edit if needed, then publish — appears on the Home tab for all players."
     },
     "resetAccess": {
       "title": "Recovery code for {name}",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -166,7 +166,8 @@
     "releases": {
       "newButton": "新发布",
       "draftWithAI": "用 AI 起草",
-      "publish": "发布"
+      "publish": "发布",
+      "howItWorks": "粘贴原始笔记（或从 CHANGELOG 刷新），用 AI 起草双语文案，按需编辑后发布——所有玩家可在首页看到。"
     },
     "resetAccess": {
       "title": "{name} 的恢复验证码",


### PR DESCRIPTION
## Summary

Two small fixes visible the moment you open the Releases admin form:

1. **Draft with AI button was unstyled.** The component used `className=\"btn-secondary\"`, but `.btn-secondary` isn't defined in `globals.css` — only `.btn-primary` and `.btn-ghost` exist. The button was rendering as bare centered text on a transparent background (visible in attached screenshot from today). Switched to `btn-ghost`, which is already in the design system and semantically correct for a secondary action.
2. **Added an explainer line** above the form so admins don't have to infer the CHANGELOG → AI draft → bilingual publish flow on first sight. Wired through `admin.releases.howItWorks` in both `en.json` and `zh-CN.json`.

## Why these and not more

The user flagged \"visual design needs to follow the design system\" with a screenshot. Triaging:

- ✅ The unstyled \"Draft with AI\" button is a **real** design-system violation — the class it references doesn't exist. One-line fix.
- ❌ Field labels (\"Version\", \"Raw notes\", \"Title (EN)\") at `text-xs text-gray-400` look low-contrast next to the H1, but they are *correct* for input field labels. `.section-label` / `.bpm-section-label` is reserved for section headings (uppercase 14px tracking-widest, applied to `<h2>` in design preview routes — never to `<label>`). Restyling them would make the form visually heavy and break the field-label convention.
- ❌ The inline-styled \"↻ from CHANGELOG\" link is a target for the parked **inline-style sweep workstream**, not a \"this is broken\" fix.

Keeping scope tight; the rest gets handled in the primitives PR.

## Test plan

- [x] `npm test` — 377/377 passing
- [ ] Reviewer: open admin → New release, confirm:
  - Explainer paragraph appears above Version field
  - \"Draft with AI\" button now renders with the glass-ghost styling (translucent surface, hover lift)
  - Form looks the same in zh-CN locale
- [ ] After merge: bpm-next auto-deploys; verify on https://vnext-badminton-app.../bpm
- [ ] After stable promotion: same check on bpm-stable

## Files

| Path | Change |
| --- | --- |
| `components/admin/ReleaseForm.tsx` | `btn-secondary` → `btn-ghost`; explainer paragraph above Version field |
| `messages/en.json` | New `admin.releases.howItWorks` |
| `messages/zh-CN.json` | New `admin.releases.howItWorks` (Chinese translation) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)