### PR TITLE
PR A — retire NEXT_PUBLIC_FLAG_RECOVERY on server endpoints

### DIFF
--- a/__tests__/players-recover.test.ts
+++ b/__tests__/players-recover.test.ts
@@ -179,20 +179,8 @@ describe('POST /api/players/recover', () => {
     expect(res.status).toBe(403);
   });
 
-  it('Flag off → 404', async () => {
-    const prev = process.env.NEXT_PUBLIC_FLAG_RECOVERY;
-    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'false';
-    try {
-      const pinHash = await hashPin('1234');
-      seedPlayer(SESSION, 'Michael', { pinHash });
-      const res = await POST(
-        makeRequest('POST', URL_PATH, { name: 'Michael', sessionId: SESSION, pin: '1234' }),
-      );
-      expect(res.status).toBe(404);
-    } finally {
-      process.env.NEXT_PUBLIC_FLAG_RECOVERY = prev;
-    }
-  });
+  // Note: the "Flag off → 404" test was removed when the recovery flag was
+  // retired. The endpoint is now unconditionally active.
 });
 
 // Silence unused var lint

--- a/__tests__/players-reset-access.test.ts
+++ b/__tests__/players-reset-access.test.ts
@@ -65,15 +65,6 @@ describe('POST /api/players/reset-access', () => {
     expect(res.status).toBe(429);
   });
 
-  it('returns 404 when flag is off', async () => {
-    const prev = process.env.NEXT_PUBLIC_FLAG_RECOVERY;
-    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'false';
-    try {
-      const player = seedPlayer(SESSION, 'Michael');
-      const res = await POST(makeAdminRequest('POST', URL_PATH, { playerId: player.id }));
-      expect(res.status).toBe(404);
-    } finally {
-      process.env.NEXT_PUBLIC_FLAG_RECOVERY = prev;
-    }
-  });
+  // Note: the "returns 404 when flag is off" test was removed when the
+  // recovery flag was retired. The endpoint is now unconditionally active.
 });

--- a/__tests__/players.test.ts
+++ b/__tests__/players.test.ts
@@ -358,15 +358,17 @@ describe('POST /api/players — opt-in PIN at sign-up', () => {
     expect(stored?.pinHash).toBeUndefined();
   });
 
-  it('PIN silently ignored when flag is OFF — 201 succeeds, no pinHash in DB', async () => {
-    process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'false';
-    try {
-      const res = await POST(makeRequest('POST', 'http://localhost/api/players', { name: 'Dan', pin: '5839' }));
-      expect(res.status).toBe(201);
-      const stored = findPlayerByName('Dan');
-      expect(stored?.pinHash).toBeUndefined();
-    } finally {
-      process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'true';
-    }
+  // Note: the "PIN silently ignored when flag is OFF" test was removed when
+  // the recovery flag was retired. PIN at signup is now accepted
+  // unconditionally; absence is the only path that produces no pinHash.
+
+  it('PIN at signup is now accepted regardless of any env flag (recovery flag retired)', async () => {
+    const res = await POST(
+      makeRequest('POST', 'http://localhost/api/players', { name: 'Dan', pin: '5839' }),
+    );
+    expect(res.status).toBe(201);
+    const stored = findPlayerByName('Dan');
+    expect(stored?.pinHash).toBeDefined();
+    expect(typeof stored?.pinHash).toBe('string');
   });
 });

--- a/app/api/players/recover/route.ts
+++ b/app/api/players/recover/route.ts
@@ -6,17 +6,13 @@ import { getContainer } from '@/lib/cosmos';
 import { verifyPin, FAKE_HASH } from '@/lib/recoveryHash';
 import { consumeCode } from '@/lib/recoveryCodes';
 import { appendEvent } from '@/lib/recoveryAudit';
-import { isFlagOn } from '@/lib/flags';
 
 export const dynamic = 'force-dynamic';
 
 const FAIL = () => NextResponse.json({ error: 'invalid_credentials' }, { status: 401 });
 
 export async function POST(req: NextRequest) {
-  if (!isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')) {
-    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
-  }
-
+  // Recovery flag retired — endpoint is unconditionally active.
   let body: { name?: unknown; sessionId?: unknown; pin?: unknown; code?: unknown };
   try {
     body = await req.json();

--- a/app/api/players/reset-access/route.ts
+++ b/app/api/players/reset-access/route.ts
@@ -4,15 +4,12 @@ import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { issueCode } from '@/lib/recoveryCodes';
 import { appendEvent } from '@/lib/recoveryAudit';
-import { isFlagOn } from '@/lib/flags';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
-  if (!isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')) {
-    return NextResponse.json({ error: 'Not Found' }, { status: 404 });
-  }
-
+  // Recovery flag retired — endpoint is unconditionally active. Admin auth +
+  // rate-limit gates remain in force.
   const ip = getClientIp(req);
   if (!checkRateLimit(`reset-access:${ip}`, 10, 60 * 60 * 1000)) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -3,7 +3,6 @@ import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { randomBytes, timingSafeEqual } from 'crypto';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 import { isAdminAuthed } from '@/lib/auth';
-import { isFlagOn } from '@/lib/flags';
 import { hashPin } from '@/lib/recoveryHash';
 import { appendEvent } from '@/lib/recoveryAudit';
 import type { RecoveryEvent } from '@/lib/types';
@@ -53,9 +52,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Name too long (max 50 chars)' }, { status: 400 });
     }
 
-    // Optional PIN at sign-up — only honored when the recovery flag is on.
+    // PIN at sign-up — accepted unconditionally (recovery flag retired). Still
+    // optional at the server boundary; PR C will make it required at signup
+    // once the client-side form ships the field. Until then, callers may
+    // omit pin and the player record is created without a hash.
     let pinHash: string | undefined;
-    if (body.pin !== undefined && body.pin !== null && isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')) {
+    if (body.pin !== undefined && body.pin !== null) {
       if (typeof body.pin !== 'string' || !/^[0-9]{4}$/.test(body.pin)) {
         return NextResponse.json({ error: 'Invalid PIN format' }, { status: 400 });
       }
@@ -204,11 +206,9 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
     }
 
-    // PIN set/change/remove — admin OR player-self via deleteToken
+    // PIN set/change/remove — admin OR player-self via deleteToken.
+    // Recovery flag retired; PIN management is unconditionally available.
     if (body.pin !== undefined) {
-      if (!isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')) {
-        return NextResponse.json({ error: 'Not Found' }, { status: 404 });
-      }
       // Pre-validate pin shape (fail fast before DB load)
       let nextPinHash: string | undefined;
       let clearPin = false;


### PR DESCRIPTION
## Summary

Auth-revamp **PR A** (of 4). Removes the recovery flag gate from four server endpoints so PIN handling and player recovery are unconditionally available on the server. Zero client change in this PR.

## Sequencing context

| | What ships | Risk |
| --- | --- | --- |
| **PR A (this)** | Server flag gates removed | None on vnext (flag is `'true'` there); none on stable for users (flag is `'false'`, but no-one's calling these endpoints there yet) |
| PR B | Admin auth migrated to per-player PIN; `SESSION_SECRET` env var added | Existing admin sessions invalidate; users log in fresh |
| PR C | PIN required at signup (client + server); `lib/flags.ts` flag removed; force-PIN modal | Existing PIN-less players see force-PIN modal |
| PR D | Contextual identity callouts | Cosmetic only |

## Changes

| File | Change |
| --- | --- |
| `app/api/players/route.ts` POST | Drop `&& isFlagOn('NEXT_PUBLIC_FLAG_RECOVERY')` from the pin-handling branch. Accept `pin` unconditionally when sent. Format + blocklist validation unchanged. **PIN remains optional at the boundary** — PR C will move to required when client + server move together. |
| `app/api/players/route.ts` PATCH | Remove the early `404` return when flag is off. PIN set / change / remove is always available. |
| `app/api/players/recover/route.ts` | Drop the flag gate at top + unused `isFlagOn` import. |
| `app/api/players/reset-access/route.ts` | Same. |
| `app/api/players/route.ts` (imports) | Drop the orphan `isFlagOn` import — no longer used. |

## Test changes

- **Removed 3 obsolete tests** that asserted the now-impossible flag-off paths:
  - `players-recover.test.ts` — "Flag off → 404"
  - `players-reset-access.test.ts` — "returns 404 when flag is off"
  - `players.test.ts` — "PIN silently ignored when flag is OFF"
- **Added 1 positive test** in `players.test.ts` confirming PIN at signup is accepted regardless of env flag state.

## Test plan

- [x] `npm test` — 375/375 passing (was 377; net -2 = -3 obsolete + +1 new).
- [ ] Reviewer: confirm `lib/flags.ts` `FLAG_RECOVERY` registry entry is *kept* in this PR — only the server gates are dropped. The flag is fully removed in PR C. (Both deploy workflows still set `NEXT_PUBLIC_FLAG_RECOVERY` env vars; that's intentional until PR C.)
- [ ] After merge: bpm-next auto-redeploys. The recovery routes and PIN-management endpoints continue to work as they did before (flag was already on).
- [ ] After bpm-stable promotion of these commits later: same routes start accepting traffic that was previously 404'd. Combined with PR C, this is intended behavior.

## Why PIN stays optional in PR A (deviation from the original plan)

The original plan said "PIN now required" in PR A. That conflicts with the "Active vnext users see zero impact" promise — current production client doesn't send `pin`, so making it required server-side would 400 every signup until PR C ships the client field. Amended PR A to drop the flag gate without changing required-ness. PR C couples the client field with the server-side requirement so they move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)