### PR TITLE
refactor(metadata): canonical URL from env var (custom-domain prep)

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -31,6 +31,10 @@ jobs:
         run: npm run build
         env:
           NEXT_PUBLIC_BASE_PATH: /bpm
+          # Canonical URL for SEO + social-share metadata. Swap when a custom
+          # domain is wired up; everything else (basePath, env, flags)
+          # stays the same.
+          NEXT_PUBLIC_BASE_URL: https://vnext-badminton-app-enhcave5djcvafe9.canadacentral-01.azurewebsites.net/bpm
           NEXT_PUBLIC_MAX_PLAYERS: '12'
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: next

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -36,6 +36,10 @@ jobs:
         run: npm run build
         env:
           NEXT_PUBLIC_BASE_PATH: /bpm
+          # Canonical URL for SEO + social-share metadata. Swap when a custom
+          # domain is wired up; everything else (basePath, env, flags)
+          # stays the same.
+          NEXT_PUBLIC_BASE_URL: https://badminton-app-gzendxb6fzefafgm.canadacentral-01.azurewebsites.net/bpm
           NEXT_PUBLIC_MAX_PLAYERS: '12'
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: stable

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -48,14 +48,25 @@ const jetbrainsMono = JetBrains_Mono({
   preload: false, // mono is below-the-fold on first load
 });
 
+/**
+ * Canonical URL for SEO + social-share metadata. Pulls from
+ * `NEXT_PUBLIC_BASE_URL` so a custom-domain swap is one Azure App Setting
+ * change + redeploy — no code edit. Fallback retains the current bpm-stable
+ * azurewebsites URL so dev and any environment without the var set produces
+ * sensible output.
+ */
+const CANONICAL_URL =
+  process.env.NEXT_PUBLIC_BASE_URL ??
+  'https://badminton-app-gzendxb6fzefafgm.canadacentral-01.azurewebsites.net/bpm';
+
 export const metadata: Metadata = {
-  metadataBase: new URL('https://badminton-app-gzendxb6fzefafgm.canadacentral-01.azurewebsites.net/bpm'),
+  metadataBase: new URL(CANONICAL_URL),
   title: 'BPM Badminton',
   description: 'Sign up for weekly badminton sessions',
   openGraph: {
     title: 'BPM Badminton',
     description: 'Sign up for weekly badminton sessions',
-    url: 'https://badminton-app-gzendxb6fzefafgm.canadacentral-01.azurewebsites.net/bpm',
+    url: CANONICAL_URL,
     siteName: 'BPM Badminton',
     type: 'website',
   },


### PR DESCRIPTION
Pre-work for the eventual custom-domain swap. Lifts the hardcoded `azurewebsites.net` URL out of `app/layout.tsx`'s `metadataBase` + OpenGraph `url` into the new `NEXT_PUBLIC_BASE_URL` env var.

After this lands, the domain swap is a 4-step Azure-side change (DNS → custom-domain binding → managed cert → update App Setting). No code edit needed.

## Files

| Path | Change |
| --- | --- |
| `app/layout.tsx` | `metadataBase` + OG `url` read `NEXT_PUBLIC_BASE_URL` with the current azurewebsites URL as fallback. |
| `.github/workflows/deploy-next.yml` | Bakes `NEXT_PUBLIC_BASE_URL=https://vnext-...` (current value). |
| `.github/workflows/deploy-stable.yml` | Bakes `NEXT_PUBLIC_BASE_URL=https://badminton-app-...` (current value). |

## Test plan

- [x] `npx tsc --noEmit` clean (no new errors).
- [x] `npm test` — 399/399 still passing.
- [ ] After merge: Azure deploys; verify the `<head>` source on vnext shows the vnext azurewebsites URL in the OG `og:url` meta tag (Page Source view → search 'og:url'). Same check on stable post-promotion.

## Why this is its own PR

Decoupled from the actual domain swap so:
1. The env-var contract ships now with current behaviour preserved.
2. When you set up the domain, the swap is one Azure App Setting + redeploy. No `main` commit needed for the domain itself.
3. If anything regresses with the env-var fallback, easy to revert without touching the domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)