### PR TITLE
hotfix: drop orphan recoveryFlag guard in AttendanceCardLive

### DIFF
--- a/components/stats/cards/AttendanceCardLive.tsx
+++ b/components/stats/cards/AttendanceCardLive.tsx
@@ -188,13 +188,11 @@ export default function AttendanceCardLive({ onSignUp }: AttendanceCardLiveProps
             Sign in
           </button>
         </div>
-        {recoveryFlag && (
-          <RecoverySheet
-            open={recoveryOpen}
-            onClose={() => setRecoveryOpen(false)}
-            sessionId={activeSessionId}
-          />
-        )}
+        <RecoverySheet
+          open={recoveryOpen}
+          onClose={() => setRecoveryOpen(false)}
+          sessionId={activeSessionId}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Build break from PR #41 (`f454f29`). The `recoveryFlag` local was removed but one usage at the bottom of the empty-state branch was missed. The vnext deploy caught it via `next build` (full tsc pass) which vitest's jsdom mode doesn't run.

One-line fix: unwrap the guard so RecoverySheet always mounts in the empty state, consistent with the rest of the auth revamp.

```
./components/stats/cards/AttendanceCardLive.tsx:191:10
Type error: Cannot find name 'recoveryFlag'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)