### PR TITLE
PR D — contextual identity callouts (Stats tab heading + Streak hero)

### DIFF
--- a/__tests__/components/StatsPlaceholder.test.tsx
+++ b/__tests__/components/StatsPlaceholder.test.tsx
@@ -21,7 +21,7 @@ describe('StatsPlaceholder', () => {
   it('renders four skeleton cards with titles in English', () => {
     renderWithLocale('en');
     expect(screen.getByText('Skill progression')).toBeTruthy();
-    expect(screen.getByText('Attendance')).toBeTruthy();
+    expect(screen.getByText('Your Attendance')).toBeTruthy();
     expect(screen.getByText('Cost trend')).toBeTruthy();
     expect(screen.getByText('Partner frequency')).toBeTruthy();
   });
@@ -40,7 +40,7 @@ describe('StatsPlaceholder', () => {
   it('renders Chinese titles when locale is zh-CN', () => {
     renderWithLocale('zh-CN');
     expect(screen.getByText('技能进展')).toBeTruthy();
-    expect(screen.getByText('出勤记录')).toBeTruthy();
+    expect(screen.getByText('您的出勤记录')).toBeTruthy();
     expect(screen.getByText('费用趋势')).toBeTruthy();
     expect(screen.getByText('搭档频率')).toBeTruthy();
   });

--- a/components/stats/StatsStreakHero.tsx
+++ b/components/stats/StatsStreakHero.tsx
@@ -106,12 +106,15 @@ export default function StatsStreakHero() {
         </span>
       </div>
       <div style={{ minWidth: 0, flex: 1 }}>
-        <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: PRIMARY, lineHeight: 1.25 }}>
-          {streak === 1 ? '1 week streak' : `${streak} weeks in a row`}
+        <p style={{ margin: 0, fontSize: 11, color: MUTED, fontWeight: 500, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+          {onPersonalBest ? `${name} — Personal Best` : `${name}'s Streak`}
+        </p>
+        <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: PRIMARY, lineHeight: 1.25, marginTop: 2 }}>
+          {streak === 1 ? "You're on a 1-week streak" : `You're on a ${streak}-week streak`}
         </p>
         <p style={{ margin: 0, fontSize: 12, color: MUTED, marginTop: 2 }}>
           {onPersonalBest
-            ? `Personal best — tied or beating your longest run of ${longestStreak}.`
+            ? `Tied or beating your longest run of ${longestStreak}.`
             : `Longest run: ${longestStreak} week${longestStreak === 1 ? '' : 's'}. Keep showing up.`}
         </p>
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -142,7 +142,7 @@
       "subtitle": "Your ACE scores over time."
     },
     "attendance": {
-      "title": "Attendance",
+      "title": "Your Attendance",
       "subtitle": "Sessions played this month."
     },
     "cost": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -142,7 +142,7 @@
       "subtitle": "你的 ACE 分数随时间变化。"
     },
     "attendance": {
-      "title": "出勤记录",
+      "title": "您的出勤记录",
       "subtitle": "本月参加的场次。"
     },
     "cost": {


### PR DESCRIPTION
## Summary

Auth-revamp **PR D** — final, cosmetic.

Surfaces the player's name inside Stats content where it makes sense, instead of a global "signed in as X" chip (decided against in planning — content over chrome).

## Changes

| File | Change |
| --- | --- |
| `messages/en.json` | `stats.attendance.title` → `Your Attendance` |
| `messages/zh-CN.json` | `stats.attendance.title` → `您的出勤记录` |
| `components/stats/StatsStreakHero.tsx` | Adds a small uppercase label above the streak count: `${name} — Personal Best` (on a PB run) or `${name}'s Streak`. Streak count line: `You're on a {N}-week streak`. |
| `__tests__/components/StatsPlaceholder.test.tsx` | Assertion strings updated for the new titles. |

## What this does NOT change

- **PlayersTab** — the current user's row already has a green left-border highlight + `(you)` suffix from earlier work.
- **HomeTab signup card** — already says "You're signed up, {name}".
- **Global identity chip** — explicitly out of scope per planning (option chosen: "contextual content callouts, not chrome").

## Test plan

- [x] `npm test` — 399/399 passing.
- [ ] Reviewer: open Stats tab on vnext after deploy. With identity resolved, confirm card heading reads "Your Attendance" and the Streak hero (when current streak ≥ 1) shows "{Name}'s Streak" / "{Name} — Personal Best" + "You're on a 5-week streak" style copy.
- [ ] Reviewer: zh-CN — heading reads "您的出勤记录".

🤖 Generated with [Claude Code](https://claude.com/claude-code)