### PR TITLE
fix(pin): drop type=password — stops Chrome flagging vnext as Dangerous

### DIFF
--- a/components/PinInput.tsx
+++ b/components/PinInput.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useId } from 'react';
+import { useId, type CSSProperties } from 'react';
 
 interface Props {
   value: string;
@@ -21,7 +21,13 @@ export default function PinInput({
       <input
         id={id}
         name={`pin-${digits}`}
-        type="password"
+        // Intentionally NOT type="password" — Chrome's password manager runs
+        // a stored-password reuse check on every type="password" field, which
+        // flags this site as "Dangerous" with a "Check your passwords"
+        // overlay when the user types a PIN that matches a saved password
+        // for any other domain. The visual masking below preserves
+        // shoulder-surf protection without engaging Chrome's heuristic.
+        type="text"
         inputMode="numeric"
         autoComplete="one-time-code"
         pattern={`[0-9]{${digits}}`}
@@ -46,7 +52,14 @@ export default function PinInput({
           background: 'var(--input-bg, rgba(255,255,255,0.05))',
           color: 'var(--text-primary)',
           width: '100%',
-        }}
+          // Visual masking — renders typed digits as dots without the
+          // type="password" semantic. Supported in Chrome/Safari/Edge and
+          // Firefox 116+. If a Firefox user pre-dates that, digits show as
+          // plain text — acceptable trade-off vs the Chrome warning.
+          // `WebkitTextSecurity` isn't in csstype's CSSProperties yet, so
+          // we cast through a vendor-extension intersection type.
+          WebkitTextSecurity: 'disc',
+        } as CSSProperties & { WebkitTextSecurity?: 'none' | 'disc' | 'circle' | 'square' }}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Chrome flagged bpm-next as **Dangerous** with a "Check your passwords / You just entered your password on a deceptive site" overlay. Two layered triggers:

1. **Generic `*.azurewebsites.net` subdomain** with a random-looking suffix — exactly the visual fingerprint Chrome's Safe Browsing ML uses to classify phishing.
2. **`<input type=\"password\">` on the PIN field** — Chrome's password manager runs a stored-password reuse check on every `type=\"password\"` field, and when the typed PIN happens to match a saved password from any other domain, Chrome shows the warning.

This PR fixes #2 — the part we control in code.

## Change

`components/PinInput.tsx`:
- `type=\"password\"` → `type=\"text\"`
- New inline style `WebkitTextSecurity: 'disc'` preserves visual masking
- `autoComplete=\"one-time-code\"` + `inputMode=\"numeric\"` unchanged

Visual behavior is identical (dots rendered while typing) — but Chrome no longer engages its password manager on the field.

## What this does NOT fix

The red **Dangerous** address-bar badge may persist on `*.azurewebsites.net` because it's a separate Safe Browsing classifier on the *domain itself*, not the form. The full cure for that is a custom domain (parked). This PR removes the password-manager half of the warning, which is the only part we can address in code.

## Browser support

`-webkit-text-security: disc` is supported in Chrome, Safari, Edge, and Firefox 116+ (Aug 2023). Pre-116 Firefox users see digits in plain text — acceptable trade-off vs the Chrome warning.

## Test plan

- [x] `npm test` — 377/377 passing
- [x] `npx tsc --noEmit` on `PinInput.tsx` — no errors (other pre-existing TS errors in test files are unrelated)
- [ ] Reviewer: open vnext after deploy, type a PIN that matches a password Chrome has stored for another site. Verify the \"Check your passwords\" overlay no longer appears.
- [ ] Reviewer: confirm typing still renders as dots (visual masking preserved) on Chrome/Safari/Firefox 116+.
- [ ] Reviewer: confirm iOS numeric pad still appears (driven by `inputMode=\"numeric\"`).
- [ ] Reviewer: confirm SMS one-time-code suggestion still works on iOS Safari (driven by `autoComplete=\"one-time-code\"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)