### PR TITLE
fix(auth): single-identity model — member-scoped PIN + invite list + admin cookie sync

### DIFF
--- a/__tests__/members.test.ts
+++ b/__tests__/members.test.ts
@@ -8,7 +8,8 @@ import {
   makeGetRequest,
 } from './helpers';
 import { GET, POST, PATCH, DELETE } from '@/app/api/members/route';
-import { GET as ME_GET } from '@/app/api/members/me/route';
+import { GET as ME_GET, PATCH as ME_PATCH } from '@/app/api/members/me/route';
+import { hashPin, verifyPin } from '@/lib/recoveryHash';
 
 setupAdminPin();
 
@@ -153,5 +154,132 @@ describe('GET /api/members/me', () => {
 
     // ASSERT: short-circuits to safe default
     expect(data.role).toBe('member');
+  });
+});
+
+describe('PATCH /api/members/me — member-scoped PIN management', () => {
+  beforeEach(() => {
+    resetMockStore();
+    setupAdminPin();
+  });
+
+  it('first-time set: claim flow — no currentPin required when member has no pinHash', async () => {
+    seedMember('Riley');
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        newPin: '4827',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.hasPin).toBe(true);
+  });
+
+  it('change with correct currentPin succeeds', async () => {
+    const oldHash = await hashPin('4827');
+    seedMember('Riley', { pinHash: oldHash });
+
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        currentPin: '4827',
+        newPin: '5392',
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('change with wrong currentPin → 401 invalid_credentials', async () => {
+    const oldHash = await hashPin('4827');
+    seedMember('Riley', { pinHash: oldHash });
+
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        currentPin: '0000',
+        newPin: '5392',
+      }),
+    );
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe('invalid_credentials');
+  });
+
+  it('change WITHOUT currentPin (when member has pinHash) → 401 current_pin_required', async () => {
+    const oldHash = await hashPin('4827');
+    seedMember('Riley', { pinHash: oldHash });
+
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        newPin: '5392',
+      }),
+    );
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toBe('current_pin_required');
+  });
+
+  it('clear PIN with correct currentPin works', async () => {
+    const oldHash = await hashPin('4827');
+    seedMember('Riley', { pinHash: oldHash });
+
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        currentPin: '4827',
+        newPin: null,
+      }),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.hasPin).toBe(false);
+  });
+
+  it('blocklisted newPin → 400 pin_too_common', async () => {
+    seedMember('Riley');
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        newPin: '1234',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe('pin_too_common');
+  });
+
+  it('non-existent member → 401 invalid_credentials (constant-time, FAKE_HASH)', async () => {
+    const res = await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Ghost',
+        currentPin: '4827',
+        newPin: '5392',
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('cross-week persistence: PIN set via member endpoint survives session advance', async () => {
+    // Member set PIN; later when sessions advance, the member.pinHash
+    // is still the source of truth — recover endpoint will verify
+    // against it regardless of any (or no) session player.
+    seedMember('Riley');
+    await ME_PATCH(
+      makeRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        newPin: '4827',
+      }),
+    );
+
+    const { getStore } = await import('./helpers');
+    const members = (getStore()['members'] ?? []) as Array<{ name: string; pinHash?: string }>;
+    const stored = members.find((m) => m.name === 'Riley');
+    expect(stored?.pinHash).toBeDefined();
+    if (stored?.pinHash) {
+      expect(await verifyPin('4827', stored.pinHash)).toBe(true);
+    }
   });
 });

--- a/__tests__/players-create-account.test.ts
+++ b/__tests__/players-create-account.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
 
 describe('POST /api/players { sessionSignup: false } — account-only path', () => {
   it('creates a member with pinHash, no session player', async () => {
+    seedMember('Riley'); // pre-seeded by admin (invite-only flow)
     const res = await POST(
       makeRequest('POST', URL_PATH, { name: 'Riley', pin: '4827', sessionSignup: false }),
     );
@@ -30,7 +31,7 @@ describe('POST /api/players { sessionSignup: false } — account-only path', () 
     const data = await res.json();
     expect(data.name).toBe('Riley');
     expect(data.deleteToken).toBeNull();
-    expect(data.id).toMatch(/^[0-9a-f]{24}$/);
+    expect(typeof data.id).toBe('string');
 
     const store = getStore();
     const members = (store['members'] ?? []) as Array<{ name: string; pinHash?: string }>;
@@ -104,11 +105,12 @@ describe('POST /api/players { sessionSignup: false } — account-only path', () 
   });
 
   it('rate-limits at 3 attempts/hr per (name, IP)', async () => {
-    // Only the FIRST attempt for a fresh name actually creates a member;
-    // subsequent attempts on that name 409 (account_exists) but still
-    // count toward the rate limiter. So 3 successful + 1 limited would
-    // require 3 different fresh names. Easier: use one name and observe
-    // limit firing at attempt 4 once 3 attempts have been counted.
+    // Only the FIRST attempt for a pre-seeded name actually creates a
+    // member; subsequent attempts on that name 409 (account_exists) but
+    // still count toward the rate limiter. Seed the names as
+    // admin-invited members first.
+    seedMember('Spammer');
+    seedMember('Different');
     const ip = { 'X-Client-IP': '10.99.0.1' };
 
     const first = await POST(
@@ -136,14 +138,15 @@ describe('POST /api/players { sessionSignup: false } — account-only path', () 
     expect(otherName.status).toBe(201);
   });
 
-  it('does not run invite-list check (account creation is universal)', async () => {
-    seedMember('Existing'); // active member exists, so non-admin signup normally requires being on the list
+  it('enforces invite list — non-existent name is rejected (admin must pre-seed)', async () => {
+    seedMember('Existing'); // "NewPerson" is NOT on the list
 
-    // Account creation for a name not on the list still succeeds
     const res = await POST(
       makeRequest('POST', URL_PATH, { name: 'NewPerson', pin: '4827', sessionSignup: false }),
     );
-    expect(res.status).toBe(201);
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.error).toBe('invite_list_not_found');
   });
 });
 

--- a/__tests__/players-recover.test.ts
+++ b/__tests__/players-recover.test.ts
@@ -28,7 +28,12 @@ beforeEach(() => {
 
 describe('POST /api/players/recover', () => {
   it('PIN success: mints fresh deleteToken, never returns pinHash', async () => {
+    // PIN auth verifies against members.pinHash (canonical source) per the
+    // expanded Batch B architecture. Seed both records so the player
+    // record exists for the deleteToken-mint path.
     const pinHash = await hashPin('1234');
+    const { seedMember } = await import('./helpers');
+    seedMember('Michael', { pinHash });
     const player = seedPlayer(SESSION, 'Michael', { pinHash, deleteToken: 'old-token' });
 
     const res = await POST(
@@ -62,6 +67,8 @@ describe('POST /api/players/recover', () => {
 
   it('Wrong PIN: 401 invalid_credentials', async () => {
     const pinHash = await hashPin('1234');
+    const { seedMember } = await import('./helpers');
+    seedMember('Michael', { pinHash });
     seedPlayer(SESSION, 'Michael', { pinHash });
     const res = await POST(
       makeRequest('POST', URL_PATH, { name: 'Michael', sessionId: SESSION, pin: '9999' }),
@@ -133,7 +140,11 @@ describe('POST /api/players/recover', () => {
   });
 
   it('Mints new token AND invalidates old', async () => {
+    // Seed member.pinHash (canonical PIN store) + player record (so we
+    // hit the existing-player branch that mints a new token).
     const pinHash = await hashPin('1234');
+    const { seedMember } = await import('./helpers');
+    seedMember('Michael', { pinHash });
     const player = seedPlayer(SESSION, 'Michael', { pinHash, deleteToken: 'old' });
     const res = await POST(
       makeRequest('POST', URL_PATH, { name: 'Michael', sessionId: SESSION, pin: '1234' }),
@@ -166,8 +177,15 @@ describe('POST /api/players/recover', () => {
     expect(res.status).toBe(400);
   });
 
-  it('Admin attempting recover → 403', async () => {
+  it('Single-identity model: an admin recovering as themselves succeeds (admin cookie persists)', async () => {
+    // Previously this test asserted 403 'Use reset-access' to keep admin
+    // and player auth strictly separate. The single-identity model retired
+    // that guard — admin status is a property of the member record, not a
+    // separate auth surface. Recovery still requires the player's own
+    // PIN, so an admin can only recover as themselves.
     const pinHash = await hashPin('1234');
+    const { seedMember } = await import('./helpers');
+    seedMember('Michael', { pinHash, role: 'admin' });
     seedPlayer(SESSION, 'Michael', { pinHash });
     const res = await POST(
       makeAdminRequest('POST', URL_PATH, {
@@ -176,7 +194,9 @@ describe('POST /api/players/recover', () => {
         pin: '1234',
       }),
     );
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.deleteToken).toMatch(/^[0-9a-f]{32}$/);
   });
 
   // Note: the "Flag off → 404" test was removed when the recovery flag was

--- a/app/api/members/me/route.ts
+++ b/app/api/members/me/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getContainer } from '@/lib/cosmos';
+import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
+import { hashPin, verifyPin, FAKE_HASH } from '@/lib/recoveryHash';
+
+const BLOCKLISTED_PINS = new Set(['0000', '1111', '1234', '4321', '1212']);
 
 export async function GET(req: NextRequest) {
   const ip = getClientIp(req);
@@ -29,4 +32,140 @@ export async function GET(req: NextRequest) {
     console.error('GET members/me error:', error);
     return NextResponse.json({ role: 'member', hasPin: false });
   }
+}
+
+/**
+ * Member-scoped PIN management. Replaces the legacy `PATCH /api/players`
+ * PIN branch which authenticated via session-scoped `deleteToken` and only
+ * worked when the user had a player record in the active session. The PIN
+ * is an account-level secret — `members.pinHash` is the canonical store —
+ * so changing it shouldn't require re-signing-up every week.
+ *
+ * Behavior:
+ * - Body: `{ name, currentPin?: string, newPin: string | null }`
+ * - If member already has a `pinHash`, `currentPin` is required and must
+ *   verify (real password-change semantics, closes the "anyone with browser
+ *   access can rewrite my PIN" hole).
+ * - If member has no `pinHash` yet (claim flow / first-time set), no
+ *   `currentPin` is required.
+ * - `newPin: null` clears the PIN.
+ * - Best-effort: mirrors the new pinHash to the active-session player
+ *   record so legacy code paths that still read `players.pinHash` keep
+ *   working through the transition.
+ * - Constant-time miss against `FAKE_HASH` so attackers can't enumerate
+ *   names via timing.
+ * - Rate-limited 5/hr per (name, IP) — same envelope as `/recover`.
+ */
+export async function PATCH(req: NextRequest) {
+  try {
+    return await handlePatch(req);
+  } catch (err) {
+    console.error('PATCH /api/members/me unhandled:', err);
+    return NextResponse.json({ error: 'service_unavailable' }, { status: 503 });
+  }
+}
+
+async function handlePatch(req: NextRequest) {
+  let body: { name?: unknown; currentPin?: unknown; newPin?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const currentPin = typeof body.currentPin === 'string' ? body.currentPin : null;
+  if (!name) {
+    return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+  }
+
+  // Validate newPin shape: null = clear, '4-digit' = set/change.
+  let nextPinHash: string | undefined;
+  let clearPin = false;
+  if (body.newPin === null) {
+    clearPin = true;
+  } else if (typeof body.newPin === 'string') {
+    if (!/^[0-9]{4}$/.test(body.newPin)) {
+      return NextResponse.json({ error: 'Invalid PIN format' }, { status: 400 });
+    }
+    if (BLOCKLISTED_PINS.has(body.newPin)) {
+      return NextResponse.json({ error: 'pin_too_common' }, { status: 400 });
+    }
+    nextPinHash = await hashPin(body.newPin);
+  } else {
+    return NextResponse.json({ error: 'Invalid PIN format' }, { status: 400 });
+  }
+
+  const ip = getClientIp(req);
+  if (!checkRateLimit(`pin-update:${name.toLowerCase()}:${ip}`, 5, 60 * 60 * 1000)) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
+  const membersContainer = getContainer('members');
+  const { resources: members } = await membersContainer.items
+    .query({
+      query: 'SELECT * FROM c WHERE LOWER(c.name) = LOWER(@name) AND c.active = true',
+      parameters: [{ name: '@name', value: name }],
+    })
+    .fetchAll();
+  const member = members[0];
+
+  if (!member) {
+    if (currentPin) await verifyPin(currentPin, FAKE_HASH);
+    return NextResponse.json({ error: 'invalid_credentials' }, { status: 401 });
+  }
+
+  const hadPin = typeof member.pinHash === 'string' && member.pinHash.length > 0;
+  if (hadPin) {
+    if (!currentPin) {
+      // Constant-time penalty so callers can't tell "no current PIN
+      // submitted" from "current PIN wrong" by latency.
+      await verifyPin('0000', member.pinHash);
+      return NextResponse.json({ error: 'current_pin_required' }, { status: 401 });
+    }
+    const ok = await verifyPin(currentPin, member.pinHash);
+    if (!ok) {
+      return NextResponse.json({ error: 'invalid_credentials' }, { status: 401 });
+    }
+  }
+  // No prior pinHash → claim flow, no currentPin required.
+
+  const memberDoc: Record<string, unknown> = { ...member, lastSeen: new Date().toISOString() };
+  if (clearPin) {
+    delete memberDoc.pinHash;
+  } else {
+    memberDoc.pinHash = nextPinHash;
+  }
+  await membersContainer.items.upsert(memberDoc);
+
+  // Best-effort mirror to the active session player. Legacy code that
+  // reads `players.pinHash` directly stays in sync. A failure here is
+  // non-fatal — the member record is the source of truth.
+  try {
+    const sessionId = await getActiveSessionId();
+    const playersContainer = getContainer('players');
+    const { resources: players } = await playersContainer.items
+      .query({
+        query: 'SELECT * FROM c WHERE c.sessionId = @sessionId AND LOWER(c.name) = LOWER(@name)',
+        parameters: [
+          { name: '@sessionId', value: sessionId },
+          { name: '@name', value: name },
+        ],
+      })
+      .fetchAll();
+    const player = players[0];
+    if (player) {
+      const playerDoc = { ...player };
+      if (clearPin) {
+        delete playerDoc.pinHash;
+      } else {
+        playerDoc.pinHash = nextPinHash;
+      }
+      await playersContainer.items.upsert(playerDoc);
+    }
+  } catch (err) {
+    console.warn('member PIN: player mirror failed (non-fatal):', err);
+  }
+
+  return NextResponse.json({ success: true, hasPin: !clearPin });
 }

--- a/app/api/players/recover/route.ts
+++ b/app/api/players/recover/route.ts
@@ -1,11 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
-import { isAdminAuthed } from '@/lib/auth';
+import { setAdminCookie, clearAdminCookie } from '@/lib/auth';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 import { getContainer } from '@/lib/cosmos';
 import { verifyPin, FAKE_HASH } from '@/lib/recoveryHash';
 import { consumeCode } from '@/lib/recoveryCodes';
 import { appendEvent } from '@/lib/recoveryAudit';
+
+/**
+ * Single-identity model: when a member with `role === 'admin'` proves their
+ * PIN, issue the admin session cookie so they don't have to log in again on
+ * AdminTab. Admin status is a property of the member record, not a separate
+ * auth surface. Conversely, when a non-admin member signs in, ANY existing
+ * admin cookie must be cleared — otherwise admin powers persist across
+ * player sign-out → sign-in-as-different-player and leak to whoever logs
+ * in next.
+ */
+function syncAdminCookie(
+  res: NextResponse,
+  member: { id: string; name: string; role?: string } | null | undefined,
+): void {
+  if (member && member.role === 'admin') {
+    setAdminCookie(res, member.id, member.name);
+  } else {
+    clearAdminCookie(res);
+  }
+}
 
 export const dynamic = 'force-dynamic';
 
@@ -26,7 +46,6 @@ export async function POST(req: NextRequest) {
 }
 
 async function handlePost(req: NextRequest) {
-  // Recovery flag retired — endpoint is unconditionally active.
   let body: { name?: unknown; sessionId?: unknown; pin?: unknown; code?: unknown };
   try {
     body = await req.json();
@@ -53,19 +72,23 @@ async function handlePost(req: NextRequest) {
   }
 
   const ip = getClientIp(req);
-  // Rate-limit BEFORE auth (CLAUDE.md rule #4) and before looking up the player
-  // so non-existent names also bucket and an attacker can't enumerate names by timing.
   if (!checkRateLimit(`recover:${name.toLowerCase()}:${ip}`, 5, 60 * 60 * 1000)) {
     return NextResponse.json({ error: 'rate_limited', retryAfter: 60 * 60 }, { status: 429 });
   }
 
-  // Admins must use /reset-access; never let /recover mint tokens for them.
-  if (isAdminAuthed(req)) {
-    return NextResponse.json({ error: 'Use reset-access' }, { status: 403 });
-  }
+  // Note: the previous "admins must use /reset-access" guard was retired
+  // alongside the single-identity model. Recovery only succeeds with the
+  // player's own PIN, so an admin cookie holder can't impersonate other
+  // players — the syncAdminCookie call below also clears admin status if
+  // the recovered identity is not itself an admin.
 
-  const container = getContainer('players');
-  const { resources } = await container.items
+  const playersContainer = getContainer('players');
+  const membersContainer = getContainer('members');
+
+  // Resolve the (optional) session player up front. Used for code path
+  // (codes are issued against a specific player record) and for the
+  // success path (mint a fresh deleteToken if a player exists).
+  const { resources: playerHits } = await playersContainer.items
     .query({
       query:
         'SELECT * FROM c WHERE c.sessionId = @sessionId AND LOWER(c.name) = LOWER(@name) AND (NOT IS_DEFINED(c.removed) OR c.removed != true)',
@@ -75,36 +98,70 @@ async function handlePost(req: NextRequest) {
       ],
     })
     .fetchAll();
-  const player = resources[0];
+  const player = playerHits[0] ?? null;
 
-  // No session player for the active session, but the user may still have
-  // a member record (account-only identity, or returning player on a fresh
-  // session before they've signed up). Fall back to verifying against the
-  // member's pinHash. Codes don't have a member-level path — those are
-  // issued against a specific player record, so we still hard-fail.
-  if (!player && pin) {
-    const membersContainer = getContainer('members');
+  // === PIN path ============================================================
+  // Verify against `members.pinHash` ALWAYS — that's the canonical PIN
+  // store. Previous behavior (verify against `players.pinHash` first) lost
+  // the PIN every week because new session-player records are created
+  // hash-less when signup doesn't include a PIN field. By making the
+  // member record the source of truth, the PIN persists across sessions.
+  if (pin) {
     const { resources: members } = await membersContainer.items
       .query({
         query: 'SELECT * FROM c WHERE LOWER(c.name) = LOWER(@name) AND c.active = true',
         parameters: [{ name: '@name', value: name }],
       })
       .fetchAll();
-    const member = members[0];
+    const member = members[0] ?? null;
+
     if (!member || typeof member.pinHash !== 'string' || !member.pinHash) {
-      // Constant-time miss against FAKE_HASH so attackers can't enumerate
-      // names or distinguish "no member" from "no PIN" by timing.
       await verifyPin(pin, FAKE_HASH);
+      if (player) {
+        const updatedEvents = appendEvent(player.recoveryEvents, {
+          event: 'recovery-failed',
+          at: new Date().toISOString(),
+          reason: 'wrong_pin',
+        });
+        await playersContainer.items.upsert({ ...player, recoveryEvents: updatedEvents });
+      }
       return FAIL();
     }
-    const ok = await verifyPin(pin, member.pinHash);
-    if (!ok) return FAIL();
 
-    // PIN matched a member without a session player. If the active session
-    // is open and has capacity, auto-create the session player so this call
-    // doubles as "sign in + sign up for this week" — the natural mental
-    // model for a returning user on a new session. Otherwise return an
-    // identity-only success with no deleteToken.
+    const ok = await verifyPin(pin, member.pinHash);
+    if (!ok) {
+      if (player) {
+        const updatedEvents = appendEvent(player.recoveryEvents, {
+          event: 'recovery-failed',
+          at: new Date().toISOString(),
+          reason: 'wrong_pin',
+        });
+        await playersContainer.items.upsert({ ...player, recoveryEvents: updatedEvents });
+      }
+      return FAIL();
+    }
+
+    // PIN verified. If a session player exists, mint a fresh deleteToken.
+    if (player) {
+      const newDeleteToken = randomBytes(16).toString('hex');
+      const updatedEvents = appendEvent(player.recoveryEvents, {
+        event: 'recovered-via-pin',
+        at: new Date().toISOString(),
+      });
+      await playersContainer.items.upsert({
+        ...player,
+        deleteToken: newDeleteToken,
+        recoveryEvents: updatedEvents,
+        // Keep the per-player pinHash mirror current for any legacy reader.
+        pinHash: member.pinHash,
+      });
+      const res = NextResponse.json({ deleteToken: newDeleteToken });
+      syncAdminCookie(res, member);
+      return res;
+    }
+
+    // No session player yet — auto-sign-up for this week if signup is
+    // open + capacity allows. Otherwise return identity-only.
     const sessionContainer = getContainer('sessions');
     const { resources: sessions } = await sessionContainer.items
       .query({ query: 'SELECT * FROM c WHERE c.id = @id', parameters: [{ name: '@id', value: sessionId }] })
@@ -116,10 +173,12 @@ async function handlePost(req: NextRequest) {
       (sessionData?.deadline && new Date() > new Date(sessionData.deadline));
 
     if (signupBlocked) {
-      return NextResponse.json({ deleteToken: null });
+      const res = NextResponse.json({ deleteToken: null });
+      syncAdminCookie(res, member);
+      return res;
     }
 
-    const { resources: active } = await container.items
+    const { resources: active } = await playersContainer.items
       .query({
         query:
           'SELECT * FROM c WHERE c.sessionId = @sessionId AND (NOT IS_DEFINED(c.removed) OR c.removed != true) AND (NOT IS_DEFINED(c.waitlisted) OR c.waitlisted != true)',
@@ -127,7 +186,9 @@ async function handlePost(req: NextRequest) {
       })
       .fetchAll();
     if (active.length >= maxPlayers) {
-      return NextResponse.json({ deleteToken: null });
+      const res = NextResponse.json({ deleteToken: null });
+      syncAdminCookie(res, member);
+      return res;
     }
 
     const newDeleteToken = randomBytes(16).toString('hex');
@@ -144,47 +205,37 @@ async function handlePost(req: NextRequest) {
       pinHash: member.pinHash,
       recoveryEvents: [{ event: 'recovered-via-pin', at: new Date().toISOString() }],
     };
-    await container.items.create(newPlayer);
-    return NextResponse.json({ deleteToken: newDeleteToken });
+    await playersContainer.items.create(newPlayer);
+    const res = NextResponse.json({ deleteToken: newDeleteToken });
+    syncAdminCookie(res, member);
+    return res;
   }
 
-  // Constant-time miss: do a real verify against FAKE_HASH so latency matches
-  // a real failed verify and an attacker can't distinguish "no player" from "wrong PIN".
+  // === Code path ===========================================================
+  // Recovery codes are still player-scoped — they're issued against a
+  // specific player.id by `/api/players/reset-access`.
   if (!player) {
-    if (pin) await verifyPin(pin, FAKE_HASH);
-    else await verifyPin(code!, FAKE_HASH);
+    await verifyPin(code!, FAKE_HASH);
     return FAIL();
   }
 
-  let ok = false;
-  if (pin) {
-    if (typeof player.pinHash === 'string' && player.pinHash) {
-      ok = await verifyPin(pin, player.pinHash);
-    } else {
-      // No PIN set — same dummy verify so latency is constant.
-      await verifyPin(pin, FAKE_HASH);
-      ok = false;
-    }
-  } else {
-    ok = await consumeCode(player.id, code!);
-  }
-
+  const ok = await consumeCode(player.id, code!);
   if (!ok) {
     const updatedEvents = appendEvent(player.recoveryEvents, {
       event: 'recovery-failed',
       at: new Date().toISOString(),
-      reason: pin ? 'wrong_pin' : 'wrong_code',
+      reason: 'wrong_code',
     });
-    await container.items.upsert({ ...player, recoveryEvents: updatedEvents });
+    await playersContainer.items.upsert({ ...player, recoveryEvents: updatedEvents });
     return FAIL();
   }
 
   const newDeleteToken = randomBytes(16).toString('hex');
   const updatedEvents = appendEvent(player.recoveryEvents, {
-    event: pin ? 'recovered-via-pin' : 'recovered-via-code',
+    event: 'recovered-via-code',
     at: new Date().toISOString(),
   });
-  await container.items.upsert({
+  await playersContainer.items.upsert({
     ...player,
     deleteToken: newDeleteToken,
     recoveryEvents: updatedEvents,

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -87,11 +87,17 @@ export async function POST(req: NextRequest) {
         })
         .fetchAll();
       const existingMember = existingMembers[0];
+      // Invite-only: account creation requires the admin to have pre-seeded
+      // the name in the members container. Profile copy says "Account
+      // creation is invite only — contact admin for inquiries (beta)" so
+      // the server has to enforce that. Admins bypass.
+      if (!existingMember && !isAdminAuthed(req)) {
+        return NextResponse.json({ error: 'invite_list_not_found', name: trimmedName }, { status: 403 });
+      }
       // Refuse to overwrite an existing PIN. Otherwise anyone who knows a
       // member's name could hijack the account by "creating an account" for
       // them with a new PIN. Pre-seeded members without a PIN can still be
-      // claimed (this is the friend-group beta flow — admin seeds names,
-      // friends claim by setting the first PIN).
+      // claimed (admin seeds names, friends claim by setting the first PIN).
       if (existingMember && typeof existingMember.pinHash === 'string' && existingMember.pinHash.length > 0) {
         return NextResponse.json({ error: 'account_exists' }, { status: 409 });
       }
@@ -263,12 +269,12 @@ export async function PATCH(req: NextRequest) {
   try {
     const body = await req.json();
     const { id } = body;
-    if (typeof id !== 'string') {
-      return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
-    }
 
     // PIN set/change/remove — admin OR player-self via deleteToken.
     // Recovery flag retired; PIN management is unconditionally available.
+    // PIN branch supports lookup by `id` (legacy) OR by `{name, sessionId,
+    // deleteToken}` (Batch B M1: avoids the client fetching the full
+    // session roster just to find its own player ID before patching).
     if (body.pin !== undefined) {
       // Pre-validate pin shape (fail fast before DB load)
       let nextPinHash: string | undefined;
@@ -292,7 +298,33 @@ export async function PATCH(req: NextRequest) {
 
       const sessionId = isAdmin && typeof body.sessionId === 'string' ? body.sessionId : await getActiveSessionId();
       const container = getContainer('players');
-      const { resource: existing } = await container.item(id, sessionId).read();
+
+      // Resolve the player record. Prefer id (legacy clients), fall back
+      // to name lookup so RecoveryPinSheet can patch without first GETing
+      // the whole roster. Use `any` for the resource type to match the
+      // existing PATCH conventions elsewhere in this file (Cosmos doesn't
+      // give us strong typing here).
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let existing: any = null;
+      if (typeof id === 'string') {
+        const { resource } = await container.item(id, sessionId).read();
+        existing = resource ?? null;
+      } else if (typeof body.name === 'string' && body.name.trim()) {
+        const trimmedLookupName = body.name.trim();
+        const { resources } = await container.items
+          .query({
+            query:
+              'SELECT * FROM c WHERE c.sessionId = @sessionId AND LOWER(c.name) = LOWER(@name) AND (NOT IS_DEFINED(c.removed) OR c.removed != true)',
+            parameters: [
+              { name: '@sessionId', value: sessionId },
+              { name: '@name', value: trimmedLookupName },
+            ],
+          })
+          .fetchAll();
+        existing = resources[0] ?? null;
+      } else {
+        return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+      }
       if (!existing) {
         return NextResponse.json({ error: 'Player not found' }, { status: 404 });
       }
@@ -348,6 +380,12 @@ export async function PATCH(req: NextRequest) {
 
       const { deleteToken: _dt, pinHash: _ph, ...safe } = updated as typeof existing;
       return NextResponse.json(safe);
+    }
+
+    // Non-PIN paths still require id. The PIN branch above handles the
+    // name-fallback case; everything below assumes an id exists.
+    if (typeof id !== 'string') {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
     }
 
     // Self-serve "I paid" path — player reports payment using their deleteToken

--- a/components/AdminTab.tsx
+++ b/components/AdminTab.tsx
@@ -92,7 +92,7 @@ export default function AdminTab() {
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   maxLength={50}
-                  autoComplete="username"
+                  autoComplete="nickname"
                   autoFocus={!name}
                 />
               </div>

--- a/components/CreateAccountSheet.tsx
+++ b/components/CreateAccountSheet.tsx
@@ -13,7 +13,7 @@ interface Props {
   sessionId: string;
 }
 
-type ErrorKind = 'mismatch' | 'too_common' | 'invalid' | 'rate_limited' | 'network' | 'name_required' | 'account_exists' | null;
+type ErrorKind = 'mismatch' | 'too_common' | 'invalid' | 'rate_limited' | 'network' | 'name_required' | 'account_exists' | 'invite_only' | null;
 
 export default function CreateAccountSheet({ open, onClose, sessionId }: Props) {
   const t = useTranslations('profile.createAccount');
@@ -45,6 +45,7 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
         if (data.error === 'pin_too_common') { setError('too_common'); return; }
         if (data.error === 'Invalid PIN format') { setError('invalid'); return; }
         if (data.error === 'account_exists') { setError('account_exists'); return; }
+        if (data.error === 'invite_list_not_found') { setError('invite_only'); return; }
         setError('network');
         return;
       }
@@ -92,7 +93,7 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
               value={name}
               onChange={(e) => setName(e.target.value)}
               maxLength={50}
-              autoComplete="username"
+              autoComplete="nickname"
             />
             <div>
               <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{t('pinLabel')}</p>
@@ -128,6 +129,9 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
             )}
             {error === 'account_exists' && (
               <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorAccountExists')}</p>
+            )}
+            {error === 'invite_only' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorInviteOnly')}</p>
             )}
           </div>
         )}

--- a/components/EnterCodeSheet.tsx
+++ b/components/EnterCodeSheet.tsx
@@ -74,7 +74,7 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
               placeholder={t('nameLabel')}
               value={name}
               onChange={(e) => setName(e.target.value)}
-              autoComplete="username"
+              autoComplete="nickname"
               style={{
                 width: '100%',
                 padding: 12,

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -509,14 +509,16 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides }: { onT
                 {!isSubmitting && <span className="material-icons icon-sm" aria-hidden="true">how_to_reg</span>}
                 {isSubmitting ? t('signup.submitting') : t('signup.button')}
               </button>
-              <button
-                type="button"
-                onClick={() => setSignInOpen(true)}
-                className="text-center text-xs underline"
-                style={{ color: 'var(--text-secondary)', background: 'transparent', border: 'none', cursor: 'pointer', padding: '8px 12px', minHeight: 44, alignSelf: 'center' }}
-              >
-                {t('signup.alreadyPlayer')}
-              </button>
+              {!hasIdentity && (
+                <button
+                  type="button"
+                  onClick={() => setSignInOpen(true)}
+                  className="text-center text-xs underline"
+                  style={{ color: 'var(--text-secondary)', background: 'transparent', border: 'none', cursor: 'pointer', padding: '8px 12px', minHeight: 44, alignSelf: 'center' }}
+                >
+                  {t('signup.alreadyPlayer')}
+                </button>
+              )}
               {session?.deadline && (
                 <p className={`text-center text-xs font-medium ${isDeadlineApproaching ? 'text-red-400' : 'text-gray-400'}`}>
                   {t('signup.closesOn', { date: format.dateTime(new Date(session.deadline), DAY_LONG) })}

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -91,10 +91,18 @@ export default function ProfileTab({
     };
   }, [identity]);
 
-  function handleLogout() {
+  async function handleLogout() {
+    // Single-identity model: logging out as a player also revokes admin
+    // status. Otherwise the admin cookie outlived the player session and
+    // leaked admin powers to whoever signed in next on the same browser.
     clearIdentity();
     setLocalIdentity(null);
     setPinIsSet(null);
+    try {
+      await fetch(`${BASE}/api/admin`, { method: 'DELETE' });
+    } catch {
+      // best-effort — local identity is already cleared
+    }
   }
 
   // Anonymous state — Profile is identity-only. Inline sign-in form (name +
@@ -152,7 +160,7 @@ export default function ProfileTab({
               placeholder={t('anonymousNamePlaceholder')}
               value={signInName}
               onChange={(e) => { setSignInName(e.target.value); setSignInError(null); }}
-              autoComplete="username"
+              autoComplete="nickname"
               maxLength={50}
             />
             <PinInput
@@ -278,6 +286,10 @@ export default function ProfileTab({
         <SettingsList
           title={tSettings('title')}
           rows={[
+            // Batch B (expanded): PIN management is now member-scoped via
+            // PATCH /api/members/me — works regardless of whether the user
+            // has a session player. The previous "Sign up for a session
+            // first" gate is no longer needed.
             {
               icon: 'key',
               // pinIsSet === null means we couldn't load status. Show the

--- a/components/RecoveryPinSheet.tsx
+++ b/components/RecoveryPinSheet.tsx
@@ -16,19 +16,27 @@ interface Props {
   onSaved: (newHasPin: boolean) => void;
 }
 
-type PinError = 'too_common' | 'invalid' | 'failed' | null;
+type PinError =
+  | 'too_common'
+  | 'invalid'
+  | 'failed'
+  | 'wrong_current'
+  | 'rate_limited'
+  | null;
 
 export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSaved }: Props) {
   const t = useTranslations('profile');
   const tSettings = useTranslations('profile.settings');
   const tPin = useTranslations('pin');
   const tRecovery = useTranslations('recovery');
+  const [currentPin, setCurrentPin] = useState('');
   const [newPin, setNewPin] = useState('');
   const [confirmPin, setConfirmPin] = useState('');
   const [pinError, setPinError] = useState<PinError>(null);
   const [submitting, setSubmitting] = useState(false);
 
   function reset() {
+    setCurrentPin('');
     setNewPin('');
     setConfirmPin('');
     setPinError(null);
@@ -38,24 +46,29 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
     setPinError(null);
     setSubmitting(true);
     try {
-      const meRes = await fetch(`${BASE}/api/players`, { cache: 'no-store' });
-      const players = (await meRes.json()) as { id: string; name: string; sessionId: string }[];
-      const me = players.find(
-        (p) => p.name.toLowerCase() === identity.name.toLowerCase() && p.sessionId === identity.sessionId,
-      );
-      if (!me) {
-        setPinError('failed');
-        return;
-      }
-      const patchRes = await fetch(`${BASE}/api/players`, {
+      // Batch B (expanded): PATCH the member record directly. PIN is an
+      // account-level secret — coupling it to the session-scoped player
+      // record meant the PIN appeared "lost" every week. The endpoint
+      // verifies `currentPin` against `members.pinHash` when one exists,
+      // closing the "anyone with browser access can rewrite my PIN" hole.
+      const patchRes = await fetch(`${BASE}/api/members/me`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: me.id, pin: value, deleteToken: identity.token }),
+        body: JSON.stringify({
+          name: identity.name,
+          // currentPin only required when a PIN is already set. The server
+          // also enforces this and returns 401 'current_pin_required' if
+          // we forget — but defending in depth.
+          currentPin: hasPin ? currentPin : undefined,
+          newPin: value,
+        }),
       });
       if (!patchRes.ok) {
         const body = await patchRes.json().catch(() => ({}));
-        if (body.error === 'pin_too_common') setPinError('too_common');
+        if (patchRes.status === 429) setPinError('rate_limited');
+        else if (body.error === 'pin_too_common') setPinError('too_common');
         else if (body.error === 'Invalid PIN format') setPinError('invalid');
+        else if (body.error === 'invalid_credentials' || body.error === 'current_pin_required') setPinError('wrong_current');
         else setPinError('failed');
         return;
       }
@@ -71,6 +84,11 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
 
   const title = hasPin ? tSettings('updatePin') : tSettings('newPin');
   const submitLabel = hasPin ? tSettings('updatePin') : tPin('save');
+  const canSubmit =
+    !submitting &&
+    newPin.length === 4 &&
+    newPin === confirmPin &&
+    (!hasPin || currentPin.length === 4);
 
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={title} maxHeight="75vh" className="max-w-lg mx-auto">
@@ -87,13 +105,37 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {hasPin && (
+            <div>
+              <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('currentLabel')}</p>
+              <PinInput
+                value={currentPin}
+                onChange={(v) => { setCurrentPin(v); setPinError(null); }}
+                digits={4}
+                label={tPin('currentLabel')}
+                autoFocus
+                ariaInvalid={pinError === 'wrong_current'}
+              />
+            </div>
+          )}
           <div>
             <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('newLabel')}</p>
-            <PinInput value={newPin} onChange={setNewPin} digits={4} label={tPin('newLabel')} autoFocus />
+            <PinInput
+              value={newPin}
+              onChange={(v) => { setNewPin(v); setPinError(null); }}
+              digits={4}
+              label={tPin('newLabel')}
+              autoFocus={!hasPin}
+            />
           </div>
           <div>
             <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('confirmLabel')}</p>
-            <PinInput value={confirmPin} onChange={setConfirmPin} digits={4} label={tPin('confirmLabel')} />
+            <PinInput
+              value={confirmPin}
+              onChange={(v) => { setConfirmPin(v); setPinError(null); }}
+              digits={4}
+              label={tPin('confirmLabel')}
+            />
           </div>
           {pinError === 'too_common' && (
             <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
@@ -103,6 +145,16 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
           {pinError === 'invalid' && (
             <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
               {t('pinInvalid')}
+            </p>
+          )}
+          {pinError === 'wrong_current' && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              {t('pinWrongCurrent')}
+            </p>
+          )}
+          {pinError === 'rate_limited' && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-amber, #f59e0b)', margin: 0 }}>
+              {t('pinRateLimited')}
             </p>
           )}
           {pinError === 'failed' && (
@@ -118,7 +170,7 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
           <button
             type="button"
             className="btn-primary"
-            disabled={submitting || newPin.length !== 4 || newPin !== confirmPin}
+            disabled={!canSubmit}
             onClick={() => savePin(newPin)}
             style={{ width: '100%' }}
           >

--- a/components/RecoverySheet.tsx
+++ b/components/RecoverySheet.tsx
@@ -81,7 +81,7 @@ export default function RecoverySheet({ open, onClose, sessionId, onForgotPin }:
               placeholder={t('nameLabel')}
               value={name}
               onChange={(e) => setName(e.target.value)}
-              autoComplete="username"
+              autoComplete="nickname"
             />
             <PinInput
               value={pin}

--- a/messages/en.json
+++ b/messages/en.json
@@ -142,7 +142,8 @@
       "errorInvalid": "PIN must be 4 digits",
       "errorRateLimited": "Too many tries. Try again in an hour.",
       "errorNetwork": "Network error. Please try again.",
-      "errorAccountExists": "An account with this name already exists. Sign in instead."
+      "errorAccountExists": "An account with this name already exists. Sign in instead.",
+      "errorInviteOnly": "This name isn't on the invite list. Ask the admin to add you."
     },
     "playerName": "Name",
     "playerSession": "Signed up for",
@@ -156,6 +157,8 @@
     "pinTooCommon": "Pick a less common PIN",
     "pinInvalid": "PIN must be 4 digits",
     "pinUpdateFailed": "Couldn't update PIN. Please try again.",
+    "pinWrongCurrent": "Current PIN doesn't match.",
+    "pinRateLimited": "Too many tries. Try again in an hour.",
     "adminToolsTitle": "Admin tools",
     "adminToolsButton": "Admin tools →",
     "settings": {
@@ -170,6 +173,7 @@
   },
   "pin": {
     "newLabel": "New PIN",
+    "currentLabel": "Current PIN",
     "confirmLabel": "Confirm PIN",
     "save": "Save",
     "cancel": "Cancel",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -142,7 +142,8 @@
       "errorInvalid": "PIN 必须是 4 位数字",
       "errorRateLimited": "尝试次数过多，请一小时后再试。",
       "errorNetwork": "网络错误，请重试。",
-      "errorAccountExists": "该名字已存在账号，请登录。"
+      "errorAccountExists": "该名字已存在账号，请登录。",
+      "errorInviteOnly": "该名字不在邀请名单上，请联系管理员添加。"
     },
     "playerName": "名字",
     "playerSession": "已报名场次",
@@ -156,6 +157,8 @@
     "pinTooCommon": "请选择不那么常见的 PIN",
     "pinInvalid": "PIN 必须是 4 位数字",
     "pinUpdateFailed": "更新 PIN 失败，请重试。",
+    "pinWrongCurrent": "当前 PIN 不正确。",
+    "pinRateLimited": "尝试次数过多，请一小时后再试。",
     "adminToolsTitle": "管理员工具",
     "adminToolsButton": "管理员工具 →",
     "settings": {
@@ -170,6 +173,7 @@
   },
   "pin": {
     "newLabel": "新 PIN",
+    "currentLabel": "当前 PIN",
     "confirmLabel": "确认 PIN",
     "save": "保存",
     "cancel": "取消",


### PR DESCRIPTION
Architectural fix closing a cluster of cross-cutting auth bugs surfaced 2026-05-01.

## Headline: PIN persists across sessions
Previously `/api/players/recover` verified against `players.pinHash` first. New session-player records get created hash-less (HomeTab signup is name-only) so the PIN appeared 'lost' every week. Now `members.pinHash` is the single source of truth; player.pinHash is a write-only mirror for legacy readers.

## New: PATCH /api/members/me
Member-scoped PIN management with proper 'current-PIN required to change' verification. Closes the silent 'anyone with browser access can rewrite my PIN' hole. Lets account-only identities (no session player) manage their own PIN — previously gated behind 'Sign up for a session first' which was a UX dead-end.

## Single-identity admin
- Admin member proves PIN → recover endpoint also issues `bpm-admin` cookie. **No more double-login on AdminTab.**
- Non-admin member signs in → any leftover admin cookie is cleared. Closes the **'Grant signs out, Michelle signs in, Michelle inherits Grant's admin' leak**.
- Profile logout also calls `DELETE /api/admin` so admin status doesn't outlive the player session.
- Retires the 'admins must use /reset-access' guard — recovery requires player's own PIN, so admin can only recover as themselves.

## Invite list enforcement
`POST /api/players { sessionSignup: false }` now refuses with 403 `invite_list_not_found` unless the name is on the active members list. Profile copy says 'invite only — contact admin'; the server now matches. (Previously **anyone could create an account with any name**, e.g. 'Jesus' in today's smoke.)

## Misc
- `PATCH /api/players` PIN branch accepts `{name, sessionId, deleteToken}` lookup — RecoveryPinSheet no longer fetches the full session roster client-side just to find its own player ID. Privacy regression closed.
- HomeTab 'Already a player?' link gated on `!hasIdentity`.
- All name inputs switched from `autoComplete="username"` → `"nickname"`. Stops Chrome from suggesting Gmail addresses.

## Tests
+8 (420 → 428): full coverage on PATCH /api/members/me including current-PIN required, wrong-current, blocklisted, constant-time miss, cross-week persistence. `npx tsc --noEmit` clean.

## Drift check
Ran `inspect-pin-drift.mjs` against shared Cosmos. Only `QA-test-account` (test data, admin role) has player.pinHash without member.pinHash. **No real users affected by the cutover.**

## Test plan
- [x] `npm test` — 428 pass
- [x] Localhost smoke: PIN survives Update flow, current-PIN required, account-only Update PIN works, admin auto-promotes on sign-in, non-admin sign-in clears admin cookie, Profile logout clears admin cookie, Create Account refuses non-invite names, name autofill no longer suggests email
- [ ] After merge to bpm-next: verify QA-test-account PIN reset path works (admin can issue recovery code, then re-set via the new sheet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)