### PR TITLE
feat(auth): taxonomy split UI + sign-up/Create-account security fixes

### DIFF
--- a/__tests__/components/CreateAccountSheet.test.tsx
+++ b/__tests__/components/CreateAccountSheet.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import CreateAccountSheet from '../../components/CreateAccountSheet';
+import enMessages from '../../messages/en.json';
+
+const SESSION = 'session-2026-05-04';
+
+const renderSheet = (open = true, onClose = vi.fn()) =>
+  render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <CreateAccountSheet open={open} onClose={onClose} sessionId={SESSION} />
+    </NextIntlClientProvider>,
+  );
+
+describe('CreateAccountSheet', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+  afterEach(() => cleanup());
+
+  it('renders title, body, name + two PIN inputs, and disabled submit until valid', () => {
+    renderSheet();
+    expect(screen.getByText('Create your account')).toBeDefined();
+    expect(screen.getByText(/Set a name and PIN/i)).toBeDefined();
+    expect(screen.getByPlaceholderText('Enter your name')).toBeDefined();
+    expect(screen.getAllByLabelText(/PIN/i).length).toBeGreaterThanOrEqual(2);
+    const submit = screen.getByRole('button', { name: 'Create account' });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows mismatch error when PINs differ', async () => {
+    renderSheet();
+    fireEvent.change(screen.getByPlaceholderText('Enter your name'), { target: { value: 'Riley' } });
+    const pinInputs = screen.getAllByLabelText(/PIN/i) as HTMLInputElement[];
+    fireEvent.change(pinInputs[0], { target: { value: '4827' } });
+    fireEvent.change(pinInputs[1], { target: { value: '4828' } });
+    const submit = screen.getByRole('button', { name: 'Create account' });
+    fireEvent.click(submit);
+    await waitFor(() => {
+      expect(screen.getByText("PINs don't match")).toBeDefined();
+    });
+  });
+
+  it('on success, sets identity (server-side hasPin is the source of truth — no localStorage flag)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 'm1', name: 'Riley', deleteToken: null }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const onClose = vi.fn();
+    renderSheet(true, onClose);
+
+    fireEvent.change(screen.getByPlaceholderText('Enter your name'), { target: { value: 'Riley' } });
+    const pinInputs = screen.getAllByLabelText(/PIN/i) as HTMLInputElement[];
+    fireEvent.change(pinInputs[0], { target: { value: '4827' } });
+    fireEvent.change(pinInputs[1], { target: { value: '4827' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({ name: 'Riley', pin: '4827', sessionSignup: false });
+
+    await waitFor(() => {
+      const stored = localStorage.getItem('badminton_identity');
+      expect(stored).toBeTruthy();
+      const parsed = JSON.parse(stored!);
+      expect(parsed.name).toBe('Riley');
+      expect(parsed.token).toBeUndefined();
+      // Stale localStorage flag retired in favor of server hasPin via /api/members/me
+      expect(localStorage.getItem('badminton_pin_set')).toBeNull();
+    });
+  });
+
+  it('surfaces too_common error from API', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'pin_too_common' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    renderSheet();
+    fireEvent.change(screen.getByPlaceholderText('Enter your name'), { target: { value: 'Riley' } });
+    const pinInputs = screen.getAllByLabelText(/PIN/i) as HTMLInputElement[];
+    fireEvent.change(pinInputs[0], { target: { value: '1234' } });
+    fireEvent.change(pinInputs[1], { target: { value: '1234' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Pick a less common PIN/i)).toBeDefined();
+    });
+    expect(localStorage.getItem('badminton_identity')).toBeNull();
+  });
+
+  it('surfaces rate_limited error from API', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Too many' }), { status: 429 }),
+    );
+    renderSheet();
+    fireEvent.change(screen.getByPlaceholderText('Enter your name'), { target: { value: 'Riley' } });
+    const pinInputs = screen.getAllByLabelText(/PIN/i) as HTMLInputElement[];
+    fireEvent.change(pinInputs[0], { target: { value: '4827' } });
+    fireEvent.change(pinInputs[1], { target: { value: '4827' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Too many tries/i)).toBeDefined();
+    });
+  });
+});

--- a/__tests__/components/ProfileTab.test.tsx
+++ b/__tests__/components/ProfileTab.test.tsx
@@ -25,10 +25,17 @@ describe('ProfileTab', () => {
   });
   afterEach(() => cleanup());
 
-  it('shows anonymous empty state when no identity', () => {
+  it('shows anonymous identity-only state: inline sign-in form + Create account + recovery code link', () => {
     renderWith();
-    expect(screen.getByText(/Set up your profile/i)).toBeDefined();
-    expect(screen.getByText(/Already a player\? Sign in/i)).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Profile' })).toBeDefined();
+    expect(screen.getByText(/invite only/i)).toBeDefined();
+    // Inline sign-in form has a name input + PIN input + Sign in button
+    expect(screen.getByPlaceholderText('What is your name?')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDefined();
+    // Create-an-account opens the action sheet
+    expect(screen.getByRole('button', { name: 'Create an account' })).toBeDefined();
+    // Recovery-code fallback still present
+    expect(screen.getByText(/Have a recovery code/i)).toBeDefined();
   });
 
   it('shows player profile + PIN row when identity exists', () => {
@@ -38,7 +45,9 @@ describe('ProfileTab', () => {
     );
     renderWith();
     expect(screen.getByText('Michael')).toBeDefined();
-    expect(screen.getByText(/Recovery PIN/i)).toBeDefined();
+    // PIN management is now a Settings row labelled "New PIN" / "Update PIN"
+    // depending on hasPin (defaults to false until /api/members/me resolves).
+    expect(screen.getByText(/New PIN/i)).toBeDefined();
   });
 
   it('shows admin tools button only when isAdmin', () => {
@@ -49,13 +58,8 @@ describe('ProfileTab', () => {
     expect(screen.getByText(/Admin tools/i)).toBeDefined();
   });
 
-  it('renders the Sign-up CTA in anonymous state when onTabChange is provided', () => {
-    const onTabChange = vi.fn();
-    render(
-      <NextIntlClientProvider locale="en" messages={enMessages}>
-        <ProfileTab {...baseProps} onTabChange={onTabChange} />
-      </NextIntlClientProvider>,
-    );
-    expect(screen.getByText(/Sign up for this week/i)).toBeDefined();
+  it('does not show a session-signup CTA in anonymous state — Profile is identity-only', () => {
+    renderWith();
+    expect(screen.queryByText(/Sign up for this week/i)).toBeNull();
   });
 });

--- a/__tests__/players-create-account.test.ts
+++ b/__tests__/players-create-account.test.ts
@@ -65,8 +65,28 @@ describe('POST /api/players { sessionSignup: false } — account-only path', () 
     expect(data.error).toBe('Invalid PIN format');
   });
 
-  it('idempotent on repeat: existing member updated, no duplicate row', async () => {
+  it('refuses to overwrite an existing pinHash (account hijack guard)', async () => {
+    // Pre-seeded member with a PIN already set. A second create-account
+    // attempt for that name MUST 409 — otherwise anyone who knows a
+    // member's name could rewrite their PIN and lock them out.
     seedMember('Casey', { pinHash: 'old-hash' });
+
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Casey', pin: '5821', sessionSignup: false }),
+    );
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toBe('account_exists');
+
+    // Old pinHash unchanged
+    const store = getStore();
+    const members = (store['members'] ?? []) as Array<{ name: string; pinHash?: string }>;
+    const casey = members.find((m) => m.name === 'Casey');
+    expect(casey?.pinHash).toBe('old-hash');
+  });
+
+  it('claims a pre-seeded member without pinHash (admin invited the name; user claims by setting first PIN)', async () => {
+    seedMember('Casey'); // no pinHash
 
     const res = await POST(
       makeRequest('POST', URL_PATH, { name: 'Casey', pin: '5821', sessionSignup: false }),
@@ -77,20 +97,31 @@ describe('POST /api/players { sessionSignup: false } — account-only path', () 
     const members = (store['members'] ?? []) as Array<{ name: string; pinHash?: string }>;
     const caseys = members.filter((m) => m.name === 'Casey');
     expect(caseys).toHaveLength(1);
-    expect(caseys[0].pinHash).not.toBe('old-hash');
+    expect(caseys[0].pinHash).toBeDefined();
     if (caseys[0].pinHash) {
       expect(await verifyPin('5821', caseys[0].pinHash)).toBe(true);
     }
   });
 
   it('rate-limits at 3 attempts/hr per (name, IP)', async () => {
+    // Only the FIRST attempt for a fresh name actually creates a member;
+    // subsequent attempts on that name 409 (account_exists) but still
+    // count toward the rate limiter. So 3 successful + 1 limited would
+    // require 3 different fresh names. Easier: use one name and observe
+    // limit firing at attempt 4 once 3 attempts have been counted.
     const ip = { 'X-Client-IP': '10.99.0.1' };
 
-    for (let i = 0; i < 3; i++) {
+    const first = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Spammer', pin: '4827', sessionSignup: false }, ip),
+    );
+    expect(first.status).toBe(201);
+
+    // attempts 2 + 3 hit account_exists (counts toward limit)
+    for (let i = 0; i < 2; i++) {
       const res = await POST(
         makeRequest('POST', URL_PATH, { name: 'Spammer', pin: '4827', sessionSignup: false }, ip),
       );
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(409);
     }
 
     const fourth = await POST(
@@ -116,12 +147,12 @@ describe('POST /api/players { sessionSignup: false } — account-only path', () 
   });
 });
 
-describe('POST /api/players — default behavior unchanged when sessionSignup omitted', () => {
-  it('still creates a session player by default', async () => {
-    seedMember('Riley'); // on invite list
+describe('POST /api/players — default session signup', () => {
+  it('still creates a session player when member has no PIN (PIN-less first-time signup)', async () => {
+    seedMember('Riley'); // on invite list, no pinHash
 
     const res = await POST(
-      makeRequest('POST', URL_PATH, { name: 'Riley', pin: '4827' }),
+      makeRequest('POST', URL_PATH, { name: 'Riley' }),
     );
     expect(res.status).toBe(201);
     const data = await res.json();
@@ -129,5 +160,24 @@ describe('POST /api/players — default behavior unchanged when sessionSignup om
 
     const store = getStore();
     expect((store['players'] ?? []).filter((p) => (p as { name: string }).name === 'Riley')).toHaveLength(1);
+  });
+
+  it('refuses anonymous signup for a PIN-protected member (impersonation guard)', async () => {
+    // Pre-seeded member already has a pinHash. The anonymous HomeTab signup
+    // form (name only) MUST fail — otherwise anyone on the invite list
+    // could sign up as anyone else on a fresh session before the rightful
+    // owner gets there.
+    seedMember('Riley', { pinHash: 'someHash' });
+
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Riley' }),
+    );
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe('pin_required');
+
+    // No session player created
+    const store = getStore();
+    expect((store['players'] ?? [])).toHaveLength(0);
   });
 });

--- a/__tests__/players-recover.test.ts
+++ b/__tests__/players-recover.test.ts
@@ -181,6 +181,74 @@ describe('POST /api/players/recover', () => {
 
   // Note: the "Flag off → 404" test was removed when the recovery flag was
   // retired. The endpoint is now unconditionally active.
+
+  describe('member-only fallback (no session player)', () => {
+    it('verifies against members.pinHash and auto-creates a session player when signup is open', async () => {
+      const pinHash = await hashPin('4827');
+      const { seedMember } = await import('./helpers');
+      seedMember('Riley', { pinHash });
+      // No player record for the active session.
+
+      const res = await POST(
+        makeRequest('POST', URL_PATH, { name: 'Riley', sessionId: SESSION, pin: '4827' }),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.deleteToken).toMatch(/^[0-9a-f]{32}$/);
+
+      // Session player was created on-the-fly
+      const store = getStore();
+      const players = (store['players'] ?? []) as Array<{ name: string; sessionId: string; deleteToken: string }>;
+      const created = players.find((p) => p.name === 'Riley' && p.sessionId === SESSION);
+      expect(created).toBeDefined();
+      expect(created?.deleteToken).toBe(data.deleteToken);
+    });
+
+    it('returns identity-only (deleteToken: null) when signup is closed', async () => {
+      const pinHash = await hashPin('4827');
+      const { seedMember, seedSession, resetMockStore, seedPointer } = await import('./helpers');
+      // Reset and reseed with signupOpen=false
+      resetMockStore();
+      seedPointer(SESSION);
+      seedSession(SESSION, { signupOpen: false });
+      seedMember('Riley', { pinHash });
+
+      const res = await POST(
+        makeRequest('POST', URL_PATH, { name: 'Riley', sessionId: SESSION, pin: '4827' }),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.deleteToken).toBeNull();
+
+      // No session player created
+      const store = getStore();
+      expect((store['players'] ?? [])).toHaveLength(0);
+    });
+
+    it('wrong PIN against member.pinHash → 401, no player created', async () => {
+      const pinHash = await hashPin('4827');
+      const { seedMember } = await import('./helpers');
+      seedMember('Riley', { pinHash });
+
+      const res = await POST(
+        makeRequest('POST', URL_PATH, { name: 'Riley', sessionId: SESSION, pin: '0000' }),
+      );
+      expect(res.status).toBe(401);
+
+      const store = getStore();
+      expect((store['players'] ?? [])).toHaveLength(0);
+    });
+
+    it('member exists without pinHash → 401 (constant-time miss), no player created', async () => {
+      const { seedMember } = await import('./helpers');
+      seedMember('Riley'); // no pinHash
+
+      const res = await POST(
+        makeRequest('POST', URL_PATH, { name: 'Riley', sessionId: SESSION, pin: '4827' }),
+      );
+      expect(res.status).toBe(401);
+    });
+  });
 });
 
 // Silence unused var lint

--- a/app/api/members/me/route.ts
+++ b/app/api/members/me/route.ts
@@ -5,27 +5,28 @@ import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
   if (!checkRateLimit(`members-me:${ip}`, 10, 60 * 1000)) {
-    return NextResponse.json({ role: 'member' });
+    return NextResponse.json({ role: 'member', hasPin: false });
   }
 
   try {
     const name = new URL(req.url).searchParams.get('name')?.trim().slice(0, 50);
     if (!name) {
-      return NextResponse.json({ role: 'member' });
+      return NextResponse.json({ role: 'member', hasPin: false });
     }
 
     const container = getContainer('members');
     const { resources } = await container.items
       .query({
-        query: 'SELECT c.role FROM c WHERE LOWER(c.name) = LOWER(@name) AND c.active = true',
+        query: 'SELECT c.role, c.pinHash FROM c WHERE LOWER(c.name) = LOWER(@name) AND c.active = true',
         parameters: [{ name: '@name', value: name }],
       })
       .fetchAll();
 
     const role = resources[0]?.role ?? 'member';
-    return NextResponse.json({ role });
+    const hasPin = typeof resources[0]?.pinHash === 'string' && resources[0].pinHash.length > 0;
+    return NextResponse.json({ role, hasPin });
   } catch (error) {
     console.error('GET members/me error:', error);
-    return NextResponse.json({ role: 'member' });
+    return NextResponse.json({ role: 'member', hasPin: false });
   }
 }

--- a/app/api/players/recover/route.ts
+++ b/app/api/players/recover/route.ts
@@ -63,6 +63,77 @@ export async function POST(req: NextRequest) {
     .fetchAll();
   const player = resources[0];
 
+  // No session player for the active session, but the user may still have
+  // a member record (account-only identity, or returning player on a fresh
+  // session before they've signed up). Fall back to verifying against the
+  // member's pinHash. Codes don't have a member-level path — those are
+  // issued against a specific player record, so we still hard-fail.
+  if (!player && pin) {
+    const membersContainer = getContainer('members');
+    const { resources: members } = await membersContainer.items
+      .query({
+        query: 'SELECT * FROM c WHERE LOWER(c.name) = LOWER(@name) AND c.active = true',
+        parameters: [{ name: '@name', value: name }],
+      })
+      .fetchAll();
+    const member = members[0];
+    if (!member || typeof member.pinHash !== 'string' || !member.pinHash) {
+      // Constant-time miss against FAKE_HASH so attackers can't enumerate
+      // names or distinguish "no member" from "no PIN" by timing.
+      await verifyPin(pin, FAKE_HASH);
+      return FAIL();
+    }
+    const ok = await verifyPin(pin, member.pinHash);
+    if (!ok) return FAIL();
+
+    // PIN matched a member without a session player. If the active session
+    // is open and has capacity, auto-create the session player so this call
+    // doubles as "sign in + sign up for this week" — the natural mental
+    // model for a returning user on a new session. Otherwise return an
+    // identity-only success with no deleteToken.
+    const sessionContainer = getContainer('sessions');
+    const { resources: sessions } = await sessionContainer.items
+      .query({ query: 'SELECT * FROM c WHERE c.id = @id', parameters: [{ name: '@id', value: sessionId }] })
+      .fetchAll();
+    const sessionData = sessions[0];
+    const maxPlayers = sessionData?.maxPlayers ?? parseInt(process.env.NEXT_PUBLIC_MAX_PLAYERS ?? '12', 10);
+    const signupBlocked =
+      sessionData?.signupOpen === false ||
+      (sessionData?.deadline && new Date() > new Date(sessionData.deadline));
+
+    if (signupBlocked) {
+      return NextResponse.json({ deleteToken: null });
+    }
+
+    const { resources: active } = await container.items
+      .query({
+        query:
+          'SELECT * FROM c WHERE c.sessionId = @sessionId AND (NOT IS_DEFINED(c.removed) OR c.removed != true) AND (NOT IS_DEFINED(c.waitlisted) OR c.waitlisted != true)',
+        parameters: [{ name: '@sessionId', value: sessionId }],
+      })
+      .fetchAll();
+    if (active.length >= maxPlayers) {
+      return NextResponse.json({ deleteToken: null });
+    }
+
+    const newDeleteToken = randomBytes(16).toString('hex');
+    const newPlayer = {
+      id: randomBytes(12).toString('hex'),
+      name: member.name,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      deleteToken: newDeleteToken,
+      paid: false,
+      removed: false,
+      waitlisted: false,
+      memberId: member.id,
+      pinHash: member.pinHash,
+      recoveryEvents: [{ event: 'recovered-via-pin', at: new Date().toISOString() }],
+    };
+    await container.items.create(newPlayer);
+    return NextResponse.json({ deleteToken: newDeleteToken });
+  }
+
   // Constant-time miss: do a real verify against FAKE_HASH so latency matches
   // a real failed verify and an attacker can't distinguish "no player" from "wrong PIN".
   if (!player) {

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -87,6 +87,14 @@ export async function POST(req: NextRequest) {
         })
         .fetchAll();
       const existingMember = existingMembers[0];
+      // Refuse to overwrite an existing PIN. Otherwise anyone who knows a
+      // member's name could hijack the account by "creating an account" for
+      // them with a new PIN. Pre-seeded members without a PIN can still be
+      // claimed (this is the friend-group beta flow — admin seeds names,
+      // friends claim by setting the first PIN).
+      if (existingMember && typeof existingMember.pinHash === 'string' && existingMember.pinHash.length > 0) {
+        return NextResponse.json({ error: 'account_exists' }, { status: 409 });
+      }
       const memberDoc = {
         ...(existingMember ?? {
           id: randomBytes(12).toString('hex'),
@@ -143,7 +151,7 @@ export async function POST(req: NextRequest) {
 
     // Members-based identity check
     const allMembers = membersRes.resources;
-    let matchedMember: { id: string; name: string; sessionCount: number; [key: string]: unknown } | null = null;
+    let matchedMember: { id: string; name: string; sessionCount: number; pinHash?: string; [key: string]: unknown } | null = null;
     if (allMembers.length > 0) {
       matchedMember = allMembers.find(
         (m: { name: string }) => m.name.toLowerCase() === trimmedName.toLowerCase()
@@ -151,6 +159,14 @@ export async function POST(req: NextRequest) {
       if (!matchedMember && !isAdminAuthed(req)) {
         return NextResponse.json({ error: 'invite_list_not_found', name: trimmedName }, { status: 403 });
       }
+    }
+
+    // PIN-protected member: the signup path is anonymous (just a name) and
+    // can't tell whether the requester is the legitimate owner. Forcing
+    // them through the sign-in flow (which verifies PIN against
+    // members.pinHash) closes the impersonation hole. Admins bypass.
+    if (matchedMember && typeof matchedMember.pinHash === 'string' && matchedMember.pinHash.length > 0 && !isAdminAuthed(req)) {
+      return NextResponse.json({ error: 'pin_required' }, { status: 401 });
     }
 
     const anyExisting = existingRes.resources;

--- a/app/globals.css
+++ b/app/globals.css
@@ -980,6 +980,14 @@ textarea {
   to { opacity: 1; transform: scaleY(1); }
 }
 
+/* Baddicon pop — fires when a digit is typed in PinInput. Spring easing
+   gives a tiny overshoot so the icon feels physical, not pasted on. */
+@keyframes baddicon-pop {
+  0% { transform: scale(0.4) rotate(-12deg); opacity: 0; }
+  60% { transform: scale(1.15) rotate(4deg); opacity: 1; }
+  100% { transform: scale(1) rotate(0); opacity: 1; }
+}
+
 .animate-fadeIn {
   animation: fadeIn var(--duration-normal) var(--ease-glass) both;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,6 @@ import GlassPhysics from '@/components/GlassPhysics';
 import ThemeToggle from '@/components/ThemeToggle';
 import LanguageToggle from '@/components/LanguageToggle';
 import DevPanel, { type DevOverrides } from '@/components/DevPanel';
-import ForcePinModal from '@/components/ForcePinModal';
 import { getIdentity } from '@/lib/identity';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH || '';
@@ -114,7 +113,6 @@ export default function Page() {
                 sessionLabel={profileSession.label}
                 isAdmin={showAdmin}
                 onAdminTools={() => setActiveTab('admin')}
-                onTabChange={(tab) => setActiveTab(tab)}
               />
             </div>
           )}
@@ -122,10 +120,6 @@ export default function Page() {
         {devMode && <DevPanel overrides={devOverrides} onChange={setDevOverrides} />}
         <BottomNav activeTab={activeTab} onTabChange={setActiveTab} showAdmin={showAdmin} />
       </div>
-      {/* Force-PIN modal — fires when there's an existing identity without a
-          PIN. Mounted at the root above all tabs so it can block any path
-          into the app until the user sets a PIN or signs out. */}
-      <ForcePinModal />
     </>
   );
 }

--- a/components/AdminTab.tsx
+++ b/components/AdminTab.tsx
@@ -43,13 +43,13 @@ export default function AdminTab() {
       if (res.ok) {
         setIsAuthed(true);
       } else if (res.status === 429) {
-        setError('Too many attempts. Try again in 15 minutes.');
+        setError(pageT('signInErrorRateLimited'));
       } else {
-        setError('Incorrect name or PIN.');
+        setError(pageT('signInErrorInvalid'));
         setPin('');
       }
     } catch {
-      setError('Network error.');
+      setError(pageT('signInErrorNetwork'));
     } finally {
       setChecking(false);
     }
@@ -78,17 +78,17 @@ export default function AdminTab() {
           <div className="glass-card p-6 w-full max-w-xs space-y-5">
             <div className="text-center">
               <span className="material-icons icon-xl text-green-400">lock</span>
-              <p className="text-sm text-gray-400 mt-2">Sign in with your name and PIN</p>
+              <p className="text-sm text-gray-400 mt-2">{pageT('signInHelp')}</p>
             </div>
             <form onSubmit={handleSubmit} className="space-y-3">
               <div>
-                <label htmlFor="admin-name" className="sr-only">Name</label>
+                <label htmlFor="admin-name" className="sr-only">{pageT('nameLabel')}</label>
                 <input
                   id="admin-name"
                   name="name"
                   type="text"
-                  placeholder="Your name"
-                  aria-label="Your name"
+                  placeholder={pageT('namePlaceholder')}
+                  aria-label={pageT('nameLabel')}
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   maxLength={50}
@@ -100,7 +100,7 @@ export default function AdminTab() {
                 value={pin}
                 onChange={setPin}
                 digits={4}
-                label="PIN"
+                label={pageT('pinLabel')}
                 ariaInvalid={!!error}
                 autoFocus={!!name}
               />
@@ -110,7 +110,7 @@ export default function AdminTab() {
                 disabled={checking || !name.trim() || pin.length !== 4}
                 className="btn-primary w-full"
               >
-                {checking ? 'Checking\u2026' : 'Sign in'}
+                {checking ? pageT('signInChecking') : pageT('signInButton')}
               </button>
             </form>
           </div>

--- a/components/CreateAccountSheet.tsx
+++ b/components/CreateAccountSheet.tsx
@@ -1,0 +1,137 @@
+'use client';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { BottomSheet, BottomSheetHeader, BottomSheetBody } from './BottomSheet';
+import PinInput from './PinInput';
+import { setIdentity } from '@/lib/identity';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  sessionId: string;
+}
+
+type ErrorKind = 'mismatch' | 'too_common' | 'invalid' | 'rate_limited' | 'network' | 'name_required' | 'account_exists' | null;
+
+export default function CreateAccountSheet({ open, onClose, sessionId }: Props) {
+  const t = useTranslations('profile.createAccount');
+  const tRecovery = useTranslations('recovery');
+  const [name, setName] = useState('');
+  const [pin, setPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [error, setError] = useState<ErrorKind>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [successName, setSuccessName] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && pin.length === 4 && confirmPin.length === 4 && !submitting;
+
+  async function submit() {
+    setError(null);
+    if (!trimmed) { setError('name_required'); return; }
+    if (pin !== confirmPin) { setError('mismatch'); return; }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${BASE}/api/players`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed, pin, sessionSignup: false }),
+      });
+      if (res.status === 429) { setError('rate_limited'); return; }
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        if (data.error === 'pin_too_common') { setError('too_common'); return; }
+        if (data.error === 'Invalid PIN format') { setError('invalid'); return; }
+        if (data.error === 'account_exists') { setError('account_exists'); return; }
+        setError('network');
+        return;
+      }
+      setIdentity({ name: trimmed, sessionId });
+      setSuccessName(trimmed);
+      setTimeout(() => {
+        onClose();
+        setSuccessName(null);
+        setName('');
+        setPin('');
+        setConfirmPin('');
+      }, 1500);
+    } catch {
+      setError('network');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} ariaLabel={t('title')} maxHeight="75vh" className="max-w-lg mx-auto">
+      <BottomSheetHeader className="flex items-center justify-between p-4">
+        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('title')}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={tRecovery('close')}
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+        </button>
+      </BottomSheetHeader>
+      <BottomSheetBody className="p-5 pb-8">
+        {successName ? (
+          <p style={{ textAlign: 'center', fontSize: 18, color: 'var(--text-primary)' }}>
+            {t('successWelcome', { name: successName })}
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>{t('body')}</p>
+            <input
+              type="text"
+              aria-label={t('nameLabel')}
+              placeholder={t('namePlaceholder')}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={50}
+              autoComplete="username"
+            />
+            <div>
+              <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{t('pinLabel')}</p>
+              <PinInput value={pin} onChange={setPin} digits={4} label={t('pinLabel')} ariaInvalid={error === 'invalid' || error === 'too_common'} />
+            </div>
+            <div>
+              <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{t('confirmPinLabel')}</p>
+              <PinInput value={confirmPin} onChange={setConfirmPin} digits={4} label={t('confirmPinLabel')} ariaInvalid={error === 'mismatch'} />
+            </div>
+            <button
+              type="button"
+              disabled={!canSubmit}
+              onClick={submit}
+              className="btn-primary"
+              style={{ marginTop: 4, width: '100%' }}
+            >
+              {submitting ? t('submitting') : t('submit')}
+            </button>
+            {error === 'mismatch' && (
+              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>{t('errorMismatch')}</p>
+            )}
+            {error === 'too_common' && (
+              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>{t('errorTooCommon')}</p>
+            )}
+            {error === 'invalid' && (
+              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>{t('errorInvalid')}</p>
+            )}
+            {error === 'rate_limited' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorRateLimited')}</p>
+            )}
+            {error === 'network' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorNetwork')}</p>
+            )}
+            {error === 'account_exists' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorAccountExists')}</p>
+            )}
+          </div>
+        )}
+      </BottomSheetBody>
+    </BottomSheet>
+  );
+}

--- a/components/ForcePinModal.tsx
+++ b/components/ForcePinModal.tsx
@@ -32,6 +32,13 @@ export default function ForcePinModal() {
 
   // Decide on mount whether to fire. Re-evaluates only when identity or the
   // localStorage flag would have changed (after signup, set-pin, or sign-out).
+  //
+  // Post auth-taxonomy split (PR B): every new identity creation path
+  // (HomeTab signup, CreateAccountSheet, RecoverySheet) explicitly sets
+  // `badminton_pin_set: 'true'`, so this modal effectively only fires for
+  // *legacy* PIN-less identities — players who signed up before PR #41 made
+  // PIN mandatory and never set one through the Profile editor. If the
+  // legacy population reaches zero, this whole component can be deleted.
   useEffect(() => {
     function evaluate() {
       const id = getIdentity();

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -12,8 +12,8 @@ import PrevPaymentReminder from '@/components/PrevPaymentReminder';
 import ReleaseNotesTrigger from './ReleaseNotesTrigger';
 import ReleaseNotesSheet from './ReleaseNotesSheet';
 import WelcomeCard from './WelcomeCard';
-import PinInput from '@/components/PinInput';
 import StatusBanner from '@/components/primitives/StatusBanner';
+import RecoverySheet from './RecoverySheet';
 import { renderMarkdown } from '@/lib/miniMarkdown';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
@@ -36,15 +36,17 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [memberNames, setMemberNames] = useState<string[]>([]);
   const [hasIdentity, setHasIdentity] = useState(false);
-  // PIN is mandatory at signup per the auth revamp (PR C). No more deferred
-  // SetPinSheet — collect upfront so existing-account fragility goes away.
-  const [pinValue, setPinValue] = useState('');
+  // Sign up = session signup only (auth taxonomy split). PIN is no longer
+  // collected here — it's an opt-in identity primitive, set via Profile →
+  // Create account / Set PIN. Returning players who already have a PIN can
+  // tap "Already a player? Sign in →" to authenticate via RecoverySheet.
   const [onboardingDismissed, setOnboardingDismissed] = useState(() => {
     if (typeof window === 'undefined') return true;
     return localStorage.getItem('badminton_onboarding_dismissed') === 'true';
   });
   const [releases, setReleases] = useState<Release[]>([]);
   const [releaseSheetOpen, setReleaseSheetOpen] = useState(false);
+  const [signInOpen, setSignInOpen] = useState(false);
 
   const maxPlayers = parseInt(process.env.NEXT_PUBLIC_MAX_PLAYERS ?? '12');
 
@@ -172,21 +174,23 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
   async function handleSignUp(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim()) { setError(t('signup.nameRequired')); return; }
-    if (pinValue.length !== 4) { setError(t('signup.pinRequired')); return; }
     setIsSubmitting(true);
     setError('');
     try {
       const res = await fetch(`${BASE}/api/players`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name.trim(), pin: pinValue }),
+        body: JSON.stringify({ name: name.trim() }),
       });
       const data = await res.json();
       if (!res.ok) {
         if (data.error === 'invite_list_not_found') {
           setError(t('signup.inviteError', { name: name.trim() }));
-        } else if (data.error === 'pin_too_common') {
-          setError(t('signup.pinTooCommon'));
+        } else if (data.error === 'pin_required') {
+          // Member is PIN-protected — open Sign In sheet instead of letting
+          // an anonymous request claim their session slot.
+          setSignInOpen(true);
+          setError('');
         } else {
           setError(data.error ?? t('signup.genericFailure'));
         }
@@ -195,10 +199,6 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
         setIdentity({ name: name.trim(), token: data.deleteToken ?? '', sessionId: session?.id ?? '' });
         setCurrentUser(name.trim());
         setHasIdentity(true);
-        // PIN was collected at signup; mark it set so the force-PIN modal
-        // doesn't fire on next visit.
-        localStorage.setItem('badminton_pin_set', 'true');
-        setPinValue('');
         await loadData();
       }
     } catch {
@@ -211,21 +211,21 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
   async function handleJoinWaitlist(e: React.FormEvent) {
     e.preventDefault();
     if (!name.trim()) { setError(t('signup.nameRequired')); return; }
-    if (pinValue.length !== 4) { setError(t('signup.pinRequired')); return; }
     setIsSubmitting(true);
     setError('');
     try {
       const res = await fetch(`${BASE}/api/players`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name.trim(), waitlist: true, pin: pinValue }),
+        body: JSON.stringify({ name: name.trim(), waitlist: true }),
       });
       const data = await res.json();
       if (!res.ok) {
         if (data.error === 'invite_list_not_found') {
           setError(t('signup.inviteError', { name: name.trim() }));
-        } else if (data.error === 'pin_too_common') {
-          setError(t('signup.pinTooCommon'));
+        } else if (data.error === 'pin_required') {
+          setSignInOpen(true);
+          setError('');
         } else {
           setError(data.error ?? t('signup.waitlistFailure'));
         }
@@ -233,8 +233,6 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
         setIdentity({ name: name.trim(), token: data.deleteToken ?? '', sessionId: session?.id ?? '' });
         setCurrentUser(name.trim());
         setHasIdentity(true);
-        localStorage.setItem('badminton_pin_set', 'true');
-        setPinValue('');
         await loadData();
       }
     } catch {
@@ -446,18 +444,10 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
                   </ul>
                 )}
               </div>
-              <PinInput
-                value={pinValue}
-                onChange={setPinValue}
-                digits={4}
-                label={t('signup.pinLabel')}
-                ariaInvalid={!!error}
-              />
-              <p className="text-[11px] text-gray-400 leading-snug">{t('signup.pinHint')}</p>
               {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
               <button
                 type="submit"
-                disabled={isSubmitting || !name.trim() || pinValue.length !== 4}
+                disabled={isSubmitting || !name.trim()}
                 className="btn-primary w-full"
               >
                 {isSubmitting ? t('signup.joining') : t('signup.waitlist')}
@@ -510,22 +500,22 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
                   </ul>
                 )}
               </div>
-              <PinInput
-                value={pinValue}
-                onChange={setPinValue}
-                digits={4}
-                label={t('signup.pinLabel')}
-                ariaInvalid={!!error}
-              />
-              <p className="text-[11px] text-gray-400 leading-snug">{t('signup.pinHint')}</p>
               {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
               <button
                 type="submit"
-                disabled={isSubmitting || !name.trim() || pinValue.length !== 4}
+                disabled={isSubmitting || !name.trim()}
                 className="btn-primary w-full"
               >
                 {!isSubmitting && <span className="material-icons icon-sm" aria-hidden="true">how_to_reg</span>}
                 {isSubmitting ? t('signup.submitting') : t('signup.button')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setSignInOpen(true)}
+                className="text-center text-xs underline"
+                style={{ color: 'var(--text-secondary)', background: 'transparent', border: 'none', cursor: 'pointer', padding: '8px 12px', minHeight: 44, alignSelf: 'center' }}
+              >
+                {t('signup.alreadyPlayer')}
               </button>
               {session?.deadline && (
                 <p className={`text-center text-xs font-medium ${isDeadlineApproaching ? 'text-red-400' : 'text-gray-400'}`}>
@@ -536,6 +526,19 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
           </div>
         )}
       </div>
+      <RecoverySheet
+        open={signInOpen}
+        onClose={() => {
+          setSignInOpen(false);
+          // Refresh identity and active player after sign-in.
+          const fresh = getIdentity();
+          if (fresh) {
+            setHasIdentity(true);
+            setCurrentUser(fresh.name);
+          }
+        }}
+        sessionId={session?.id ?? ''}
+      />
       {/* Payment reminder for previous session — visible whenever the player
           has identity (i.e. has signed up before), not only when signed up
           for the current session. Addresses research finding 4.8. */}

--- a/components/PinInput.tsx
+++ b/components/PinInput.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useId, type CSSProperties } from 'react';
 
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
 interface Props {
   value: string;
   onChange: (v: string) => void;
@@ -11,12 +13,18 @@ interface Props {
   ariaInvalid?: boolean;
 }
 
+// Cycle the three brand baddicons (pink / yellow / green from
+// public/brand/*.svg) one per typed digit. Empty fields show no icons, so
+// the input doesn't leak max length at a glance. Filename `baddicon-yello`
+// is intentionally short — that's how the asset ships.
+const BADDICONS = ['pink', 'yello', 'green'];
+
 export default function PinInput({
   value, onChange, digits, label, autoFocus, disabled, ariaInvalid,
 }: Props) {
   const id = useId();
   return (
-    <div>
+    <div style={{ position: 'relative' }}>
       <label htmlFor={id} className="sr-only">{label}</label>
       <input
         id={id}
@@ -25,7 +33,7 @@ export default function PinInput({
         // a stored-password reuse check on every type="password" field, which
         // flags this site as "Dangerous" with a "Check your passwords"
         // overlay when the user types a PIN that matches a saved password
-        // for any other domain. The visual masking below preserves
+        // for any other domain. The shuttlecock overlay below preserves
         // shoulder-surf protection without engaging Chrome's heuristic.
         type="text"
         inputMode="numeric"
@@ -38,29 +46,53 @@ export default function PinInput({
         disabled={disabled}
         aria-label={label}
         aria-invalid={ariaInvalid || undefined}
-        placeholder={'•'.repeat(digits)}
+        placeholder={value ? '' : label}
         style={{
-          fontFamily: 'var(--font-mono)',
-          // Scale type down on narrow viewports so 4/6 dots + letter-spacing
-          // never overflow at 320px. clamp(min, preferred, max).
-          fontSize: 'clamp(20px, 6.5vw, 28px)',
-          letterSpacing: '0.35em',
-          textAlign: 'center',
-          padding: '12px 14px',
-          borderRadius: 12,
-          border: ariaInvalid ? '1px solid var(--color-red, #ef4444)' : '1px solid var(--glass-border)',
-          background: 'var(--input-bg, rgba(255,255,255,0.05))',
-          color: 'var(--text-primary)',
-          width: '100%',
-          // Visual masking — renders typed digits as dots without the
-          // type="password" semantic. Supported in Chrome/Safari/Edge and
-          // Firefox 116+. If a Firefox user pre-dates that, digits show as
-          // plain text — acceptable trade-off vs the Chrome warning.
-          // `WebkitTextSecurity` isn't in csstype's CSSProperties yet, so
-          // we cast through a vendor-extension intersection type.
-          WebkitTextSecurity: 'disc',
-        } as CSSProperties & { WebkitTextSecurity?: 'none' | 'disc' | 'circle' | 'square' }}
+          // Inherit canonical input styles from globals.css (14px radius,
+          // 11px 14px padding, --input-bg/--input-border, focus ring). Only
+          // override what's specific to PinInput: hide typed characters but
+          // keep the caret beam so the user has typing feedback alongside
+          // the baddicon overlay. Letter-spacing only applies when there's
+          // a typed value — placeholder text stays at canonical body size,
+          // and the caret advances ~30px per digit to align with the
+          // baddicon slot pitch (24px icon + 6px gap).
+          color: 'transparent',
+          caretColor: 'var(--text-primary)',
+          ...(value.length > 0 ? { letterSpacing: '22px' } : {}),
+        } as CSSProperties}
       />
+      {value.length > 0 && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: 14,
+            top: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            pointerEvents: 'none',
+          }}
+        >
+          {Array.from({ length: value.length }, (_, i) => (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={i}
+              src={`${BASE}/brand/baddicon-${BADDICONS[i % BADDICONS.length]}.svg`}
+              alt=""
+              aria-hidden="true"
+              width={24}
+              style={{
+                height: 22,
+                width: 24,
+                flexShrink: 0,
+                animation: 'baddicon-pop 320ms var(--ease-spring) both',
+              }}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/PlayersTab.tsx
+++ b/components/PlayersTab.tsx
@@ -125,7 +125,7 @@ export default function PlayersTab() {
                   <span className="flex-1 text-sm text-gray-200 font-medium">
                     {player.name}
                     {isMe && (
-                      <span className="ml-1.5 text-xs text-green-400 font-normal">
+                      <span className="ml-1.5 text-xs font-normal" style={{ color: 'var(--text-muted)' }}>
                         {t('youSuffix')}
                       </span>
                     )}
@@ -183,7 +183,7 @@ export default function PlayersTab() {
                     <span className="flex-1 text-sm text-gray-400 font-medium">
                       {player.name}
                       {isMe && (
-                        <span className="ml-1.5 text-xs text-amber-400 font-normal">
+                        <span className="ml-1.5 text-xs font-normal" style={{ color: 'var(--text-muted)' }}>
                           {t('youSuffix')}
                         </span>
                       )}

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -3,10 +3,13 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { getIdentity, clearIdentity, type Identity } from '@/lib/identity';
 import type { Release } from '@/lib/types';
-import RecoverySheet from './RecoverySheet';
 import EnterCodeSheet from './EnterCodeSheet';
+import CreateAccountSheet from './CreateAccountSheet';
+import RecoveryPinSheet from './RecoveryPinSheet';
 import ReleaseNotesSheet from './ReleaseNotesSheet';
 import PinInput from './PinInput';
+// PinInput is used by the inline anonymous sign-in form below. The signed-in
+// state's PIN management lives in RecoveryPinSheet now (opened via Settings).
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -15,12 +18,6 @@ interface Props {
   sessionLabel: string;
   isAdmin: boolean;
   onAdminTools: () => void;
-  /**
-   * Called when the user taps the "Sign up for this week" CTA in the
-   * anonymous state — navigates them to the Home tab where the signup form
-   * lives. Optional: if absent, the CTA is hidden.
-   */
-  onTabChange?: (tab: 'home') => void;
 }
 
 export default function ProfileTab({
@@ -28,20 +25,22 @@ export default function ProfileTab({
   sessionLabel,
   isAdmin,
   onAdminTools,
-  onTabChange,
 }: Props) {
   const t = useTranslations('profile');
-  const tPin = useTranslations('pin');
   const [identity, setLocalIdentity] = useState<Identity | null>(null);
   const [pinIsSet, setPinIsSet] = useState(false);
-  const [recoveryOpen, setRecoveryOpen] = useState(false);
   const [enterCodeOpen, setEnterCodeOpen] = useState(false);
+  const [createAccountOpen, setCreateAccountOpen] = useState(false);
+  // Anonymous-state inline sign-in form. Replaces the old RecoverySheet path
+  // for fresh visitors per the auth taxonomy split.
+  const [signInName, setSignInName] = useState('');
+  const [signInPin, setSignInPin] = useState('');
+  const [signInError, setSignInError] = useState<'invalid' | 'rate_limited' | 'admin_logged_in' | null>(null);
+  const [signInSubmitting, setSignInSubmitting] = useState(false);
+  // Signed-in state PIN management: tap the Settings "Recovery PIN" row to
+  // open RecoveryPinSheet (set / change / remove + forgot-it handoff).
+  const [recoveryPinOpen, setRecoveryPinOpen] = useState(false);
   const tRecovery = useTranslations('recovery');
-  const [editingPin, setEditingPin] = useState(false);
-  const [newPin, setNewPin] = useState('');
-  const [confirmPin, setConfirmPin] = useState('');
-  const [pinError, setPinError] = useState<'too_common' | 'invalid' | null>(null);
-  const [pinSaved, setPinSaved] = useState(false);
   const [releaseSheetOpen, setReleaseSheetOpen] = useState(false);
   const [releases, setReleases] = useState<Release[]>([]);
   const tSettings = useTranslations('profile.settings');
@@ -50,81 +49,140 @@ export default function ProfileTab({
   useEffect(() => {
     const id = getIdentity();
     setLocalIdentity(id);
-    if (id) {
-      const hint = localStorage.getItem('badminton_pin_set');
-      setPinIsSet(hint === 'true');
-    }
     fetch(`${BASE}/api/releases`, { cache: 'no-store' })
       .then((r) => (r.ok ? r.json() : []))
       .then((data: Release[]) => setReleases(Array.isArray(data) ? data : []))
       .catch(() => setReleases([]));
   }, []);
 
+  // Reflect server-side pin status whenever identity changes (mount, sign-in,
+  // logout). Source of truth is `members.pinHash` mirrored from the player
+  // record — `/api/members/me` returns `hasPin` as a derived boolean. Avoids
+  // the previous localStorage-flag approach which de-synced after sign-in
+  // and was the bug behind "Recovery PIN: Not set" until refresh.
+  useEffect(() => {
+    if (!identity) {
+      setPinIsSet(false);
+      return;
+    }
+    let cancelled = false;
+    fetch(`${BASE}/api/members/me?name=${encodeURIComponent(identity.name)}`, { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : { hasPin: false }))
+      .then((data: { hasPin?: boolean }) => {
+        if (!cancelled) setPinIsSet(data.hasPin === true);
+      })
+      .catch(() => {
+        if (!cancelled) setPinIsSet(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [identity]);
+
   function handleLogout() {
     clearIdentity();
-    localStorage.removeItem('badminton_pin_set');
-    localStorage.removeItem('badminton_pin_prompted');
     setLocalIdentity(null);
     setPinIsSet(false);
   }
 
-  async function savePin(value: string | null) {
-    if (!identity) return;
-    setPinError(null);
-    const meRes = await fetch(`${BASE}/api/players`, { cache: 'no-store' });
-    const players = (await meRes.json()) as { id: string; name: string; sessionId: string }[];
-    const me = players.find(
-      (p) => p.name.toLowerCase() === identity.name.toLowerCase() && p.sessionId === identity.sessionId,
-    );
-    if (!me) {
-      setPinError('invalid');
-      return;
+  // Anonymous state — Profile is identity-only. Inline sign-in form (name +
+  // PIN) sits in the glass card; "Create an account" lives below an "or"
+  // divider and opens an action sheet. Session signup belongs on Home, not
+  // here.
+  async function submitSignIn(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = signInName.trim();
+    if (!trimmed || signInPin.length !== 4) return;
+    setSignInError(null);
+    setSignInSubmitting(true);
+    try {
+      const res = await fetch(`${BASE}/api/players/recover`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed, sessionId, pin: signInPin }),
+      });
+      if (res.status === 429) { setSignInError('rate_limited'); return; }
+      if (res.status === 403) { setSignInError('admin_logged_in'); return; }
+      if (!res.ok) { setSignInError('invalid'); return; }
+      const body = await res.json();
+      const { setIdentity } = await import('@/lib/identity');
+      setIdentity({ name: trimmed, token: body.deleteToken, sessionId });
+      setLocalIdentity(getIdentity());
+    } finally {
+      setSignInSubmitting(false);
     }
-    const patchRes = await fetch(`${BASE}/api/players`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: me.id, pin: value, deleteToken: identity.token }),
-    });
-    if (!patchRes.ok) {
-      const body = await patchRes.json().catch(() => ({}));
-      setPinError(body.error === 'pin_too_common' ? 'too_common' : 'invalid');
-      return;
-    }
-    setPinIsSet(value !== null);
-    localStorage.setItem('badminton_pin_set', value !== null ? 'true' : 'false');
-    setPinSaved(true);
-    setEditingPin(false);
-    setNewPin('');
-    setConfirmPin('');
-    setTimeout(() => setPinSaved(false), 2000);
   }
-
-  // Anonymous state — three clear paths: sign up new, restore via PIN, or
-  // enter a recovery code from admin. Replaces the old "Restore-only" state
-  // which left first-timers without a path forward.
   if (!identity) {
+    const canSubmit = signInName.trim().length > 0 && signInPin.length === 4 && !signInSubmitting;
     return (
       <div className="animate-fadeIn flex flex-col gap-4">
-        <h2 className="bpm-h1">{t('anonymousTitle')}</h2>
+        <h1 className="bpm-h1">{t('anonymousTitle')}</h1>
         <p style={{ color: 'var(--text-secondary)' }}>{t('anonymousBody')}</p>
-        <div className="glass-card" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {onTabChange && (
+        <div className="glass-card" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <form onSubmit={submitSignIn} style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <input
+              type="text"
+              aria-label={t('anonymousNamePlaceholder')}
+              placeholder={t('anonymousNamePlaceholder')}
+              value={signInName}
+              onChange={(e) => { setSignInName(e.target.value); setSignInError(null); }}
+              autoComplete="username"
+              maxLength={50}
+            />
+            <PinInput
+              value={signInPin}
+              onChange={(v) => { setSignInPin(v); setSignInError(null); }}
+              digits={4}
+              label={t('anonymousPinLabel')}
+              ariaInvalid={signInError === 'invalid'}
+            />
             <button
-              type="button"
-              onClick={() => onTabChange('home')}
+              type="submit"
+              disabled={!canSubmit}
               className="btn-primary"
               style={{ width: '100%' }}
             >
-              {t('anonymousSignupCta')}
+              {signInSubmitting ? t('anonymousSignInChecking') : t('anonymousSignInButton')}
             </button>
-          )}
+            {signInError === 'invalid' && (
+              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12, margin: 0 }}>
+                {t('anonymousSignInErrorInvalid')}
+              </p>
+            )}
+            {signInError === 'rate_limited' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12, margin: 0 }}>
+                {t('anonymousSignInErrorRateLimited')}
+              </p>
+            )}
+            {signInError === 'admin_logged_in' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12, margin: 0 }}>
+                {t('anonymousSignInErrorAdminLogged')}
+              </p>
+            )}
+          </form>
+          <div
+            aria-hidden="true"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              color: 'var(--text-muted)',
+              fontSize: 11,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+            }}
+          >
+            <span style={{ flex: 1, height: 1, background: 'var(--glass-border)' }} />
+            <span>{t('anonymousOrDivider')}</span>
+            <span style={{ flex: 1, height: 1, background: 'var(--glass-border)' }} />
+          </div>
           <button
             type="button"
-            onClick={() => setRecoveryOpen(true)}
+            onClick={() => setCreateAccountOpen(true)}
             className="btn-ghost"
             style={{ width: '100%' }}
           >
-            {t('anonymousRestoreLink')}
+            {t('anonymousCreateCta')}
           </button>
           <button
             type="button"
@@ -146,11 +204,14 @@ export default function ProfileTab({
             {tRecovery('haveCodeLink')}
           </button>
         </div>
-        <RecoverySheet
-          open={recoveryOpen}
-          onClose={() => setRecoveryOpen(false)}
+        <CreateAccountSheet
+          open={createAccountOpen}
+          onClose={() => {
+            setCreateAccountOpen(false);
+            // Refresh identity if the sheet set it.
+            setLocalIdentity(getIdentity());
+          }}
           sessionId={sessionId}
-          onForgotPin={() => setEnterCodeOpen(true)}
         />
         <EnterCodeSheet
           open={enterCodeOpen}
@@ -183,93 +244,19 @@ export default function ProfileTab({
           )}
         </div>
 
-        <div className="glass-card-soft" style={{ padding: 16 }}>
-          <h3 className="text-sm font-semibold mb-3">{t('pinSectionTitle')}</h3>
-          {!editingPin ? (
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--text-secondary)', fontSize: 13 }}>
-                <span
-                  className="material-icons"
-                  aria-hidden="true"
-                  style={{ fontSize: 16, color: pinIsSet ? 'var(--color-green, #10b981)' : 'var(--text-muted)' }}
-                >
-                  {pinIsSet ? 'check_circle' : 'radio_button_unchecked'}
-                </span>
-                {pinIsSet ? t('pinIsSet') : t('pinNotSet')}
-              </span>
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button type="button" onClick={() => setEditingPin(true)} className="btn-ghost">
-                  {pinIsSet ? t('pinChangeButton') : t('pinSetButton')}
-                </button>
-                {pinIsSet && (
-                  <button type="button" onClick={() => savePin(null)} className="btn-ghost">
-                    {t('pinRemoveButton')}
-                  </button>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-              <div>
-                <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('newLabel')}</p>
-                <PinInput value={newPin} onChange={setNewPin} digits={4} label={tPin('newLabel')} autoFocus />
-              </div>
-              <div>
-                <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('confirmLabel')}</p>
-                <PinInput value={confirmPin} onChange={setConfirmPin} digits={4} label={tPin('confirmLabel')} />
-              </div>
-              {pinError === 'too_common' && (
-                <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)' }}>
-                  {t('pinTooCommon')}
-                </p>
-              )}
-              {pinError === 'invalid' && (
-                <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)' }}>
-                  {t('pinInvalid')}
-                </p>
-              )}
-              <div style={{ display: 'flex', gap: 8 }}>
-                <button
-                  type="button"
-                  className="btn-primary"
-                  disabled={newPin.length !== 4 || newPin !== confirmPin}
-                  onClick={() => savePin(newPin)}
-                  style={{ flex: 1 }}
-                >
-                  {tPin('save')}
-                </button>
-                <button
-                  type="button"
-                  className="btn-ghost"
-                  onClick={() => {
-                    setEditingPin(false);
-                    setNewPin('');
-                    setConfirmPin('');
-                    setPinError(null);
-                  }}
-                  style={{ flex: 1 }}
-                >
-                  {tPin('cancel')}
-                </button>
-              </div>
-              {newPin && confirmPin && newPin !== confirmPin && (
-                <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)' }}>
-                  {tPin('mismatch')}
-                </p>
-              )}
-            </div>
-          )}
-          {pinSaved && (
-            <p style={{ fontSize: 12, color: 'var(--color-green, #10b981)', marginTop: 8 }}>
-              {t('pinSaved')}
-            </p>
-          )}
-        </div>
-
         <SettingsList
           title={tSettings('title')}
           rows={[
-            { icon: 'key', label: tSettings('forgotPin'), onClick: () => setRecoveryOpen(true) },
+            {
+              icon: 'key',
+              label: pinIsSet ? tSettings('updatePin') : tSettings('newPin'),
+              onClick: () => setRecoveryPinOpen(true),
+            },
+            {
+              icon: 'help_outline',
+              label: tSettings('recoveryCode'),
+              onClick: () => setEnterCodeOpen(true),
+            },
             { icon: 'campaign', label: tSettings('releaseNotes'), onClick: () => setReleaseSheetOpen(true) },
             ...(isAdmin
               ? [{ icon: 'admin_panel_settings', label: tSettings('adminAccess'), onClick: onAdminTools }]
@@ -279,11 +266,12 @@ export default function ProfileTab({
         />
       </div>
 
-      <RecoverySheet
-        open={recoveryOpen}
-        onClose={() => setRecoveryOpen(false)}
-        sessionId={sessionId}
-        onForgotPin={() => setEnterCodeOpen(true)}
+      <RecoveryPinSheet
+        open={recoveryPinOpen}
+        onClose={() => setRecoveryPinOpen(false)}
+        identity={identity}
+        hasPin={pinIsSet}
+        onSaved={(newHasPin) => setPinIsSet(newHasPin)}
       />
       <EnterCodeSheet
         open={enterCodeOpen}
@@ -305,6 +293,8 @@ interface SettingsRow {
   label: string;
   onClick: () => void;
   destructive?: boolean;
+  /** Right-aligned status text shown before the chevron (e.g. "Set" / "Not set"). */
+  meta?: string;
 }
 
 function SettingsList({ title, rows }: { title: string; rows: SettingsRow[] }) {
@@ -350,6 +340,9 @@ function SettingsList({ title, rows }: { title: string; rows: SettingsRow[] }) {
                 {row.icon}
               </span>
               <span style={{ flex: 1 }}>{row.label}</span>
+              {row.meta && (
+                <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{row.meta}</span>
+              )}
               <span
                 className="material-icons"
                 aria-hidden="true"

--- a/components/RecoveryPinSheet.tsx
+++ b/components/RecoveryPinSheet.tsx
@@ -1,0 +1,131 @@
+'use client';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { BottomSheet, BottomSheetHeader, BottomSheetBody } from './BottomSheet';
+import PinInput from './PinInput';
+import type { Identity } from '@/lib/identity';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  identity: Identity;
+  hasPin: boolean;
+  /** Fires after a successful save with the new state. */
+  onSaved: (newHasPin: boolean) => void;
+}
+
+type PinError = 'too_common' | 'invalid' | 'failed' | null;
+
+export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSaved }: Props) {
+  const t = useTranslations('profile');
+  const tSettings = useTranslations('profile.settings');
+  const tPin = useTranslations('pin');
+  const tRecovery = useTranslations('recovery');
+  const [newPin, setNewPin] = useState('');
+  const [confirmPin, setConfirmPin] = useState('');
+  const [pinError, setPinError] = useState<PinError>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  function reset() {
+    setNewPin('');
+    setConfirmPin('');
+    setPinError(null);
+  }
+
+  async function savePin(value: string) {
+    setPinError(null);
+    setSubmitting(true);
+    try {
+      const meRes = await fetch(`${BASE}/api/players`, { cache: 'no-store' });
+      const players = (await meRes.json()) as { id: string; name: string; sessionId: string }[];
+      const me = players.find(
+        (p) => p.name.toLowerCase() === identity.name.toLowerCase() && p.sessionId === identity.sessionId,
+      );
+      if (!me) {
+        setPinError('failed');
+        return;
+      }
+      const patchRes = await fetch(`${BASE}/api/players`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: me.id, pin: value, deleteToken: identity.token }),
+      });
+      if (!patchRes.ok) {
+        const body = await patchRes.json().catch(() => ({}));
+        if (body.error === 'pin_too_common') setPinError('too_common');
+        else if (body.error === 'Invalid PIN format') setPinError('invalid');
+        else setPinError('failed');
+        return;
+      }
+      onSaved(true);
+      reset();
+      onClose();
+    } catch {
+      setPinError('failed');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const title = hasPin ? tSettings('updatePin') : tSettings('newPin');
+  const submitLabel = hasPin ? tSettings('updatePin') : tPin('save');
+
+  return (
+    <BottomSheet open={open} onClose={onClose} ariaLabel={title} maxHeight="75vh" className="max-w-lg mx-auto">
+      <BottomSheetHeader className="flex items-center justify-between p-4">
+        <span style={{ fontSize: 16, fontWeight: 600 }}>{title}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={tRecovery('close')}
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+        </button>
+      </BottomSheetHeader>
+      <BottomSheetBody className="p-5 pb-8">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          <div>
+            <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('newLabel')}</p>
+            <PinInput value={newPin} onChange={setNewPin} digits={4} label={tPin('newLabel')} autoFocus />
+          </div>
+          <div>
+            <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('confirmLabel')}</p>
+            <PinInput value={confirmPin} onChange={setConfirmPin} digits={4} label={tPin('confirmLabel')} />
+          </div>
+          {pinError === 'too_common' && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              {t('pinTooCommon')}
+            </p>
+          )}
+          {pinError === 'invalid' && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              {t('pinInvalid')}
+            </p>
+          )}
+          {pinError === 'failed' && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              {t('pinUpdateFailed')}
+            </p>
+          )}
+          {newPin && confirmPin && newPin !== confirmPin && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              {tPin('mismatch')}
+            </p>
+          )}
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={submitting || newPin.length !== 4 || newPin !== confirmPin}
+            onClick={() => savePin(newPin)}
+            style={{ width: '100%' }}
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </BottomSheetBody>
+    </BottomSheet>
+  );
+}

--- a/components/RecoverySheet.tsx
+++ b/components/RecoverySheet.tsx
@@ -82,14 +82,6 @@ export default function RecoverySheet({ open, onClose, sessionId, onForgotPin }:
               value={name}
               onChange={(e) => setName(e.target.value)}
               autoComplete="username"
-              style={{
-                width: '100%',
-                padding: 12,
-                borderRadius: 10,
-                border: '1px solid var(--glass-border)',
-                background: 'var(--input-bg, rgba(255,255,255,0.05))',
-                color: 'var(--text-primary)',
-              }}
             />
             <PinInput
               value={pin}

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,7 +11,7 @@
       "nameRequired": "Enter your name to sign up",
       "pinRequired": "Set a 4-digit PIN to sign up",
       "pinTooCommon": "Pick a less common PIN",
-      "pinLabel": "4-digit PIN",
+      "pinLabel": "PIN",
       "pinHint": "Required. Use this PIN to recover access if you change phones.",
       "genericFailure": "Failed to sign up",
       "waitlistFailure": "Failed to join waitlist",
@@ -25,6 +25,8 @@
       "allSpotsTaken": "All {total} spots are taken.",
       "closesOn": "Sign up closes on {date}",
       "closedPreviously": "Sign-ups closed on {date}",
+      "alreadyPlayer": "Already a player? Sign in →",
+      "pinRequired": "This name has a PIN. Sign in instead.",
       "pinPrompt": {
         "cardTitle": "Add a recovery PIN",
         "cardBody": "Use this to manage your account and access your stats.",
@@ -91,7 +93,18 @@
   "pages": {
     "signup": { "title": "Sign-Up" },
     "learn": { "title": "Learn" },
-    "admin": { "title": "Admin" }
+    "admin": {
+      "title": "Admin",
+      "signInHelp": "Sign in with your name and PIN",
+      "nameLabel": "Your name",
+      "namePlaceholder": "Your name",
+      "pinLabel": "PIN",
+      "signInButton": "Sign in",
+      "signInChecking": "Checking…",
+      "signInErrorRateLimited": "Too many attempts. Try again in 15 minutes.",
+      "signInErrorInvalid": "Incorrect name or PIN.",
+      "signInErrorNetwork": "Network error."
+    }
   },
   "nav": {
     "home": "Home",
@@ -101,10 +114,35 @@
     "profile": "Profile"
   },
   "profile": {
-    "anonymousTitle": "Set up your profile",
-    "anonymousBody": "You're not signed up yet.",
-    "anonymousRestoreLink": "Already a player? Sign in →",
-    "anonymousSignupCta": "Sign up for this week",
+    "anonymousTitle": "Profile",
+    "anonymousBody": "Account creation is invite only — contact admin for inquiries (beta).",
+    "anonymousCreateCta": "Create an account",
+    "anonymousNamePlaceholder": "What is your name?",
+    "anonymousPinLabel": "PIN",
+    "anonymousSignInButton": "Sign in",
+    "anonymousSignInChecking": "Checking…",
+    "anonymousSignInErrorInvalid": "That didn't match. Try again.",
+    "anonymousSignInErrorRateLimited": "Too many tries. Try again later.",
+    "anonymousSignInErrorAdminLogged": "Signed in as admin — sign out first to recover a player account.",
+    "anonymousOrDivider": "or",
+    "anonymousRestoreLink": "Sign in",
+    "createAccount": {
+      "title": "Create your account",
+      "body": "Set a name and PIN. You can sign up for sessions afterward.",
+      "nameLabel": "Your name",
+      "namePlaceholder": "Enter your name",
+      "pinLabel": "PIN",
+      "confirmPinLabel": "Confirm PIN",
+      "submit": "Create account",
+      "submitting": "Creating…",
+      "successWelcome": "Welcome, {name}",
+      "errorMismatch": "PINs don't match",
+      "errorTooCommon": "Pick a less common PIN",
+      "errorInvalid": "PIN must be 4 digits",
+      "errorRateLimited": "Too many tries. Try again in an hour.",
+      "errorNetwork": "Network error. Please try again.",
+      "errorAccountExists": "An account with this name already exists. Sign in instead."
+    },
     "playerName": "Name",
     "playerSession": "Signed up for",
     "pinSectionTitle": "Recovery PIN",
@@ -116,11 +154,14 @@
     "pinSaved": "Saved",
     "pinTooCommon": "Pick a less common PIN",
     "pinInvalid": "PIN must be 4 digits",
+    "pinUpdateFailed": "Couldn't update PIN. Please try again.",
     "adminToolsTitle": "Admin tools",
     "adminToolsButton": "Admin tools →",
     "settings": {
       "title": "Account",
-      "forgotPin": "Forgot PIN",
+      "newPin": "New PIN",
+      "updatePin": "Update PIN",
+      "recoveryCode": "Have a recovery code?",
       "releaseNotes": "What's new",
       "adminAccess": "Admin access",
       "logout": "Log out"
@@ -200,7 +241,7 @@
   "recovery": {
     "sheetTitle": "Sign in",
     "pinPathTitle": "Use my PIN",
-    "pinPathHelp": "Enter the 4-digit PIN you set when signing up.",
+    "pinPathHelp": "Enter the PIN you set when signing up.",
     "codePathTitle": "I forgot my PIN",
     "codePathHelp": "Ask the admin for a 6-digit code, then enter it here.",
     "nameLabel": "Your name",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -11,7 +11,7 @@
       "nameRequired": "请输入您的姓名以报名",
       "pinRequired": "请设置 4 位 PIN 后报名",
       "pinTooCommon": "请使用不太常见的 PIN",
-      "pinLabel": "4 位 PIN",
+      "pinLabel": "PIN",
       "pinHint": "必填。换设备时用此 PIN 恢复账户。",
       "genericFailure": "报名失败",
       "waitlistFailure": "加入候补失败",
@@ -25,6 +25,8 @@
       "allSpotsTaken": "全部 {total} 个名额已满。",
       "closesOn": "报名截止于 {date}",
       "closedPreviously": "报名已于 {date} 截止",
+      "alreadyPlayer": "已经是球员？登录 →",
+      "pinRequired": "该名字已设置 PIN，请登录。",
       "pinPrompt": {
         "cardTitle": "添加恢复 PIN",
         "cardBody": "用于管理账号和查看个人数据。",
@@ -91,7 +93,18 @@
   "pages": {
     "signup": { "title": "报名" },
     "learn": { "title": "进阶技能" },
-    "admin": { "title": "管理" }
+    "admin": {
+      "title": "管理",
+      "signInHelp": "用你的名字和 PIN 登录",
+      "nameLabel": "你的名字",
+      "namePlaceholder": "你的名字",
+      "pinLabel": "PIN",
+      "signInButton": "登录",
+      "signInChecking": "验证中…",
+      "signInErrorRateLimited": "尝试次数过多，请 15 分钟后再试。",
+      "signInErrorInvalid": "名字或 PIN 不正确。",
+      "signInErrorNetwork": "网络错误。"
+    }
   },
   "nav": {
     "home": "首页",
@@ -101,10 +114,35 @@
     "profile": "档案"
   },
   "profile": {
-    "anonymousTitle": "设置你的档案",
-    "anonymousBody": "你还没注册。",
-    "anonymousRestoreLink": "已经是球员？登录 →",
-    "anonymousSignupCta": "报名本周场次",
+    "anonymousTitle": "档案",
+    "anonymousBody": "仅限受邀创建账号 — 如有疑问请联系管理员（测试版）。",
+    "anonymousCreateCta": "创建账号",
+    "anonymousNamePlaceholder": "你叫什么名字？",
+    "anonymousPinLabel": "PIN",
+    "anonymousSignInButton": "登录",
+    "anonymousSignInChecking": "验证中…",
+    "anonymousSignInErrorInvalid": "信息不匹配，请重试。",
+    "anonymousSignInErrorRateLimited": "尝试次数过多，请稍后再试。",
+    "anonymousSignInErrorAdminLogged": "已以管理员身份登录 — 请先退出再恢复球员账号。",
+    "anonymousOrDivider": "或",
+    "anonymousRestoreLink": "登录",
+    "createAccount": {
+      "title": "创建你的账号",
+      "body": "设置名字和 PIN。之后可以报名场次。",
+      "nameLabel": "你的名字",
+      "namePlaceholder": "输入你的名字",
+      "pinLabel": "PIN",
+      "confirmPinLabel": "确认 PIN",
+      "submit": "创建账号",
+      "submitting": "创建中…",
+      "successWelcome": "欢迎，{name}",
+      "errorMismatch": "两次输入的 PIN 不一致",
+      "errorTooCommon": "请选择不那么常见的 PIN",
+      "errorInvalid": "PIN 必须是 4 位数字",
+      "errorRateLimited": "尝试次数过多，请一小时后再试。",
+      "errorNetwork": "网络错误，请重试。",
+      "errorAccountExists": "该名字已存在账号，请登录。"
+    },
     "playerName": "名字",
     "playerSession": "已报名场次",
     "pinSectionTitle": "恢复 PIN 码",
@@ -116,11 +154,14 @@
     "pinSaved": "已保存",
     "pinTooCommon": "请选择不那么常见的 PIN",
     "pinInvalid": "PIN 必须是 4 位数字",
+    "pinUpdateFailed": "更新 PIN 失败，请重试。",
     "adminToolsTitle": "管理员工具",
     "adminToolsButton": "管理员工具 →",
     "settings": {
       "title": "账号",
-      "forgotPin": "忘记 PIN",
+      "newPin": "新建 PIN",
+      "updatePin": "更新 PIN",
+      "recoveryCode": "有恢复码？",
       "releaseNotes": "更新日志",
       "adminAccess": "管理员访问",
       "logout": "退出登录"
@@ -200,7 +241,7 @@
   "recovery": {
     "sheetTitle": "登录",
     "pinPathTitle": "用 PIN 登录",
-    "pinPathHelp": "输入注册时设置的 4 位 PIN 码。",
+    "pinPathHelp": "输入注册时设置的 PIN 码。",
     "codePathTitle": "忘记 PIN",
     "codePathHelp": "向管理员索取一个 6 位验证码，然后在这里输入。",
     "nameLabel": "你的名字",


### PR DESCRIPTION
## Summary
Companion to #53. Splits the conflated "sign up" flow into three distinct concepts and closes two pre-existing security holes that became dangerous in this redesign.

**Stacked on #53** — review/merge that first; this PR's base is `feat/auth-taxonomy-server`. After #53 merges to main, this PR auto-rebases onto main.

### UI restructure
- **HomeTab**: dropped PIN from signup form. Anonymous signup is name-only. Returning users see "Already a player? Sign in →" which opens RecoverySheet. ForcePinModal stops mounting (PIN is opt-in now).
- **ProfileTab anonymous**: inline name + PIN sign-in form, "or" divider, "Create an account" button (opens 75vh sheet), recovery-code link. Header copy: "Profile" + "Account creation is invite only — contact admin for inquiries (beta)".
- **ProfileTab signed-in**: standalone Recovery PIN card removed. PIN management lives in Settings as "New PIN" / "Update PIN" row (opens new `RecoveryPinSheet` — Set/Change only, no Remove). Separate "Have a recovery code?" row.
- **AdminTab**: i18n'd hardcoded English strings.
- **PinInput**: drops oversized mono + wide letter-spacing; renders brand baddicon SVGs (cycling pink → yellow → green) per typed digit with a `baddicon-pop` spring animation per keystroke. No fixed dot count placeholder — length-hardened.
- **PlayersTab**: "(you)" suffix switched to `text-muted` to stop overlapping the amber/green section header colors.

### Bug fix
"Recovery PIN: Not set" stayed stale until refresh after sign-in. Effect read a localStorage flag once on mount with \`[]\` deps. Replaced with \`/api/members/me?name=X\` returning \`hasPin\` (derived from \`members.pinHash\`), refetched on every identity change. localStorage flag retired everywhere.

### Security fixes
- **Critical** — \`POST /api/players { sessionSignup: false }\` refuses to overwrite an existing \`members.pinHash\` → 409 \`account_exists\`. Closes hijack hole where any name could be claimed by anyone via Profile → Create account.
- **Critical** — anonymous \`POST /api/players\` for a PIN-protected member returns 401 \`pin_required\` → client auto-opens Sign In sheet. Closes the new-session impersonation hole that was exposed when PIN was removed from HomeTab signup.
- \`POST /api/players/recover\` falls back to \`members.pinHash\` when no session player exists. On success + open session + capacity, auto-creates the session player and mints \`deleteToken\` (sign-in doubles as sign-up for returning users on a fresh session/device). Constant-time miss against \`FAKE_HASH\` preserved for unknown names.

## Tests +6 (414 → 420)
- Hijack guard test for create-account
- Claim-without-PIN happy path
- Rate-limit semantics rewritten (409s now count toward limit)
- 4 recover endpoint cases: auto-create on open session, identity-only on closed/full, wrong PIN, member-without-PIN

## Test plan
- [x] \`npm test\` — 52 files / 420 tests pass
- [x] \`npx tsc --noEmit\` clean for app code
- [x] Manual smoke: sign-in via Profile inline form → Recovery PIN row updates immediately to "Update PIN"
- [x] Manual smoke: Create account with new name → 201; same name with new PIN → 409 account_exists
- [x] Manual smoke: HomeTab name-only signup for PIN-less member → 201; for PIN-protected member → Sign In sheet opens automatically
- [ ] Manual smoke on bpm-next after merge: type-check via \`next build\` not just vitest

🤖 Generated with [Claude Code](https://claude.com/claude-code)