### PR TITLE
fix(theme): shrink + spread aurora blobs to reduce color-mix overlap

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -423,10 +423,13 @@ h1, h2, h3, h4 {
   animation: aurora-drift 14s ease-in-out infinite alternate;
 }
 
-/* Blob 1 — slate-blue (cool atmospheric) */
+/* Blob 1 — slate-blue (cool atmospheric, upper-left)
+   Sized down ~25% from the original (110×80vmax) so each blob owns its
+   corner instead of bleeding into the others. The previous overlap mixed
+   slate+green into murky teal in the middle of every screen. */
 .aurora-blob-1 {
-  width: 110vmax; height: 80vmax;
-  left: -10vmax; top: 4vh;
+  width: 80vmax; height: 60vmax;
+  left: -15vmax; top: -2vh;
   background: radial-gradient(ellipse 50% 50% at 50% 50%,
     rgba(120, 158, 196, 0.50) 0%,
     rgba(74, 120, 170, 0.22) 32%,
@@ -434,10 +437,10 @@ h1, h2, h3, h4 {
     transparent 80%);
 }
 
-/* Blob 2 — brand court-green (warm accent) */
+/* Blob 2 — brand court-green (warm accent, lower-right) */
 .aurora-blob-2 {
-  width: 100vmax; height: 72vmax;
-  right: -15vmax; bottom: 4vh;
+  width: 75vmax; height: 55vmax;
+  right: -15vmax; bottom: -2vh;
   background: radial-gradient(ellipse 50% 50% at 50% 50%,
     rgba(74, 222, 128, 0.32) 0%,
     rgba(74, 222, 128, 0.14) 34%,
@@ -446,10 +449,12 @@ h1, h2, h3, h4 {
   animation-delay: -5s;
 }
 
-/* Blob 3 — warm-yellow (midtone glow) */
+/* Blob 3 — warm-yellow (midtone glow, mid-right)
+   Smaller still and pushed further right + down so it doesn't sit on
+   top of blob 1. Reads as an accent point rather than a third wash. */
 .aurora-blob-3 {
-  width: 85vmax; height: 65vmax;
-  right: 10vmax; top: 22vh;
+  width: 55vmax; height: 42vmax;
+  right: -8vmax; top: 30vh;
   background: radial-gradient(ellipse 50% 50% at 50% 50%,
     rgba(232, 210, 160, 0.34) 0%,
     rgba(210, 185, 130, 0.14) 36%,


### PR DESCRIPTION
## Reported issue

User: "the aurora should not overlap each other too much."

The three aurora blobs are sized at 110/100/85 vmax — at most viewport sizes that means each blob covers the entire visible width, so all three overlap heavily and produce muddy color mixes (slate + green = teal in the middle, green + yellow = lime on the right). Each blob loses its identity; the wash reads as one homogenous gradient instead of three distinct atmospheric points.

## Fix

Shrink each blob ~25-35% and spread the off-screen anchors so visible footprints don't pile on top of each other:

| Blob | Before | After | Notes |
| --- | --- | --- | --- |
| 1 (slate-blue) | 110×80vmax @ `left:-10vmax, top:4vh` | 80×60vmax @ `left:-15vmax, top:-2vh` | Upper-left; pushed further off-screen so visible center is up in the corner |
| 2 (court-green) | 100×72vmax @ `right:-15vmax, bottom:4vh` | 75×55vmax @ `right:-15vmax, bottom:-2vh` | Lower-right; same width relative to blob 1 |
| 3 (warm-yellow) | 85×65vmax @ `right:10vmax, top:22vh` | 55×42vmax @ `right:-8vmax, top:30vh` | Mid-right; pulled into the right edge so it doesn't sit on top of blob 1 |

Colors and animation timings unchanged. Light-mode color overrides apply on top of these positions (light theme only changes the gradient backgrounds, not sizes), so the lighter pastels also benefit from less overlap.

## What this does NOT change

- The blob colors themselves
- The drift animation
- The per-tab override on Sign-Ups (court diagram still hides the blobs there)

## Test plan

- [x] `npm test` — 399/399 (CSS-only)
- [x] `npx tsc --noEmit` clean
- [ ] Reviewer: open vnext after deploy. Compare to current — each blob should read as a distinct atmospheric point now, not a homogenous wash. The middle of every screen should look more like the dark page bg, less like teal.
- [ ] Light mode sanity check — pastels should also feel cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
