### PR TITLE
fix(recovery): distinguish 403 admin response from invalid PIN/code

### DIFF
--- a/components/EnterCodeSheet.tsx
+++ b/components/EnterCodeSheet.tsx
@@ -17,7 +17,7 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
   const t = useTranslations('recovery');
   const [name, setName] = useState('');
   const [code, setCode] = useState('');
-  const [error, setError] = useState<'invalid' | 'rate_limited' | null>(null);
+  const [error, setError] = useState<'invalid' | 'rate_limited' | 'admin_logged_in' | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -31,6 +31,10 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
         body: JSON.stringify({ name: name.trim(), sessionId, code }),
       });
       if (res.status === 429) { setError('rate_limited'); return; }
+      // Admin cookie set: /api/players/recover refuses (admins must use
+      // /reset-access instead). Surface this distinctly so the user knows
+      // they're not just typing the wrong code.
+      if (res.status === 403) { setError('admin_logged_in'); return; }
       if (!res.ok) { setError('invalid'); return; }
       const body = await res.json();
       setIdentity({ name: name.trim(), token: body.deleteToken, sessionId });
@@ -104,6 +108,11 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
             {error === 'rate_limited' && (
               <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
                 {t('errorRateLimited')}
+              </p>
+            )}
+            {error === 'admin_logged_in' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+                {t('errorAdminLoggedIn')}
               </p>
             )}
           </div>

--- a/components/RecoverySheet.tsx
+++ b/components/RecoverySheet.tsx
@@ -22,7 +22,7 @@ export default function RecoverySheet({ open, onClose, sessionId, onForgotPin }:
   const t = useTranslations('recovery');
   const [name, setName] = useState('');
   const [pin, setPin] = useState('');
-  const [error, setError] = useState<'invalid' | 'rate_limited' | null>(null);
+  const [error, setError] = useState<'invalid' | 'rate_limited' | 'admin_logged_in' | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -36,6 +36,10 @@ export default function RecoverySheet({ open, onClose, sessionId, onForgotPin }:
         body: JSON.stringify({ name: name.trim(), sessionId, pin }),
       });
       if (res.status === 429) { setError('rate_limited'); return; }
+      // Admin cookie set: /api/players/recover refuses (admins must use
+      // /reset-access instead). Surface this distinctly so the user knows
+      // they're not just typing the wrong PIN.
+      if (res.status === 403) { setError('admin_logged_in'); return; }
       if (!res.ok) { setError('invalid'); return; }
       const body = await res.json();
       setIdentity({ name: name.trim(), token: body.deleteToken, sessionId });
@@ -132,6 +136,11 @@ export default function RecoverySheet({ open, onClose, sessionId, onForgotPin }:
             {error === 'rate_limited' && (
               <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
                 {t('errorRateLimited')}
+              </p>
+            )}
+            {error === 'admin_logged_in' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+                {t('errorAdminLoggedIn')}
               </p>
             )}
           </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -192,6 +192,7 @@
     "haveCodeLink": "Have a recovery code from admin?",
     "errorInvalid": "That didn't match. Try again.",
     "errorRateLimited": "Too many tries. Try again later.",
+    "errorAdminLoggedIn": "Signed in as admin — sign out first to recover a player account.",
     "welcomeBack": "Welcome back, {name}",
     "close": "Close"
   }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -192,6 +192,7 @@
     "haveCodeLink": "有管理员发的验证码？",
     "errorInvalid": "信息不匹配，请重试。",
     "errorRateLimited": "尝试次数过多，请稍后再试。",
+    "errorAdminLoggedIn": "当前为管理员登录——请先退出后再恢复玩家账户。",
     "welcomeBack": "欢迎回来，{name}",
     "close": "关闭"
   }


### PR DESCRIPTION
## Summary

When the recovery endpoint returns **403** (admin cookie set — admins must use `/reset-access` instead of `/recover`), both client sheets were collapsing it into the generic `setError('invalid')` branch. The user saw "That didn't match. Try again." and triple-checked their PIN before realizing the issue was their admin session.

This PR adds a discrete `admin_logged_in` error path in both sheets so the failure mode is labeled correctly.

## Why this came up

Reported on bpm-next today as `GET /bpm/api/players/recover 403 (Forbidden)` in DevTools. The server-side guard at `app/api/players/recover/route.ts:53` is **working as designed** — without it, a malicious admin could mint a `deleteToken` for any player without their cooperation. `/reset-access` requires the player to enter a 6-digit code, which builds the cooperation in. The bug was purely client-side message routing.

## Changes

| File | Change |
| --- | --- |
| `components/RecoverySheet.tsx` | Add `'admin_logged_in'` to error union; check `res.status === 403` before `!res.ok`; render a new amber alert |
| `components/EnterCodeSheet.tsx` | Same treatment |
| `messages/en.json` | New `recovery.errorAdminLoggedIn` |
| `messages/zh-CN.json` | New `recovery.errorAdminLoggedIn` (zh-CN) |

## Out of scope (deliberate)

Considered also **hiding** the Restore button entirely while the admin cookie is set. Skipped because:

- An admin who legitimately plays in the friend group will at some point want to test or use the recovery flow.
- The fix below already tells them what's wrong and how to proceed.
- Hiding the entry point makes the system *less* understandable, not more — they'd just see no Restore option and wonder why.

If we later decide it's confusing for non-playing admins, easy follow-up.

## Test plan

- [x] `npm test` — 377/377 passing
- [ ] Reviewer: as admin (with admin cookie), open Profile → Restore, type a name + 4-digit PIN, submit. Verify the new amber message appears: "Signed in as admin — sign out first to recover a player account."
- [ ] Same flow via the EnterCode path (Forgot PIN? → 6-digit code).
- [ ] Confirm the existing wrong-PIN path still shows the original red "That didn't match. Try again." (no regression on the invalid case).
- [ ] zh-CN locale renders the translated message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)