### PR TITLE
fix(auth): WS#3 — admin-auth hardening (role re-check, unauth writes, first-PIN claim)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Omit `COSMOS_CONNECTION_STRING` from `.env.local` to use the in-memory mock stor
 Sessions are date-keyed (`session-YYYY-MM-DD`). A pointer document (`id: 'active-session-pointer'`) tracks the current session. **Always use `getActiveSessionId()`** — never `SESSION_ID` directly (legacy compat only). The pointer falls back to `'current-session'` if no pointer doc exists — do not remove this fallback.
 
 ### Auth
-- Admin: HTTP-only cookie via PIN, validated with `timingSafeEqual`. All admin routes call `isAdminAuthed(req)`.
+- Admin: HTTP-only cookie via PIN, validated with `timingSafeEqual`. **Mutating** admin routes call `await isAdminAuthedWithMember(req)` (re-reads the Member, enforces `role==='admin' && active===true` on every request, so demotion takes effect immediately); **read-only** routes use the cheap sync `isAdminAuthed(req)` (cookie signature + expiry only — no Cosmos read on hot paths). See `lib/auth.ts`. The inline rule-7 sessionId-override checks (skills/players/games) also stay sync. (WS#3 audit, 2026-06-03.)
 - Player self-cancel: `deleteToken` (random 16 bytes hex) returned once at sign-up, stored in `localStorage`, validated server-side.
 
 ### Soft Delete
@@ -83,7 +83,7 @@ Canonical bundle mirrored at `docs/design-system/` (43 files — tokens, 28 spec
 
 1. **`deleteToken` never in responses.** Strip after any GET/PATCH: `const { deleteToken: _dt, ...safe } = record`.
 2. **`timingSafeEqual` for all secret comparisons.** Never `===` for PINs or cookies.
-3. **Auth before DB.** `isAdminAuthed(req)` at top of every admin route, before body parsing.
+3. **Auth before DB.** Admin check at top of every admin route, before body parsing. **Mutating** handlers use `await isAdminAuthedWithMember(req)` (role re-check); read-only handlers may use sync `isAdminAuthed(req)`.
 4. **Rate limit before auth.** Rate limiting first in handler so it can't be bypassed.
 5. **`POST /api/claude` is admin-only.** Unauthenticated access would expose API key budget.
 6. **`getClientIp(req)` for IP.** Reads `X-Client-IP` then `X-Forwarded-For`. Never `req.ip` (returns Azure proxy IP).
@@ -92,6 +92,7 @@ Canonical bundle mirrored at `docs/design-system/` (43 files — tokens, 28 spec
 9. **`purgeAll: true` is irreversible.** Hard-deletes all records including soft-deleted.
 10. **Aliases require admin auth.** E-transfer names are sensitive payment data.
 11. **PIN comparison hashes first.** `admin/route.ts` hashes both PIN and admin PIN to SHA-256 before `timingSafeEqual` to avoid leaking PIN length via timing.
+12. **Member-scoped writes bind to the member cookie.** A name-keyed write that mutates one member's data (e.g. `equipment/gear` PUT) must require a `member_session` cookie matching the target member (`verifyMemberAuth` → `memberId`) OR admin — never name-only, since names are enumerable. The cookie is minted at sign-up (no PIN needed), preserving "anon-signup trust" while closing impersonation. (WS#3, 2026-06-03.)
 
 ## Gotchas
 
@@ -114,7 +115,8 @@ Canonical bundle mirrored at `docs/design-system/` (43 files — tokens, 28 spec
   - **Sign in** (Profile path) = name + PIN auth via `<SignInForm>` rendered inline on ProfileTab's anonymous view. POST `/api/players/recover` verifies against `members.pinHash` and returns **identity-only** (`deleteToken: null`) — Profile sign-in does NOT auto-register for a session (commit 6046755, 2026-05-07). Constant-time miss against `FAKE_HASH`. Rate-limited 5/hr per `(name, IP)`. HomeTab's old "Already a player?" link + standalone RecoverySheet card (#89) were removed 2026-05-12 in favor of the adaptive form above.
   - **Cancel spot** ≠ **Sign out**. `PlayersTab.handleCancel` removes the user from the active session player list and zeroes the deleteToken (server consumed it), but preserves name + sessionId in localStorage. The user stays signed in and can re-sign-up with one tap. `clearIdentity()` belongs only in `ProfileTab.handleLogout`.
   - PINs scrypt-hashed via `lib/recoveryHash.ts`. Lost-device admin code via `POST /api/players/reset-access` (10/hr per IP, 6-digit, 15-min TTL — in-memory `lib/recoveryCodes.ts`, does NOT survive cold starts).
-  - **Recovery code path clears `members.pinHash`** (and the `players.pinHash` mirror) on success — the user reached this path because they forgot their PIN, so any subsequent `RecoveryPinSheet` should render in 2-field mode (no current-PIN prompt). Without this, the sheet's `hasPin` check left users stuck after a reset.
+  - **Recovery code path clears `members.pinHash`** (and the `players.pinHash` mirror) on success — the user reached this path because they forgot their PIN, so any subsequent `RecoveryPinSheet` should render in 2-field mode (no current-PIN prompt). Without this, the sheet's `hasPin` check left users stuck after a reset. **It also mints a `member_session` cookie** (consuming a valid admin-issued code proves identity, same as a PIN sign-in) — this is what lets the user pass the members/me first-set guard below when they pick a replacement PIN. (WS#3, 2026-06-03.)
+  - **`PATCH /api/members/me` first-PIN set (claim flow) requires identity proof** (WS#3, 2026-06-03): a `member_session` cookie for that name (minted at sign-up, PIN sign-in, or recovery-code reset) OR admin. Previously name-only — member names are enumerable via `GET /api/members`, so anyone could claim an unclaimed (no-PIN) account and sign in as them. The **change-PIN** branch is unaffected (`currentPin` is its credential). Client-side: `GET /api/members/me` returns `authed`; `ProfileTab` passes it to `RecoveryPinSheet`, which blocks first-set with actionable guidance (`profile.pinNeedsSignIn`) when known-not-authed (e.g. cookie expired past its 30-day TTL while `localStorage` identity persists), and never blocks on `authed === null` (unknown — server is the backstop).
   - Profile signed-in: PIN management lives in Settings as `New PIN` / `Update PIN` row → opens `RecoveryPinSheet` (Set/Change only — no Remove). Status sourced from `/api/members/me?name=X` returning `hasPin`, refetched on identity change.
   - **PIN is opt-in.** `ForcePinModal` was removed in commit 2026-05-07 (was already unmounted; deleted with no consumers).
   - **Admin login**: per-player auth via name + own PIN (`POST /api/admin`); cookie HMAC-signed via `SESSION_SECRET`. `member.role === 'admin'` required. Bootstrap names via `ADMIN_NAMES` env var. **Cookie TTL is 30 days** (`lib/auth.ts:29`); was 8h pre-v1.3, bumped to match `badminton_identity` localStorage longevity.

--- a/__tests__/admin-auth-rolecheck.test.ts
+++ b/__tests__/admin-auth-rolecheck.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { POST as aliasesPOST, PATCH as aliasesPATCH, DELETE as aliasesDELETE } from '@/app/api/aliases/route';
+import { POST as announcementsPOST } from '@/app/api/announcements/route';
+import { POST as birdsPOST } from '@/app/api/birds/route';
+import { POST as releasesPOST } from '@/app/api/releases/route';
+import { POST as skillsPOST } from '@/app/api/skills/route';
+import { PUT as sessionPUT } from '@/app/api/session/route';
+import { POST as advancePOST } from '@/app/api/session/advance/route';
+import { POST as settlePOST } from '@/app/api/session/settle/route';
+import { PATCH as birdUsagePATCH } from '@/app/api/session/bird-usage/route';
+import { POST as dismissPOST } from '@/app/api/session/dismiss-anomaly/route';
+import { DELETE as playersDELETE } from '@/app/api/players/route';
+import { POST as resetAccessPOST } from '@/app/api/players/reset-access/route';
+import { POST as backfillPOST } from '@/app/api/admin/backfill-attendance/route';
+import { POST as migratePOST } from '@/app/api/admin/migrate-memberId/route';
+import { POST as membersPOST, PATCH as membersPATCH, DELETE as membersDELETE } from '@/app/api/members/route';
+import {
+  resetMockStore,
+  setupAdminPin,
+  makeAdminRequest,
+  seedAdminMember,
+  seedPointer,
+  seedSession,
+  seedPlayer,
+  getStore,
+} from './helpers';
+
+import type { NextRequest } from 'next/server';
+
+type Handler = (req: NextRequest) => Promise<Response>;
+
+/**
+ * Every audit-scoped *mutating* admin route must re-check the caller's role on
+ * each request (via `isAdminAuthedWithMember`), so an admin demoted or
+ * deactivated AFTER login loses write powers immediately rather than at the
+ * 30-day cookie expiry. With a valid admin cookie but a member doc whose
+ * `role !== 'admin'` (or `active === false`), the route must return 401.
+ */
+const MUTATING_ROUTES: Array<{ name: string; handler: Handler; method: string; url: string; body?: Record<string, unknown> }> = [
+  { name: 'aliases POST', handler: aliasesPOST, method: 'POST', url: 'http://localhost:3000/api/aliases', body: { name: 'x', etransferName: 'y' } },
+  { name: 'aliases PATCH', handler: aliasesPATCH, method: 'PATCH', url: 'http://localhost:3000/api/aliases', body: { name: 'x', etransferName: 'y' } },
+  { name: 'aliases DELETE', handler: aliasesDELETE, method: 'DELETE', url: 'http://localhost:3000/api/aliases?name=x' },
+  { name: 'announcements POST', handler: announcementsPOST, method: 'POST', url: 'http://localhost:3000/api/announcements', body: { text: 'hi' } },
+  { name: 'birds POST', handler: birdsPOST, method: 'POST', url: 'http://localhost:3000/api/birds', body: { brand: 'Yonex', model: 'AS-30', tubesBought: 1, pricePerTube: 30 } },
+  { name: 'releases POST', handler: releasesPOST, method: 'POST', url: 'http://localhost:3000/api/releases', body: { version: 'v9', notes: 'x' } },
+  { name: 'skills POST', handler: skillsPOST, method: 'POST', url: 'http://localhost:3000/api/skills', body: { name: 'x', skills: {} } },
+  { name: 'session PUT', handler: sessionPUT, method: 'PUT', url: 'http://localhost:3000/api/session', body: { title: 'x' } },
+  { name: 'session/advance POST', handler: advancePOST, method: 'POST', url: 'http://localhost:3000/api/session/advance', body: {} },
+  { name: 'session/settle POST', handler: settlePOST, method: 'POST', url: 'http://localhost:3000/api/session/settle', body: {} },
+  { name: 'session/bird-usage PATCH', handler: birdUsagePATCH, method: 'PATCH', url: 'http://localhost:3000/api/session/bird-usage', body: { purchaseId: 'x', sessionId: 'session-2026-04-24', tubes: 1 } },
+  { name: 'session/dismiss-anomaly POST', handler: dismissPOST, method: 'POST', url: 'http://localhost:3000/api/session/dismiss-anomaly', body: { key: 'x' } },
+  { name: 'players/reset-access POST', handler: resetAccessPOST, method: 'POST', url: 'http://localhost:3000/api/players/reset-access', body: { name: 'x' } },
+  { name: 'admin/backfill-attendance POST', handler: backfillPOST, method: 'POST', url: 'http://localhost:3000/api/admin/backfill-attendance', body: {} },
+  { name: 'admin/migrate-memberId POST', handler: migratePOST, method: 'POST', url: 'http://localhost:3000/api/admin/migrate-memberId', body: {} },
+  { name: 'members POST', handler: membersPOST, method: 'POST', url: 'http://localhost:3000/api/members', body: { name: 'x' } },
+  { name: 'members PATCH', handler: membersPATCH, method: 'PATCH', url: 'http://localhost:3000/api/members', body: { id: 'x' } },
+  { name: 'members DELETE', handler: membersDELETE, method: 'DELETE', url: 'http://localhost:3000/api/members?id=x' },
+];
+
+describe('admin role re-check on mutating routes (demotion takes effect immediately)', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+  });
+
+  for (const route of MUTATING_ROUTES) {
+    it(`${route.name} returns 401 when the cookie's member was demoted to non-admin`, async () => {
+      seedAdminMember({ role: 'member' });
+      const res = await route.handler(makeAdminRequest(route.method, route.url, route.body));
+      expect(res.status).toBe(401);
+    });
+  }
+
+  it('aliases POST returns 401 when the cookie\'s member was deactivated', async () => {
+    seedAdminMember({ active: false });
+    const res = await aliasesPOST(
+      makeAdminRequest('POST', 'http://localhost:3000/api/aliases', { name: 'x', etransferName: 'y' }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+/**
+ * players DELETE doesn't hard-401 on a non-admin — it degrades the inline
+ * `isAdmin` flag and falls through to the player-self cancel path. So the
+ * demotion contract here is behavioural: a demoted admin's `purgeAll` must NOT
+ * hard-delete the session's roster.
+ */
+describe('players DELETE purgeAll is refused for a demoted admin', () => {
+  beforeEach(() => {
+    setupAdminPin();
+    resetMockStore();
+    seedPointer('session-2026-04-24');
+    seedSession('session-2026-04-24');
+  });
+
+  it('leaves the roster intact when the cookie\'s member is no longer admin', async () => {
+    seedPlayer('session-2026-04-24', 'Alice');
+    seedPlayer('session-2026-04-24', 'Bob');
+    seedAdminMember({ role: 'member' });
+
+    await playersDELETE(
+      makeAdminRequest('DELETE', 'http://localhost:3000/api/players', { purgeAll: true }),
+    );
+
+    const players = (getStore()['players'] ?? []) as Array<{ name: string }>;
+    expect(players.map((p) => p.name).sort()).toEqual(['Alice', 'Bob']);
+  });
+});

--- a/__tests__/announcements.test.ts
+++ b/__tests__/announcements.test.ts
@@ -7,12 +7,14 @@ import {
   makeAdminRequest,
   seedPointer,
   seedSession,
+  seedAdminMember,
 } from './helpers';
 
 describe('POST /api/announcements — markdown round-trip', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-24');
     seedSession('session-2026-04-24');
   });

--- a/__tests__/api/releases.test.ts
+++ b/__tests__/api/releases.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GET, POST, DELETE } from '../../app/api/releases/route';
 import { NextRequest } from 'next/server';
-import { resetMockStore, makeAdminRequest, makeRequest, setupAdminPin } from '../helpers';
+import { resetMockStore, makeAdminRequest, makeRequest, setupAdminPin,
+  seedAdminMember,
+} from '../helpers';
 
 setupAdminPin();
 
@@ -32,6 +34,7 @@ const validBody = {
 describe('/api/releases', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
   });
 
   it('GET returns array (public)', async () => {

--- a/__tests__/birds.test.ts
+++ b/__tests__/birds.test.ts
@@ -7,6 +7,7 @@ import {
   makeGetRequest,
   seedPointer,
   seedSession,
+  seedAdminMember,
 } from './helpers';
 import { GET, POST, DELETE, PATCH } from '@/app/api/birds/route';
 
@@ -14,6 +15,7 @@ describe('Birds API', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
   });
 
   describe('POST /api/birds', () => {

--- a/__tests__/components/RecoveryPinSheet.test.tsx
+++ b/__tests__/components/RecoveryPinSheet.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import RecoveryPinSheet from '../../components/RecoveryPinSheet';
+import enMessages from '../../messages/en.json';
+
+const identity = { name: 'Riley', token: 'tok', sessionId: 'session-2026-04-27' };
+
+function renderSheet(props: { hasPin: boolean; authed: boolean | null }) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      <RecoveryPinSheet
+        open
+        onClose={vi.fn()}
+        identity={identity}
+        hasPin={props.hasPin}
+        authed={props.authed}
+        onSaved={vi.fn()}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe('RecoveryPinSheet — first-set requires an active session', () => {
+  afterEach(() => cleanup());
+
+  it('blocks first-PIN set with guidance when the member is not authed', () => {
+    renderSheet({ hasPin: false, authed: false });
+    // Actionable guidance instead of the set form.
+    expect(screen.getByText(/sign up for this week/i)).toBeDefined();
+    // The Save action must not be offered — there's no valid credential.
+    expect(screen.queryByRole('button', { name: /^save$/i })).toBeNull();
+  });
+
+  it('allows first-PIN set when the member is authed (holds a member cookie)', () => {
+    renderSheet({ hasPin: false, authed: true });
+    expect(screen.queryByText(/sign up for this week/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDefined();
+  });
+
+  it('does not block on unknown auth (authed null) — server is the backstop', () => {
+    renderSheet({ hasPin: false, authed: null });
+    expect(screen.queryByText(/sign up for this week/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDefined();
+  });
+
+  it('never blocks the change-PIN path (hasPin true)', () => {
+    renderSheet({ hasPin: true, authed: false });
+    expect(screen.queryByText(/sign up for this week/i)).toBeNull();
+  });
+});

--- a/__tests__/equipment-gear.test.ts
+++ b/__tests__/equipment-gear.test.ts
@@ -1,12 +1,20 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GET, PUT } from '@/app/api/equipment/gear/route';
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
+import { setMemberCookie } from '@/lib/auth';
+import { setupAdminPin, makeAdminRequest, seedAdminMember } from './helpers';
 
 function get(url: string): NextRequest {
   return new NextRequest(new URL(url, 'http://localhost/bpm'));
 }
+function memberCookieValue(memberId: string, name: string): string {
+  const r = NextResponse.json({});
+  setMemberCookie(r, memberId, name);
+  return r.cookies.get('member_session')!.value;
+}
+/** Anonymous PUT (no member cookie). */
 function put(body: unknown): NextRequest {
   return new NextRequest(new URL('/api/equipment/gear', 'http://localhost/bpm'), {
     method: 'PUT',
@@ -14,16 +22,30 @@ function put(body: unknown): NextRequest {
     headers: { 'content-type': 'application/json' },
   });
 }
+/** PUT signed in as a given member. */
+function putAs(memberId: string, name: string, body: unknown): NextRequest {
+  return new NextRequest(new URL('/api/equipment/gear', 'http://localhost/bpm'), {
+    method: 'PUT',
+    body: JSON.stringify(body),
+    headers: {
+      'content-type': 'application/json',
+      cookie: `member_session=${memberCookieValue(memberId, name)}`,
+    },
+  });
+}
+
+const racket = { catalogId: 'r1', category: 'racket', label: 'Yonex Astrox 88' };
 
 describe('/api/equipment/gear', () => {
   beforeEach(async () => {
     process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'true';
+    setupAdminPin();
     const members = getContainer('members');
     await members.items.upsert({ id: 'm-lin', name: 'Lin', active: true, stage: 4 });
   });
 
-  it('PUT sets a member racket, GET reads it back', async () => {
-    const putRes = await PUT(put({ name: 'Lin', item: { catalogId: 'r1', category: 'racket', label: 'Yonex Astrox 88' } }));
+  it('PUT (as the member) sets a racket, GET reads it back', async () => {
+    const putRes = await PUT(putAs('m-lin', 'Lin', { name: 'Lin', item: racket }));
     expect(putRes.status).toBe(200);
 
     const getRes = await GET(get('/api/equipment/gear?name=Lin'));
@@ -34,13 +56,33 @@ describe('/api/equipment/gear', () => {
   });
 
   it('PUT replaces the existing racket rather than duplicating', async () => {
-    await PUT(put({ name: 'Lin', item: { catalogId: 'r1', category: 'racket', label: 'Astrox 88' } }));
-    await PUT(put({ name: 'Lin', item: { catalogId: 'r2', category: 'racket', label: 'Nanoflare 800' } }));
+    await PUT(putAs('m-lin', 'Lin', { name: 'Lin', item: { catalogId: 'r1', category: 'racket', label: 'Astrox 88' } }));
+    await PUT(putAs('m-lin', 'Lin', { name: 'Lin', item: { catalogId: 'r2', category: 'racket', label: 'Nanoflare 800' } }));
     const getRes = await GET(get('/api/equipment/gear?name=Lin'));
     const body = await getRes.json();
     const rackets = body.gear.items.filter((i: { category: string }) => i.category === 'racket');
     expect(rackets).toHaveLength(1);
     expect(rackets[0].label).toBe('Nanoflare 800');
+  });
+
+  it('rejects an anonymous PUT (no member cookie)', async () => {
+    const res = await PUT(put({ name: 'Lin', item: racket }));
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects writing another member's gear", async () => {
+    const members = getContainer('members');
+    await members.items.upsert({ id: 'm-bob', name: 'Bob', active: true });
+    const res = await PUT(putAs('m-bob', 'Bob', { name: 'Lin', item: racket }));
+    expect(res.status).toBe(401);
+  });
+
+  it("lets an admin write on a member's behalf", async () => {
+    seedAdminMember();
+    const res = await PUT(
+      makeAdminRequest('PUT', 'http://localhost/bpm/api/equipment/gear', { name: 'Lin', item: racket }),
+    );
+    expect(res.status).toBe(200);
   });
 
   it('GET returns empty gear for an unknown member (loaded-empty, not error)', async () => {

--- a/__tests__/games.test.ts
+++ b/__tests__/games.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GET, POST } from '@/app/api/games/route';
 import { NextRequest } from 'next/server';
+import { resetMockStore, seedPointer, setupAdminPin, makeAdminRequest } from './helpers';
 
 function get(url: string): NextRequest {
   return new NextRequest(new URL(url, 'http://localhost/bpm'));
@@ -54,5 +55,39 @@ describe('/api/games', () => {
     process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'false';
     const res = await POST(post(validGame));
     expect(res.status).toBe(404);
+  });
+});
+
+describe('/api/games — sessionId override is admin-only (rule 7)', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'true';
+    setupAdminPin();
+    resetMockStore();
+    seedPointer('session-active');
+  });
+
+  it('ignores a client sessionId override on an anonymous POST (writes to the active session)', async () => {
+    const res = await POST(post({ ...validGame, sessionId: 'session-evil' }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.sessionId).toBe('session-active');
+  });
+
+  it('honors the sessionId override for an admin POST', async () => {
+    const res = await POST(
+      makeAdminRequest('POST', 'http://localhost/bpm/api/games', { ...validGame, sessionId: 'session-archive' }),
+    );
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.sessionId).toBe('session-archive');
+  });
+
+  it('ignores a ?sessionId= override on an anonymous GET (reads the active session)', async () => {
+    // Log into the active session, then a foreign read attempt must not surface it
+    // under the foreign id — the anon GET resolves to the active session regardless.
+    await POST(post({ ...validGame, sessionId: 'session-evil' }));
+    const res = await GET(get('/api/games?sessionId=session-evil'));
+    const body = await res.json();
+    expect(body.games.every((g: { sessionId: string }) => g.sessionId === 'session-active')).toBe(true);
   });
 });

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -166,6 +166,41 @@ export async function seedTestAdminMember() {
   return member;
 }
 
+/** The memberId carried by the test admin cookie — exported so tests can
+ *  seed a member doc at that id (e.g. a demoted/deactivated admin). */
+export const ADMIN_MEMBER_ID = TEST_ADMIN_MEMBER_ID;
+
+/**
+ * Seed the test admin Member *synchronously* (no `pinHash`). The async-with-member
+ * admin gate (`isAdminAuthedWithMember`) only re-checks `role === 'admin' &&
+ * active === true`, so mutating-route tests don't need the scrypt-hashed PIN that
+ * `seedTestAdminMember` computes — just the role/active fields. Pass overrides to
+ * model a demoted (`{ role: 'member' }`) or deactivated (`{ active: false }`)
+ * admin. Idempotent on the fixed admin memberId. Returns the member.
+ */
+export function seedAdminMember(overrides: Record<string, unknown> = {}) {
+  const store = getStore();
+  if (!store['members']) store['members'] = [];
+  const base = {
+    id: TEST_ADMIN_MEMBER_ID,
+    name: TEST_ADMIN_NAME,
+    role: 'admin' as const,
+    sessionCount: 0,
+    active: true,
+    createdAt: new Date().toISOString(),
+  };
+  const existing = (store['members'] as Array<{ id: string }>).find(
+    (m) => m.id === TEST_ADMIN_MEMBER_ID,
+  );
+  if (existing) {
+    Object.assign(existing, base, overrides);
+    return existing;
+  }
+  const member = { ...base, ...overrides };
+  store['members'].push(member);
+  return member;
+}
+
 function base64urlEncode(buf: Buffer): string {
   return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
 }

--- a/__tests__/members.test.ts
+++ b/__tests__/members.test.ts
@@ -3,6 +3,7 @@ import {
   resetMockStore,
   setupAdminPin,
   seedMember,
+  seedAdminMember,
   makeRequest,
   makeAdminRequest,
   makeGetRequest,
@@ -67,6 +68,10 @@ describe('GET /api/members', () => {
 describe('POST /api/members', () => {
   beforeEach(() => {
     resetMockStore();
+    // POST /api/members now uses the role-rechecking async admin gate, so the
+    // cookie's admin Member must exist. (GET stays sync — seeding here only,
+    // not in the GET block which asserts member-list counts.)
+    seedAdminMember();
   });
 
   it('admin creates a new member → 201', async () => {

--- a/__tests__/members.test.ts
+++ b/__tests__/members.test.ts
@@ -205,18 +205,46 @@ describe('PATCH /api/members/me — member-scoped PIN management', () => {
     setupAdminPin();
   });
 
-  it('first-time set: claim flow — no currentPin required when member has no pinHash', async () => {
-    seedMember('Riley');
+  it('first-time set: a signed-in member sets a first PIN with no currentPin', async () => {
+    const m = seedMember('Riley');
+    const res = await ME_PATCH(
+      makeRequest(
+        'POST',
+        'http://localhost:3000/api/members/me',
+        { name: 'Riley', newPin: '4827' },
+        { cookie: `member_session=${memberCookie(m.id, 'Riley')}` },
+      ),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.hasPin).toBe(true);
+  });
+
+  it('rejects an anonymous first-PIN claim — no member cookie + no currentPin → 401', async () => {
+    // Member names are enumerable via GET /api/members. Without this guard,
+    // any visitor could claim an unclaimed (no-PIN) account by POSTing a name
+    // + newPin, then sign in as them.
+    seedMember('Riley'); // no pinHash
     const res = await ME_PATCH(
       makeRequest('POST', 'http://localhost:3000/api/members/me', {
         name: 'Riley',
         newPin: '4827',
       }),
     );
+    expect(res.status).toBe(401);
+  });
+
+  it('admin may set a member\'s first PIN on their behalf', async () => {
+    seedMember('Riley'); // no pinHash
+    seedAdminMember();
+    const res = await ME_PATCH(
+      makeAdminRequest('POST', 'http://localhost:3000/api/members/me', {
+        name: 'Riley',
+        newPin: '4827',
+      }),
+    );
     expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.success).toBe(true);
-    expect(data.hasPin).toBe(true);
   });
 
   it('change with correct currentPin succeeds', async () => {
@@ -281,12 +309,14 @@ describe('PATCH /api/members/me — member-scoped PIN management', () => {
   });
 
   it('first-time set mints a member_session cookie — device trusted for one-tap sign-up', async () => {
-    seedMember('Riley');
+    const m = seedMember('Riley');
     const res = await ME_PATCH(
-      makeRequest('POST', 'http://localhost:3000/api/members/me', {
-        name: 'Riley',
-        newPin: '4827',
-      }),
+      makeRequest(
+        'POST',
+        'http://localhost:3000/api/members/me',
+        { name: 'Riley', newPin: '4827' },
+        { cookie: `member_session=${memberCookie(m.id, 'Riley')}` },
+      ),
     );
     expect(res.status).toBe(200);
     // Proving PIN ownership by setting it should trust this device, so the
@@ -351,12 +381,14 @@ describe('PATCH /api/members/me — member-scoped PIN management', () => {
     // Member set PIN; later when sessions advance, the member.pinHash
     // is still the source of truth — recover endpoint will verify
     // against it regardless of any (or no) session player.
-    seedMember('Riley');
+    const m = seedMember('Riley');
     await ME_PATCH(
-      makeRequest('POST', 'http://localhost:3000/api/members/me', {
-        name: 'Riley',
-        newPin: '4827',
-      }),
+      makeRequest(
+        'POST',
+        'http://localhost:3000/api/members/me',
+        { name: 'Riley', newPin: '4827' },
+        { cookie: `member_session=${memberCookie(m.id, 'Riley')}` },
+      ),
     );
 
     const { getStore } = await import('./helpers');

--- a/__tests__/players-delete.test.ts
+++ b/__tests__/players-delete.test.ts
@@ -7,6 +7,7 @@ import {
   seedPlayer,
   makeRequest,
   makeAdminRequest,
+  seedAdminMember,
 } from './helpers';
 import { DELETE } from '@/app/api/players/route';
 
@@ -21,6 +22,7 @@ describe('DELETE /api/players', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
     seedPointer(SESSION_ID);
     seedSession(SESSION_ID);
   });

--- a/__tests__/players-recover.test.ts
+++ b/__tests__/players-recover.test.ts
@@ -77,6 +77,22 @@ describe('POST /api/players/recover', () => {
     expect(data.deleteToken).toMatch(/^[0-9a-f]{32}$/);
   });
 
+  it('Code success mints a member_session cookie — the post-reset PIN sheet needs identity proof', async () => {
+    const { seedMember } = await import('./helpers');
+    const oldHash = await hashPin('1234');
+    seedMember('Sarah', { pinHash: oldHash });
+    const player = seedPlayer(SESSION, 'Sarah', { deleteToken: 'old-token' });
+    const { code } = await issueCode(player.id, SESSION);
+
+    const res = await POST(
+      makeRequest('POST', URL_PATH, { name: 'Sarah', sessionId: SESSION, code }),
+    );
+    expect(res.status).toBe(200);
+    // Consuming the code clears the PIN; the minted cookie is what lets the
+    // user pass the members/me first-set guard when they choose a new PIN.
+    expect(res.cookies.get('member_session')?.value).toBeTruthy();
+  });
+
   it('Wrong PIN: 401 invalid_credentials', async () => {
     const pinHash = await hashPin('1234');
     const { seedMember } = await import('./helpers');

--- a/__tests__/players-reset-access.test.ts
+++ b/__tests__/players-reset-access.test.ts
@@ -9,6 +9,7 @@ import {
   adminCookieValue,
   makeRequest,
   makeAdminRequest,
+  seedAdminMember,
 } from './helpers';
 import { __resetForTests } from '@/lib/recoveryCodes';
 
@@ -17,6 +18,7 @@ const URL_PATH = 'http://localhost:3000/api/players/reset-access';
 
 beforeEach(() => {
   resetMockStore();
+  seedAdminMember();
   setupAdminPin();
   __resetForTests();
   seedPointer(SESSION);

--- a/__tests__/players.test.ts
+++ b/__tests__/players.test.ts
@@ -11,6 +11,7 @@ import {
   makeAdminRequest,
   makeGetRequest,
   getStore,
+  seedAdminMember,
 } from './helpers';
 
 // ---- HELPERS ----
@@ -213,6 +214,9 @@ describe('PATCH /api/players — pin field', () => {
   beforeEach(() => {
     resetMockStoreH();
     setupAdminPin();
+    // PATCH now derives its admin flag via the role-rechecking async gate, so
+    // the cookie's admin Member must exist for the admin-set-PIN path.
+    seedAdminMember();
     seedPointerH(SESSION);
     seedSessionH(SESSION);
     process.env.NEXT_PUBLIC_FLAG_RECOVERY = 'true';

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -6,6 +6,7 @@ import {
   makeRequest,
   makeAdminRequest,
   makeGetRequest,
+  seedAdminMember,
 } from './helpers';
 
 function releaseBody(version = 'v1.0.0') {
@@ -20,6 +21,7 @@ describe('POST /api/releases', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
   });
 
   it('creates a release with env stamp when admin', async () => {
@@ -45,6 +47,7 @@ describe('PATCH /api/releases', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
   });
 
   it('updates existing record and stamps editedAt', async () => {
@@ -104,6 +107,7 @@ describe('GET /api/releases after PATCH', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
   });
 
   it('returns the edited version after PATCH', async () => {
@@ -132,6 +136,7 @@ describe('DELETE /api/releases', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
   });
 
   it('deletes a release when admin', async () => {

--- a/__tests__/session-bird-usage.test.ts
+++ b/__tests__/session-bird-usage.test.ts
@@ -8,6 +8,7 @@ import {
   seedPointer,
   seedSession,
   getStore,
+  seedAdminMember,
 } from './helpers';
 
 function seedPurchase(id: string, name: string, tubes = 10, costPerTube = 12): void {
@@ -28,6 +29,7 @@ describe('PATCH /api/session/bird-usage', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-24');
     seedSession('session-2026-04-24');
     seedPurchase('pur-yonex-1', 'Yonex AS-50');

--- a/__tests__/session-put-preserves.test.ts
+++ b/__tests__/session-put-preserves.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { PUT } from '@/app/api/session/route';
-import { resetMockStore, setupAdminPin, seedPointer, seedSession, makeAdminRequest, getStore } from './helpers';
+import { resetMockStore, setupAdminPin, seedPointer, seedSession, makeAdminRequest, getStore,
+  seedAdminMember,
+} from './helpers';
 
 /**
  * Audit finding: PUT /api/session rebuilt the doc from a fixed key-set and
@@ -17,6 +19,7 @@ const SID = 'session-2026-06-01';
 describe('PUT /api/session preserves fields the client does not send', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
     setupAdminPin();
     seedPointer(SID);
     seedSession(SID, {

--- a/__tests__/session-settle.test.ts
+++ b/__tests__/session-settle.test.ts
@@ -11,6 +11,7 @@ import {
   seedSession,
   seedPlayer,
   getStore,
+  seedAdminMember,
 } from './helpers';
 
 const SID = 'session-2026-05-04';
@@ -33,6 +34,7 @@ describe('POST /api/session/settle', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
     seedPointer(SID);
     seedSession(SID, { costPerCourt: 30, courts: 2 });
   });
@@ -148,6 +150,7 @@ describe('DELETE /api/session/settle', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
     seedPointer(SID);
     seedSession(SID, { costPerCourt: 30, courts: 2 });
   });
@@ -203,6 +206,7 @@ describe('advance derives prevCostPerPerson from settled snapshot', () => {
   beforeEach(() => {
     setupAdminPin();
     resetMockStore();
+    seedAdminMember();
     seedPointer(SID);
     seedSession(SID, { costPerCourt: 30, courts: 2 });
   });

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -9,6 +9,7 @@ import {
   makeAdminRequest,
   makeGetRequest,
   getStore,
+  seedAdminMember,
 } from './helpers';
 import { GET, PUT } from '@/app/api/session/route';
 import { POST as ADVANCE } from '@/app/api/session/advance/route';
@@ -20,6 +21,7 @@ setupAdminPin();
 describe('GET /api/session', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-05');
     seedSession('session-2026-04-05', { title: 'Test Session' });
   });
@@ -43,6 +45,7 @@ describe('GET /api/session', () => {
 describe('PUT /api/session', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-05');
     seedSession('session-2026-04-05', { title: 'Original Title' });
   });
@@ -234,6 +237,7 @@ describe('PUT /api/session', () => {
 describe('POST /api/session/advance', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-05');
     seedSession('session-2026-04-05', { title: 'Test Session' });
   });
@@ -353,6 +357,7 @@ describe('POST /api/session/advance', () => {
 describe('GET /api/sessions/costs', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-05');
   });
 

--- a/__tests__/skills.test.ts
+++ b/__tests__/skills.test.ts
@@ -7,6 +7,7 @@ import {
   makeRequest,
   makeAdminRequest,
   makeGetRequest,
+  seedAdminMember,
 } from './helpers';
 import { GET, POST, PATCH, DELETE } from '@/app/api/skills/route';
 
@@ -15,6 +16,7 @@ setupAdminPin();
 describe('Skills API', () => {
   beforeEach(() => {
     resetMockStore();
+    seedAdminMember();
     seedPointer('session-2026-04-12');
     seedSession('session-2026-04-12', { title: 'Test Session' });
   });
@@ -158,6 +160,7 @@ describe('Skills API', () => {
       );
       // Switch active session
       resetMockStore();
+      seedAdminMember();
       seedPointer('session-2026-04-19');
       seedSession('session-2026-04-19', { title: 'Next Session' });
 

--- a/app/api/admin/backfill-attendance/route.ts
+++ b/app/api/admin/backfill-attendance/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, sessionIdFromDate } from '@/lib/cosmos';
-import { isAdminAuthed } from '@/lib/auth';
+import { isAdminAuthedWithMember } from '@/lib/auth';
 
 /**
  * Admin-only one-shot backfill endpoint for historical attendance.
@@ -36,7 +36,7 @@ interface Body {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) {
+  if (!(await isAdminAuthedWithMember(req)).authed) {
     return NextResponse.json({ error: 'Not authorized' }, { status: 401 });
   }
 

--- a/app/api/admin/migrate-memberId/route.ts
+++ b/app/api/admin/migrate-memberId/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,7 +15,7 @@ interface MigrationSummary {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   let dryRun = false;
   try {

--- a/app/api/aliases/route.ts
+++ b/app/api/aliases/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { randomBytes } from 'crypto';
 
 export const dynamic = 'force-dynamic';
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     const body = await req.json();
     const appName = typeof body.appName === 'string' ? body.appName.trim().slice(0, 50) : '';
@@ -43,7 +43,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     const body = await req.json();
     const { id } = body;
@@ -67,7 +67,7 @@ export async function PATCH(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     const body = await req.json();
     const { id } = body;

--- a/app/api/announcements/route.ts
+++ b/app/api/announcements/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { readActiveAnnouncements } from '@/lib/announcements';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { randomBytes } from 'crypto';
 
 export async function GET() {
@@ -12,7 +12,7 @@ export async function GET() {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const sessionId = await getActiveSessionId();
@@ -45,7 +45,7 @@ export async function DELETE(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const sessionId = await getActiveSessionId();
@@ -89,7 +89,7 @@ export async function PATCH(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const sessionId = await getActiveSessionId();

--- a/app/api/birds/route.ts
+++ b/app/api/birds/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
 import { randomBytes } from 'crypto';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { normalizeBirdUsages, totalTubes } from '@/lib/birdUsages';
 import type { Session } from '@/lib/types';
 
@@ -61,7 +61,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const body = await req.json();
@@ -105,7 +105,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const body = await req.json();
@@ -124,7 +124,7 @@ export async function DELETE(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const body = await req.json();

--- a/app/api/equipment/gear/route.ts
+++ b/app/api/equipment/gear/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, ensureContainer } from '@/lib/cosmos';
+import { verifyMemberAuth, isAdminAuthedWithMember } from '@/lib/auth';
 import { isFlagOn } from '@/lib/flags';
 import type { PlayerGear, GearItem } from '@/lib/types';
 
@@ -48,10 +49,10 @@ export async function GET(req: NextRequest) {
   }
 }
 
-// TODO(value-hub): gear writes are name-keyed and unauthenticated for Slice-0
-// (a racket preference is low-sensitivity, same trust as anon sign-up). Bind to
-// PIN/identity here if gear later carries sensitive data — verify body.pin
-// against member.pinHash, same envelope as POST /api/players.
+// Gear writes are identity-bound: the caller must hold the member_session
+// cookie for the target member (minted at sign-up, no PIN required) or be an
+// admin. See the owner/admin check below. GET stays public — a racket
+// preference is low-sensitivity to read.
 export async function PUT(req: NextRequest) {
   if (!isFlagOn('NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE')) {
     return NextResponse.json({ error: 'not_found' }, { status: 404 });
@@ -66,6 +67,16 @@ export async function PUT(req: NextRequest) {
     }
     const memberId = await resolveMemberId(name);
     if (!memberId) return NextResponse.json({ error: 'member_not_found' }, { status: 404 });
+
+    // Gear is member-scoped: only the member themselves (proven by the
+    // member_session cookie minted at sign-up — no PIN required) or an admin
+    // may write it. Closes the name-keyed impersonation hole while keeping the
+    // "same trust as anon sign-up" bar the feature was designed around.
+    const caller = verifyMemberAuth(req);
+    const isOwner = caller?.memberId === memberId;
+    if (!isOwner && !(await isAdminAuthedWithMember(req)).authed) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
 
     const incoming: GearItem = {
       id: typeof body.item.id === 'string' ? body.item.id : randomBytes(12).toString('hex'),

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, ensureContainer, getActiveSessionId } from '@/lib/cosmos';
+import { isAdminAuthed } from '@/lib/auth';
 import { isFlagOn } from '@/lib/flags';
 import { getClientIp, checkRateLimit } from '@/lib/rateLimit';
 import type { GameResult } from '@/lib/types';
@@ -30,8 +31,9 @@ export async function GET(req: NextRequest) {
   }
   try {
     await ensureGames();
+    // sessionId override is admin-only (rule 7); non-admins read the active session.
     const override = new URL(req.url).searchParams.get('sessionId');
-    const sessionId = override || (await getActiveSessionId());
+    const sessionId = override && isAdminAuthed(req) ? override : await getActiveSessionId();
     const container = getContainer('gameResults');
     const { resources } = await container.items
       .query({
@@ -70,7 +72,8 @@ export async function POST(req: NextRequest) {
     const loggedBy = typeof body.loggedBy === 'string' ? body.loggedBy.trim().slice(0, 50) : '';
     if (!loggedBy) return NextResponse.json({ error: 'loggedBy_required' }, { status: 400 });
 
-    const sessionId = typeof body.sessionId === 'string' && body.sessionId
+    // sessionId override is admin-only (rule 7); non-admins log to the active session.
+    const sessionId = typeof body.sessionId === 'string' && body.sessionId && isAdminAuthed(req)
       ? body.sessionId
       : await getActiveSessionId();
 

--- a/app/api/members/me/route.ts
+++ b/app/api/members/me/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 import { hashPin, verifyPin, FAKE_HASH } from '@/lib/recoveryHash';
-import { verifyMemberAuth, setMemberCookie } from '@/lib/auth';
+import { verifyMemberAuth, isAdminAuthedWithMember, setMemberCookie } from '@/lib/auth';
 
 const BLOCKLISTED_PINS = new Set(['0000', '1111', '1234', '4321', '1212']);
 
@@ -136,7 +136,18 @@ async function handlePatch(req: NextRequest) {
       return NextResponse.json({ error: 'invalid_credentials' }, { status: 401 });
     }
   }
-  // No prior pinHash → claim flow, no currentPin required.
+  // No prior pinHash → first-set / claim flow. There's no currentPin to require,
+  // but identity must still be proven: a member_session cookie for THIS name
+  // (minted at sign-up, PIN sign-in, or recovery-code reset) or an admin.
+  // Without this, anyone who knows an enumerable member name (GET /api/members)
+  // could claim the account by setting its first PIN, then sign in as them.
+  if (!hadPin) {
+    const caller = verifyMemberAuth(req);
+    const isSelf = !!caller && caller.name.toLowerCase() === name.toLowerCase();
+    if (!isSelf && !(await isAdminAuthedWithMember(req)).authed) {
+      return NextResponse.json({ error: 'auth_required' }, { status: 401 });
+    }
+  }
 
   const memberDoc: Record<string, unknown> = { ...member, lastSeen: new Date().toISOString() };
   if (clearPin) {

--- a/app/api/members/route.ts
+++ b/app/api/members/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { randomBytes } from 'crypto';
 
 export async function GET(req: NextRequest) {
@@ -32,7 +32,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     const body = await req.json();
     const trimmedName = typeof body.name === 'string' ? body.name.trim() : '';
@@ -86,7 +86,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     const body = await req.json();
     const { id } = body;
@@ -160,7 +160,7 @@ export async function PATCH(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     const body = await req.json();
     const { id } = body;

--- a/app/api/players/recover/route.ts
+++ b/app/api/players/recover/route.ts
@@ -229,5 +229,13 @@ async function handlePost(req: NextRequest) {
     pinHash: '',
   });
 
-  return NextResponse.json({ deleteToken: newDeleteToken });
+  const res = NextResponse.json({ deleteToken: newDeleteToken });
+  // Consuming a valid admin-issued recovery code proves identity (same as a PIN
+  // sign-in does on the pin path), so mint the member_session cookie. Without
+  // it the user — who just cleared their PIN — would have no credential for the
+  // members/me first-set guard when they pick a new PIN in the next sheet.
+  if (member) {
+    setMemberCookie(res, String(member.id), String(member.name));
+  }
+  return res;
 }

--- a/app/api/players/reset-access/route.ts
+++ b/app/api/players/reset-access/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { issueCode } from '@/lib/recoveryCodes';
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
   }
 
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   let body: { playerId?: unknown };
   try {

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
 import { randomBytes, timingSafeEqual } from 'crypto';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
-import { isAdminAuthed, verifyMemberAuth, setMemberCookie } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, verifyMemberAuth, setMemberCookie } from '@/lib/auth';
 import { hashPin, verifyPin, FAKE_HASH } from '@/lib/recoveryHash';
 import { appendEvent } from '@/lib/recoveryAudit';
 import type { RecoveryEvent } from '@/lib/types';
@@ -342,7 +342,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  const isAdmin = isAdminAuthed(req);
+  const isAdmin = (await isAdminAuthedWithMember(req)).authed;
 
   try {
     const body = await req.json();
@@ -560,7 +560,7 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: 'Too many requests. Please wait a moment.' }, { status: 429 });
   }
 
-  const isAdmin = isAdminAuthed(req);
+  const isAdmin = (await isAdminAuthedWithMember(req)).authed;
 
   try {
     const body = await req.json();

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, ensureContainer } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { getEnv, type EnvName } from '@/lib/flags';
 
 export const dynamic = 'force-dynamic';
@@ -72,7 +72,7 @@ export async function GET(_req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     await ensureReleasesContainer();
     const raw = await req.json();
@@ -104,7 +104,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     await ensureReleasesContainer();
     const raw = await req.json();
@@ -146,7 +146,7 @@ export async function PATCH(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
   try {
     await ensureReleasesContainer();
     const { id } = await req.json();

--- a/app/api/session/advance/route.ts
+++ b/app/api/session/advance/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, setActiveSessionId, sessionIdFromDate } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { toValidIso } from '@/app/api/session/route';
 import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
 
@@ -34,7 +34,7 @@ function calculateSignupOpensOffset(session: any): number {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const body = await req.json();

--- a/app/api/session/bird-usage/route.ts
+++ b/app/api/session/bird-usage/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { normalizeBirdUsages } from '@/lib/birdUsages';
 import type { BirdUsage, Session } from '@/lib/types';
 
@@ -17,7 +17,7 @@ export const dynamic = 'force-dynamic';
  * - tubes === 0 removes the entry for that purchase (undo assignment).
  */
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const body = await req.json();

--- a/app/api/session/dismiss-anomaly/route.ts
+++ b/app/api/session/dismiss-anomaly/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,7 +19,7 @@ export const dynamic = 'force-dynamic';
  * round-trip client version, AND we never write fields we didn't read).
  */
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   let code: string;
   try {

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, POINTER_ID, DEFAULT_SESSION } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import type { BirdUsage, ETransferRecipient } from '@/lib/types';
 
 function isValidETransferRecipient(value: unknown): value is ETransferRecipient {
@@ -44,7 +44,7 @@ export function toValidIso(val: unknown): string {
 }
 
 export async function PUT(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const body = await req.json();

--- a/app/api/session/settle/route.ts
+++ b/app/api/session/settle/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
 import type { Player, Session, SettledSnapshot } from '@/lib/types';
 
@@ -32,7 +32,7 @@ async function resolveTargetSessionId(req: NextRequest): Promise<string> {
  * silently redefine what already-paid players paid for.
  */
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const sessionId = await resolveTargetSessionId(req);
@@ -143,7 +143,7 @@ export async function POST(req: NextRequest) {
  * payment from this person") that survives a typo'd settle.
  */
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     const sessionId = await resolveTargetSessionId(req);

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, getActiveSessionId, ensureContainer } from '@/lib/cosmos';
-import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import type { PlayerSkills } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -68,7 +68,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     await ensureSkillsContainer();
@@ -124,7 +124,7 @@ export async function POST(req: NextRequest) {
 }
 
 export async function PATCH(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     await ensureSkillsContainer();
@@ -158,7 +158,7 @@ export async function PATCH(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
-  if (!isAdminAuthed(req)) return unauthorized();
+  if (!(await isAdminAuthedWithMember(req)).authed) return unauthorized();
 
   try {
     await ensureSkillsContainer();

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -35,6 +35,10 @@ export default function ProfileTab({
   // 5xx on /api/members/me silently rendered "Recovery PIN: Not set" and
   // pushed users into a re-create loop that 409'd on `account_exists`.
   const [pinIsSet, setPinIsSet] = useState<boolean | null>(null);
+  // Whether this device holds a valid member_session cookie. Gates first-PIN
+  // set in RecoveryPinSheet (the server requires the cookie for the claim flow).
+  // null = unknown — don't block on it.
+  const [pinAuthed, setPinAuthed] = useState<boolean | null>(null);
   const [memberCreatedAt, setMemberCreatedAt] = useState<string | null>(null);
   const [isSignedUp, setIsSignedUp] = useState<boolean>(false);
   const [enterCodeOpen, setEnterCodeOpen] = useState(false);
@@ -92,10 +96,12 @@ export default function ProfileTab({
         if (!r.ok) throw new Error(`hasPin fetch ${r.status}`);
         return r.json();
       })
-      .then((data: { hasPin?: boolean; createdAt?: string | null }) => {
+      .then((data: { hasPin?: boolean; createdAt?: string | null; authed?: boolean }) => {
         if (cancelled) return;
         setPinIsSet(data.hasPin === true);
         setMemberCreatedAt(typeof data.createdAt === 'string' ? data.createdAt : null);
+        // `authed` gates first-PIN set in RecoveryPinSheet; unknown stays null.
+        setPinAuthed(typeof data.authed === 'boolean' ? data.authed : null);
       })
       .catch((err) => {
         if (cancelled) return;
@@ -104,6 +110,7 @@ export default function ProfileTab({
         // recreate-account loops on transient backend failures.
         console.warn('hasPin fetch failed:', err);
         setPinIsSet(null);
+        setPinAuthed(null);
       });
 
     // Signed-up status — independent chain; its failure must NOT touch pinIsSet.
@@ -336,6 +343,7 @@ export default function ProfileTab({
         onClose={() => setRecoveryPinOpen(false)}
         identity={identity}
         hasPin={pinIsSet === true}
+        authed={pinAuthed}
         onSaved={(newHasPin) => setPinIsSet(newHasPin)}
       />
       <EnterCodeSheet

--- a/components/RecoveryPinSheet.tsx
+++ b/components/RecoveryPinSheet.tsx
@@ -12,6 +12,14 @@ interface Props {
   onClose: () => void;
   identity: Identity;
   hasPin: boolean;
+  /**
+   * Whether this device holds a valid member_session cookie for the identity
+   * (from `GET /api/members/me` → `authed`). Tri-state: `null` = unknown
+   * (fetch pending/failed) — don't block on unknown, let the server be the
+   * backstop. Only `false` (known-not-authed) gates the first-PIN set, since
+   * the server requires that cookie for the claim flow.
+   */
+  authed?: boolean | null;
   /** Fires after a successful save with the new state. */
   onSaved: (newHasPin: boolean) => void;
 }
@@ -22,9 +30,10 @@ type PinError =
   | 'failed'
   | 'wrong_current'
   | 'rate_limited'
+  | 'needs_signin'
   | null;
 
-export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSaved }: Props) {
+export default function RecoveryPinSheet({ open, onClose, identity, hasPin, authed = null, onSaved }: Props) {
   const t = useTranslations('profile');
   const tSettings = useTranslations('profile.settings');
   const tPin = useTranslations('pin');
@@ -69,6 +78,9 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
         else if (body.error === 'pin_too_common') setPinError('too_common');
         else if (body.error === 'Invalid PIN format') setPinError('invalid');
         else if (body.error === 'invalid_credentials' || body.error === 'current_pin_required') setPinError('wrong_current');
+        // Server's first-set guard rejected us — the cookie expired since the
+        // client last checked `authed`. Show the same actionable guidance.
+        else if (body.error === 'auth_required') setPinError('needs_signin');
         else setPinError('failed');
         return;
       }
@@ -82,6 +94,10 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
     }
   }
 
+  // First-set requires a member_session cookie (server enforces it). Block the
+  // form only when we KNOW the device isn't authed; `null` (unknown) falls
+  // through to let the user try, with the server as the backstop.
+  const firstSetBlocked = !hasPin && authed === false;
   const title = hasPin ? tSettings('updatePin') : tSettings('newPin');
   const submitLabel = hasPin ? tSettings('updatePin') : tPin('save');
   const canSubmit =
@@ -104,6 +120,16 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
+        {firstSetBlocked ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <p role="alert" style={{ fontSize: 14, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
+              {t('pinNeedsSignIn')}
+            </p>
+            <button type="button" className="cc-btn cc-btn-secondary cc-btn-lg" onClick={onClose}>
+              {tRecovery('close')}
+            </button>
+          </div>
+        ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
           {hasPin && (
             <div>
@@ -162,6 +188,11 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
               {t('pinUpdateFailed')}
             </p>
           )}
+          {pinError === 'needs_signin' && (
+            <p role="alert" style={{ fontSize: 12, color: 'var(--color-amber, #f59e0b)', margin: 0 }}>
+              {t('pinNeedsSignIn')}
+            </p>
+          )}
           {newPin && confirmPin && newPin !== confirmPin && (
             <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
               {tPin('mismatch')}
@@ -176,6 +207,7 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, onSa
             {submitLabel}
           </button>
         </div>
+        )}
       </BottomSheetBody>
     </BottomSheet>
   );

--- a/messages/en.json
+++ b/messages/en.json
@@ -173,6 +173,7 @@
     "pinTooCommon": "Pick a less common PIN",
     "pinInvalid": "PIN must be 4 digits",
     "pinUpdateFailed": "Couldn't update PIN. Please try again.",
+    "pinNeedsSignIn": "Sign up for this week first — it re-activates your account on this device so you can set a PIN.",
     "pinWrongCurrent": "Current PIN doesn't match.",
     "pinRateLimited": "Too many tries. Try again in an hour.",
     "adminToolsTitle": "Admin tools",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -173,6 +173,7 @@
     "pinTooCommon": "请选择不那么常见的 PIN",
     "pinInvalid": "PIN 必须是 4 位数字",
     "pinUpdateFailed": "更新 PIN 失败，请重试。",
+    "pinNeedsSignIn": "请先报名本周活动——这会在此设备上重新激活你的账户，然后即可设置 PIN。",
     "pinWrongCurrent": "当前 PIN 不正确。",
     "pinRateLimited": "尝试次数过多，请一小时后再试。",
     "adminToolsTitle": "管理员工具",


### PR DESCRIPTION
Workstream #3 of the 2026-06-02 codebase audit (`docs/audit/README.md`), **audit-scoped**. Closes the admin-auth findings. Self-contained; branched off `main` after WS#1/#2 landed.

## What changed

**A — role re-check on mutating routes (`e57f505`)**
~16 mutating admin routes switched from sync `isAdminAuthed` (cookie signature + expiry only) to async `isAdminAuthedWithMember` (re-reads the Member, enforces `role==='admin' && active===true`). A demoted/deactivated admin now loses write powers on the **next request** instead of after the 30-day cookie TTL — the contract `lib/auth.ts` already documented. Read-only GETs and the rule-7 sessionId override stay sync by design (no Cosmos read on hot paths). players PATCH/DELETE inline `isAdmin` flag (unlocks purgeAll/clearAll) made role-aware too.

**B — two unauthenticated write paths (`c10bf5d`)**
- `games` POST/GET: client `sessionId` override was honored with no auth (rule 7). Gated behind admin; non-admins use the active session.
- `equipment/gear` PUT: name-keyed, fully unauthenticated → anyone could overwrite any member's gear. Bound to identity — member_session cookie for the target member (minted at sign-up, no PIN) or admin. GET stays public.

**C — members/me first-PIN claim (`8443359`)**
Setting a member's **first** PIN required only their (enumerable) name — account-takeover vector. First-set now requires a member_session cookie for that name or admin. Coordinated so the legit post-recovery "set a new PIN" flow keeps working: `/api/players/recover` code path now mints a member cookie on success (it just proved the admin-issued code).

**C client (`384d8a0`)**
Surfaces the `authed` signal members/me already returns so a PIN-less member with an expired cookie gets actionable guidance ("Sign up for this week first…") instead of a generic failure. Tri-state — never blocks on unknown.

## Tests
718 pass (was 685 at branch base). New: `admin-auth-rolecheck.test.ts` (demotion → 401 across every switched route + players purge), games/gear override + identity tests, members/me anon-claim rejection + recover-cookie, `RecoveryPinSheet.test.tsx` gating. `tsc --noEmit` clean (only the 7 pre-existing test-type errors remain — WS#4).

## Known seams (non-blocking, called out for review)
1. `games` override stayed **sync** `isAdminAuthed` (matches existing skills/players style) — a demoted admin could misdirect game writes for up to 30 days. Flag-gated, trivial scores.
2. `POST /api/claude` (budget-spending) stayed sync per audit scope — demoted admin keeps 30-day API-budget access.
3. Async auth means a transient Cosmos error now **fail-closes** admin mutations to 401 (correct posture, but a behavior change on B1).
4. `CLAUDE.md` auth-taxonomy still documents the old "first-PIN claim, no currentPin" as a feature — needs a doc update (batched separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)