### PR TITLE
fix(signup): show PIN field on the waitlist form so PIN'd members can join

### DIFF
--- a/__tests__/players-signup-with-pin.test.ts
+++ b/__tests__/players-signup-with-pin.test.ts
@@ -5,6 +5,7 @@ import {
   seedPointer,
   seedSession,
   seedMember,
+  seedPlayer,
   makeRequest,
 } from './helpers';
 import { POST } from '@/app/api/players/route';
@@ -162,5 +163,67 @@ describe('POST /api/players with trusted-device cookie (member_session)', () => 
     const res = await POST(req);
     expect(res.status).toBe(201);
     expect(res.cookies.get('member_session')?.value).toBeTruthy();
+  });
+});
+
+/**
+ * Waitlist sign-up enforces the same PIN guard as a normal sign-up. The Home
+ * waitlist form now reveals the PIN field adaptively and sends `pin` alongside
+ * `waitlist: true` — these tests lock in the server contract that form satisfies.
+ * Regression for the "PIN required but no PIN input" waitlist bug.
+ */
+describe('POST /api/players waitlist with PIN', () => {
+  const sessionId = 'session-2026-05-20';
+  const pin = '2468';
+
+  beforeEach(async () => {
+    resetMockStore();
+    seedPointer(sessionId);
+    // Capacity of 2, both spots taken → the session is full so any further
+    // sign-up must go through the waitlist branch.
+    seedSession(sessionId, { maxPlayers: 2, signupOpen: true });
+    seedPlayer(sessionId, 'Viktor');
+    seedPlayer(sessionId, 'Carolina');
+    const pinHash = await hashPin(pin);
+    seedMember('Lin', { pinHash });
+  });
+
+  it('valid PIN + waitlist:true waitlists the PIN-protected member (201)', async () => {
+    const req = makeRequest('POST', 'http://localhost:3000/api/players', {
+      name: 'Lin',
+      pin,
+      waitlist: true,
+    }, { 'X-Client-IP': '10.2.0.1' });
+
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.name).toBe('Lin');
+    expect(body.waitlisted).toBe(true);
+    expect(body.pinHash).toBeUndefined();
+  });
+
+  it('missing PIN + waitlist:true returns 401 pin_required (guard runs before the waitlist branch)', async () => {
+    const req = makeRequest('POST', 'http://localhost:3000/api/players', {
+      name: 'Lin',
+      waitlist: true,
+    }, { 'X-Client-IP': '10.2.0.2' });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('pin_required');
+  });
+
+  it('wrong PIN + waitlist:true returns 401 pin_incorrect', async () => {
+    const req = makeRequest('POST', 'http://localhost:3000/api/players', {
+      name: 'Lin',
+      pin: '9999',
+      waitlist: true,
+    }, { 'X-Client-IP': '10.2.0.3' });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('pin_incorrect');
   });
 });

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -240,8 +240,11 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
   }, []);
   const openReleaseSheet = useCallback(() => setReleaseSheetOpen(true), []);
 
-  async function handleSignUp(e: React.FormEvent) {
-    e.preventDefault();
+  // Unified sign-up + waitlist submit. `waitlist` adds `waitlist: true` to the
+  // POST body and tunes the failure copy — otherwise the auth flow (anon /
+  // sign-in PIN / create PIN) is identical, so a PIN-protected member can join
+  // the waitlist with the same inline PIN field the open-signup form uses.
+  async function performSignup(waitlist: boolean) {
     // Legible-fail: refuse the mutation with a clear reason instead of
     // firing a fetch that throws and leaves the form in limbo.
     if (!online) { setError(t('signup.offline')); return; }
@@ -290,11 +293,11 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         const signupRes = await fetch(`${BASE}/api/players`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: trimmed, pin }),
+          body: JSON.stringify({ name: trimmed, pin, ...(waitlist ? { waitlist: true } : {}) }),
         });
         const signupData = await signupRes.json();
         if (!signupRes.ok) {
-          setError(signupData.error ?? t('signup.genericFailure'));
+          setError(signupData.error ?? (waitlist ? t('signup.waitlistFailure') : t('signup.genericFailure')));
           if (signupRes.status === 409) loadData();
           return;
         }
@@ -302,7 +305,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         setIdentity({ name: trimmed, token: signupData.deleteToken ?? '', sessionId: session.id });
         setCurrentUser(trimmed);
         setHasIdentity(true);
-        setJustSignedUp(true);
+        if (!waitlist) setJustSignedUp(true);
         await loadData();
       } else {
         // 'anon' and 'create' both go through POST /api/players. The only
@@ -310,6 +313,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         // (e.g. rejects 'pin_too_common', enforces invite list).
         const body: Record<string, unknown> = { name: trimmed };
         if (authMode === 'create') body.pin = pin;
+        if (waitlist) body.waitlist = true;
         const res = await fetch(`${BASE}/api/players`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -325,7 +329,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
           } else if (data.error === 'pin_too_common' || data.error === 'Invalid PIN format') {
             setError(t('signup.pinTooCommon'));
           } else {
-            setError(data.error ?? t('signup.genericFailure'));
+            setError(data.error ?? (waitlist ? t('signup.waitlistFailure') : t('signup.genericFailure')));
           }
           if (res.status === 409) loadData();
           return;
@@ -334,7 +338,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         setIdentity({ name: trimmed, token: data.deleteToken ?? '', sessionId: session.id });
         setCurrentUser(trimmed);
         setHasIdentity(true);
-        setJustSignedUp(true);
+        if (!waitlist) setJustSignedUp(true);
         await loadData();
       }
     } catch {
@@ -344,42 +348,14 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
     }
   }
 
+  async function handleSignUp(e: React.FormEvent) {
+    e.preventDefault();
+    await performSignup(false);
+  }
+
   async function handleJoinWaitlist(e: React.FormEvent) {
     e.preventDefault();
-    if (!name.trim()) { setError(t('signup.nameRequired')); return; }
-    setIsSubmitting(true);
-    setError('');
-    try {
-      const res = await fetch(`${BASE}/api/players`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name.trim(), waitlist: true }),
-      });
-      const data = await res.json();
-      if (!res.ok) {
-        if (data.error === 'invite_list_not_found') {
-          setError(t('signup.inviteError', { name: name.trim() }));
-        } else if (data.error === 'pin_required') {
-          setError(t('signup.pinRequired'));
-        } else {
-          setError(data.error ?? t('signup.waitlistFailure'));
-        }
-      } else {
-        // Batch C M2: same empty-sessionId guard as handleSignUp.
-        if (!session?.id) {
-          setError(t('signup.networkError'));
-          return;
-        }
-        setIdentity({ name: name.trim(), token: data.deleteToken ?? '', sessionId: session.id });
-        setCurrentUser(name.trim());
-        setHasIdentity(true);
-        await loadData();
-      }
-    } catch {
-      setError(t('signup.networkError'));
-    } finally {
-      setIsSubmitting(false);
-    }
+    await performSignup(true);
   }
 
   if (loading) {
@@ -555,14 +531,58 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
                 ariaLabel={t('signup.nameAriaLabel')}
                 errorId={error ? 'signup-error' : undefined}
               />
+              {/* PIN inputs — same adaptive reveal as the open-signup form, so a
+                  PIN-protected member can authenticate while joining the waitlist
+                  (the server enforces the PIN on waitlist sign-ups too). */}
+              {authMode === 'sign-in' && (
+                <PinInput
+                  value={pin}
+                  onChange={(v) => { setPin(v); setError(''); }}
+                  digits={4}
+                  label={t('signup.pinLabel')}
+                  ariaInvalid={!!error}
+                />
+              )}
+              {authMode === 'create' && (
+                <>
+                  <PinInput
+                    value={pin}
+                    onChange={(v) => { setPin(v); setError(''); }}
+                    digits={4}
+                    label={t('signup.pinCreateLabel')}
+                    ariaInvalid={!!error}
+                  />
+                  <PinInput
+                    value={confirmPin}
+                    onChange={(v) => { setConfirmPin(v); setError(''); }}
+                    digits={4}
+                    label={t('signup.pinConfirmLabel')}
+                    ariaInvalid={!!error}
+                  />
+                </>
+              )}
               {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
               <button
                 type="submit"
-                disabled={isSubmitting || !name.trim() || !online}
+                disabled={
+                  isSubmitting || !name.trim() || !online
+                  || (authMode === 'sign-in' && pin.length !== 4)
+                  || (authMode === 'create' && (pin.length !== 4 || confirmPin.length !== 4))
+                }
                 className="cc-btn cc-btn-primary cc-btn-lg"
               >
                 {isSubmitting ? t('signup.joining') : t('signup.waitlist')}
               </button>
+              {authMode === 'sign-in' && (
+                <button
+                  type="button"
+                  onClick={() => setEnterCodeOpen(true)}
+                  className="text-xs underline mx-auto"
+                  style={{ color: 'var(--text-secondary)', background: 'transparent', border: 'none', cursor: 'pointer', padding: '8px 12px', minHeight: 44 }}
+                >
+                  {t('signup.forgotPin')}
+                </button>
+              )}
             </form>
           </div>
         ) : (


### PR DESCRIPTION
## The bug

When a session is full, a **PIN-protected member** tapping **"Join waitlist"** on the Home tab hit a dead end: the app reported "PIN required" but there was no field to type a PIN.

Root cause was a client/server mismatch:

- **Server** (`app/api/players/route.ts`): the PIN-ownership guard for a PIN'd member runs *before* the `isFull && joinWaitlist` branch, so a waitlist sign-up correctly returns `401 pin_required`. This is intended anti-impersonation security and is unchanged.
- **Client** (`components/HomeTab.tsx`): the open-signup form is adaptive (reveals a `PinInput` based on `authMode` from `useMemberProbe` and sends the PIN), but the **waitlist form** rendered name-only and `handleJoinWaitlist` POSTed `{ name, waitlist: true }` with no PIN. The server asked for a PIN the form never collected.

## The fix

- Unified the two submit handlers into `performSignup(waitlist: boolean)`. The auth flow (anon / sign-in PIN / create PIN) is now identical for sign-up and waitlist; `waitlist` only adds `waitlist: true` to the POST body and tunes the failure copy. This removes a near-duplicate handler.
- The waitlist form now gains the same adaptive PIN reveal as the open-signup form:
  - `sign-in` → single PIN field + "Forgot your PIN?" link
  - `create` → PIN + Confirm PIN
  - `anon` → name only (unchanged)
  - submit button disabled until the PIN(s) are 4 digits, matching the open form.

No new i18n keys — all reuse existing `signup.*` strings already used by the open form.

## Tests

Added a `POST /api/players` waitlist + PIN regression block to `__tests__/players-signup-with-pin.test.ts`:
- valid PIN + `waitlist: true` → `201`, `waitlisted: true`
- missing PIN + `waitlist: true` → `401 pin_required`
- wrong PIN + `waitlist: true` → `401 pin_incorrect`

Full suite: **721 passed (98 files)**. No new TypeScript errors introduced (the pre-existing test-file `tsc` warnings predate this change).

## Manual verification

With the mock store (no DB) and `SEED_DEV_SCENARIO=fresh-thursday` (Lin has PIN `2468`): fill the session to capacity so the "Full — join waitlist" state shows, type `Lin` → the PIN field appears, enter `2468` → joins the waitlist; wrong PIN shows an inline error; a member with no PIN gets the create-PIN flow; an unknown name joins name-only as before.

https://claude.ai/code/session_017GkdJXb8qWkCe4wE3WpQX4

---
_Generated by [Claude Code](https://claude.ai/code/session_017GkdJXb8qWkCe4wE3WpQX4)_