### PR TITLE
P3 — <ConfirmInline> primitive + audit-driven scope correction

### DIFF
--- a/components/PlayersTab.tsx
+++ b/components/PlayersTab.tsx
@@ -7,6 +7,7 @@ import { getIdentity, clearIdentity } from '@/lib/identity';
 import ShuttleLoader from '@/components/ShuttleLoader';
 import ShuttleIcon from '@/components/ShuttleIcon';
 import PageHeader from '@/components/primitives/PageHeader';
+import ConfirmInline from '@/components/primitives/ConfirmInline';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const DAY_LONG = { weekday: 'long', month: 'long', day: 'numeric' } as const;
@@ -132,11 +133,13 @@ export default function PlayersTab() {
                   {isMe && (
                     <div className="flex flex-col items-end gap-0.5">
                       {confirmingCancel ? (
-                        <div className="flex items-center gap-2 text-xs">
-                          <span className="text-gray-400">{t('cancelConfirm')}</span>
-                          <button type="button" onClick={handleCancel} className="text-red-400 hover:text-red-300 transition-colors px-2 py-1" style={{ minHeight: 32 }}>{t('confirmYes')}</button>
-                          <button type="button" onClick={() => setConfirmingCancel(false)} className="text-gray-400 hover:text-white transition-colors px-2 py-1" style={{ minHeight: 32 }}>{t('confirmNo')}</button>
-                        </div>
+                        <ConfirmInline
+                          message={t('cancelConfirm')}
+                          yesLabel={t('confirmYes')}
+                          noLabel={t('confirmNo')}
+                          onYes={handleCancel}
+                          onNo={() => setConfirmingCancel(false)}
+                        />
                       ) : (
                         <button
                           type="button"
@@ -188,11 +191,13 @@ export default function PlayersTab() {
                     {isMe && (
                       <div className="flex flex-col items-end gap-0.5">
                         {confirmingCancel ? (
-                          <div className="flex items-center gap-2 text-xs">
-                            <span className="text-gray-400">{t('cancelConfirm')}</span>
-                            <button type="button" onClick={handleCancel} className="text-red-400 hover:text-red-300 transition-colors">{t('confirmYes')}</button>
-                            <button type="button" onClick={() => setConfirmingCancel(false)} className="text-gray-400 hover:text-white transition-colors">{t('confirmNo')}</button>
-                          </div>
+                          <ConfirmInline
+                            message={t('cancelConfirm')}
+                            yesLabel={t('confirmYes')}
+                            noLabel={t('confirmNo')}
+                            onYes={handleCancel}
+                            onNo={() => setConfirmingCancel(false)}
+                          />
                         ) : (
                           <button
                             type="button"

--- a/components/primitives/ConfirmInline.tsx
+++ b/components/primitives/ConfirmInline.tsx
@@ -1,0 +1,63 @@
+/**
+ * Inline "Are you sure? Yes / No" confirmation row. Replaces the
+ * destructive-action confirmation pattern that appeared in PlayersTab
+ * twice (active row + waitlist row) with subtly different styling
+ * each time:
+ *
+ *   <div className="flex items-center gap-2 text-xs">
+ *     <span className="text-gray-400">{message}</span>
+ *     <button onClick={onYes} className="text-red-400 …">{yesLabel}</button>
+ *     <button onClick={onNo} className="text-gray-400 …">{noLabel}</button>
+ *   </div>
+ *
+ * The component standardizes the size/spacing and forces both buttons
+ * to a 32px min-height for tap targets (one of the original call sites
+ * had this; the other did not — drift caught and reconciled).
+ */
+export interface ConfirmInlineProps {
+  message: string;
+  yesLabel: string;
+  noLabel: string;
+  onYes: () => void;
+  onNo: () => void;
+  /**
+   * Color tone for the affirmative button. Defaults to `'danger'` since
+   * the canonical use is a destructive cancel/remove confirmation.
+   */
+  yesTone?: 'danger' | 'accent';
+}
+
+export default function ConfirmInline({
+  message,
+  yesLabel,
+  noLabel,
+  onYes,
+  onNo,
+  yesTone = 'danger',
+}: ConfirmInlineProps) {
+  const yesClass =
+    yesTone === 'danger'
+      ? 'text-red-400 hover:text-red-300'
+      : 'text-green-400 hover:text-green-300';
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <span className="text-gray-400">{message}</span>
+      <button
+        type="button"
+        onClick={onYes}
+        className={`${yesClass} transition-colors px-2 py-1`}
+        style={{ minHeight: 32 }}
+      >
+        {yesLabel}
+      </button>
+      <button
+        type="button"
+        onClick={onNo}
+        className="text-gray-400 hover:text-white transition-colors px-2 py-1"
+        style={{ minHeight: 32 }}
+      >
+        {noLabel}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Primitives plan, **PR P3 of 3** (the planned P3 + P4 collapsed after audit; see commit message for details).

The 'Are you sure? Yes/No' inline-confirmation pattern in PlayersTab had subtly drifted between the active-row and waitlist-row call sites — one had `minHeight: 32` + padding, the other didn't. `<ConfirmInline>` standardizes to the more accessible variant.

## Audit-driven scope changes

The original plan called for 4 PRs / 6 primitives. Honest audit during implementation cut this to 3 PRs / 3 primitives:

| Planned | Outcome |
| --- | --- |
| P1 `<PageHeader>` (8 sweeps) | ✅ shipped |
| P2 `<StatusBanner>` (7 sweeps) | ✅ shipped |
| P3a `<SectionLabel>` | ❌ canceled — class is already the primitive, wrapping in React adds ceremony |
| P3b `<EmptyState>` | ❌ canceled — only 3 thin one-liners, not the full icon+title+body+CTA shape |
| P3c `<InlineRow>` | ❌ canceled — single consumer (ProfileTab.SettingsList), would fragment |
| **P3 `<ConfirmInline>`** (2 sweeps, this PR) | ✅ shipped |
| P4 Profile inline-style sweep | ⏸ deferred — Tailwind-conversion exercise, not primitive consolidation; merits its own PR |

Net: 3 primitives, 17 production sweeps. ~150 LOC of duplication eliminated across the four-PR run.

## Files

| Path | Change |
| --- | --- |
| `components/primitives/ConfirmInline.tsx` | New — message + yes/no labels + tone enum |
| `components/PlayersTab.tsx` | 2 confirmation rows → `<ConfirmInline>`; reconciles the drifted variant |

Tests: 399/399. `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)