### PR TITLE
feat(api): account-only signup path via sessionSignup:false

### DIFF
--- a/__tests__/players-create-account.test.ts
+++ b/__tests__/players-create-account.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { POST } from '@/app/api/players/route';
+import {
+  resetMockStore,
+  seedPointer,
+  seedSession,
+  seedMember,
+  setupAdminPin,
+  makeRequest,
+  getStore,
+} from './helpers';
+import { verifyPin } from '@/lib/recoveryHash';
+
+const SESSION = 'session-2026-04-30';
+const URL_PATH = 'http://localhost:3000/api/players';
+
+beforeEach(() => {
+  resetMockStore();
+  setupAdminPin();
+  seedPointer(SESSION);
+  seedSession(SESSION);
+});
+
+describe('POST /api/players { sessionSignup: false } — account-only path', () => {
+  it('creates a member with pinHash, no session player', async () => {
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Riley', pin: '4827', sessionSignup: false }),
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.name).toBe('Riley');
+    expect(data.deleteToken).toBeNull();
+    expect(data.id).toMatch(/^[0-9a-f]{24}$/);
+
+    const store = getStore();
+    const members = (store['members'] ?? []) as Array<{ name: string; pinHash?: string }>;
+    expect(members.find((m) => m.name === 'Riley')?.pinHash).toBeDefined();
+    expect(store['players'] ?? []).toHaveLength(0);
+  });
+
+  it('PIN is required — 400 when omitted', async () => {
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Riley', sessionSignup: false }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/PIN required/);
+  });
+
+  it('rejects blocklisted PINs', async () => {
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Riley', pin: '1234', sessionSignup: false }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe('pin_too_common');
+  });
+
+  it('rejects malformed PINs (non-4-digit)', async () => {
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Riley', pin: '12', sessionSignup: false }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe('Invalid PIN format');
+  });
+
+  it('idempotent on repeat: existing member updated, no duplicate row', async () => {
+    seedMember('Casey', { pinHash: 'old-hash' });
+
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Casey', pin: '5821', sessionSignup: false }),
+    );
+    expect(res.status).toBe(201);
+
+    const store = getStore();
+    const members = (store['members'] ?? []) as Array<{ name: string; pinHash?: string }>;
+    const caseys = members.filter((m) => m.name === 'Casey');
+    expect(caseys).toHaveLength(1);
+    expect(caseys[0].pinHash).not.toBe('old-hash');
+    if (caseys[0].pinHash) {
+      expect(await verifyPin('5821', caseys[0].pinHash)).toBe(true);
+    }
+  });
+
+  it('rate-limits at 3 attempts/hr per (name, IP)', async () => {
+    const ip = { 'X-Client-IP': '10.99.0.1' };
+
+    for (let i = 0; i < 3; i++) {
+      const res = await POST(
+        makeRequest('POST', URL_PATH, { name: 'Spammer', pin: '4827', sessionSignup: false }, ip),
+      );
+      expect(res.status).toBe(201);
+    }
+
+    const fourth = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Spammer', pin: '4827', sessionSignup: false }, ip),
+    );
+    expect(fourth.status).toBe(429);
+
+    // Different name from same IP gets its own bucket
+    const otherName = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Different', pin: '4827', sessionSignup: false }, ip),
+    );
+    expect(otherName.status).toBe(201);
+  });
+
+  it('does not run invite-list check (account creation is universal)', async () => {
+    seedMember('Existing'); // active member exists, so non-admin signup normally requires being on the list
+
+    // Account creation for a name not on the list still succeeds
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'NewPerson', pin: '4827', sessionSignup: false }),
+    );
+    expect(res.status).toBe(201);
+  });
+});
+
+describe('POST /api/players — default behavior unchanged when sessionSignup omitted', () => {
+  it('still creates a session player by default', async () => {
+    seedMember('Riley'); // on invite list
+
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Riley', pin: '4827' }),
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.deleteToken).toMatch(/^[0-9a-f]{32}$/);
+
+    const store = getStore();
+    expect((store['players'] ?? []).filter((p) => (p as { name: string }).name === 'Riley')).toHaveLength(1);
+  });
+});

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -67,6 +67,42 @@ export async function POST(req: NextRequest) {
       pinHash = await hashPin(body.pin);
     }
 
+    // Account-only path: create/update the member record without signing up
+    // for a session. PIN is required here — there's no session player to
+    // generate a deleteToken from, so the member's pinHash is the only
+    // recovery primitive. Tighter rate limit than session signup since
+    // account creation is rarer and more enumeration-sensitive.
+    if (body.sessionSignup === false) {
+      if (!pinHash) {
+        return NextResponse.json({ error: 'PIN required for account creation' }, { status: 400 });
+      }
+      if (!checkRateLimit(`create-account:${trimmedName.toLowerCase()}:${ip}`, 3, 60 * 60 * 1000)) {
+        return NextResponse.json({ error: 'Too many account creation attempts. Try again later.' }, { status: 429 });
+      }
+      const membersContainer = getContainer('members');
+      const { resources: existingMembers } = await membersContainer.items
+        .query({
+          query: 'SELECT * FROM c WHERE LOWER(c.name) = LOWER(@name)',
+          parameters: [{ name: '@name', value: trimmedName }],
+        })
+        .fetchAll();
+      const existingMember = existingMembers[0];
+      const memberDoc = {
+        ...(existingMember ?? {
+          id: randomBytes(12).toString('hex'),
+          name: trimmedName,
+          active: true,
+          sessionCount: 0,
+          createdAt: new Date().toISOString(),
+        }),
+        pinHash,
+        lastSeen: new Date().toISOString(),
+      };
+      const { resource } = await membersContainer.items.upsert(memberDoc);
+      const safe = resource as Record<string, unknown>;
+      return NextResponse.json({ id: safe.id, name: safe.name, deleteToken: null }, { status: 201 });
+    }
+
     const sessionContainer = getContainer('sessions');
     const membersContainer = getContainer('members');
     const container = getContainer('players');

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -12,7 +12,10 @@ const LEGACY_TOKEN_KEY = 'badminton_deletetoken';
 
 export interface Identity {
   name: string;
-  token: string;
+  /** Session-player deleteToken. Absent for account-only identities created
+   *  via the `sessionSignup: false` POST path — those upgrade to a full
+   *  identity once the user signs up for a session. */
+  token?: string;
   sessionId: string;
 }
 


### PR DESCRIPTION
## Summary
- POST /api/players accepts new `sessionSignup: false` flag → creates/updates a member with pinHash, no session player
- PIN required on this path (member's pinHash is the only recovery primitive when no deleteToken exists)
- 3/hr rate limit per name+IP via existing `lib/rateLimit.ts` helper; key `create-account:{name}:{ip}`
- Skips invite-list check and signup-window/deadline checks (account creation is universal; session signup keeps the gate)
- `lib/identity.ts` Identity.token marked optional — account-only identities have no deleteToken until they sign up for a session

PR A of a 3-PR series for the auth taxonomy split (sign up = session, create account = identity, log in = name+PIN auth). No client surface consumes this yet — PR B adds the Profile "Create account" sheet that POSTs with `sessionSignup: false`.

## Test plan
- [x] npm test — 8 new tests in `players-create-account.test.ts`, 51 files / 409 tests pass
- [x] npx tsc --noEmit clean
- [x] Smoke via curl on localhost: happy path → 201 with `deleteToken: null`; missing PIN → 400; blocklisted PIN → 400
- [ ] No-op until PR B lands the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)