### PR TITLE
fix: WS#5 — three correctness/data bugs (cover-paid, birdUsages collapse, N+1)

### DIFF
--- a/__tests__/birdUsages.helpers.test.ts
+++ b/__tests__/birdUsages.helpers.test.ts
@@ -1,6 +1,46 @@
 import { describe, it, expect } from 'vitest';
-import { tubesUsedAcross, avgTubesPerSession, runwayWeeks } from '@/lib/birdUsages';
+import { tubesUsedAcross, avgTubesPerSession, runwayWeeks, mergeBirdUsageEdit } from '@/lib/birdUsages';
 import type { Session, BirdUsage } from '@/lib/types';
+
+describe('mergeBirdUsageEdit — preserve other purchases when editing one', () => {
+  const sorted = (arr: { purchaseId: string; tubes: number }[]) =>
+    [...arr].sort((a, b) => a.purchaseId.localeCompare(b.purchaseId));
+
+  it('updates the edited purchase and keeps the others (the bug: it collapsed to one)', () => {
+    const original = new Map([['A', 2], ['B', 3]]);
+    expect(sorted(mergeBirdUsageEdit(original, 'A', 5))).toEqual([
+      { purchaseId: 'A', tubes: 5 },
+      { purchaseId: 'B', tubes: 3 },
+    ]);
+  });
+
+  it('removes only the edited purchase when its tubes go to 0', () => {
+    const original = new Map([['A', 2], ['B', 3]]);
+    expect(mergeBirdUsageEdit(original, 'A', 0)).toEqual([{ purchaseId: 'B', tubes: 3 }]);
+  });
+
+  it('adds a new purchase alongside existing ones', () => {
+    const original = new Map([['A', 2]]);
+    expect(sorted(mergeBirdUsageEdit(original, 'C', 1))).toEqual([
+      { purchaseId: 'A', tubes: 2 },
+      { purchaseId: 'C', tubes: 1 },
+    ]);
+  });
+
+  it('returns the original untouched when there is no edit (null purchase)', () => {
+    const original = new Map([['A', 2], ['B', 3]]);
+    expect(sorted(mergeBirdUsageEdit(original, null, 0))).toEqual([
+      { purchaseId: 'A', tubes: 2 },
+      { purchaseId: 'B', tubes: 3 },
+    ]);
+  });
+
+  it('does not mutate the input map', () => {
+    const original = new Map([['A', 2]]);
+    mergeBirdUsageEdit(original, 'A', 9);
+    expect(original.get('A')).toBe(2);
+  });
+});
 
 function mkSession(usages: Partial<BirdUsage>[] | null): Pick<Session, 'birdUsages'> {
   if (!usages) return { birdUsages: undefined };

--- a/__tests__/components/PaymentsCard.canCover.test.tsx
+++ b/__tests__/components/PaymentsCard.canCover.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { canCover } from '@/components/admin/CommandCenter/PaymentsCard';
+
+/**
+ * `canCover` is the single shared predicate for "this player has an outstanding,
+ * coverable debt" — used by both the "Cover their $X" ActionRow and the
+ * remove-intercept. They previously drifted (the ActionRow omitted `!paid`),
+ * offering to write off a debt the player had already paid.
+ */
+describe('canCover — outstanding-debt predicate', () => {
+  it('is true for an unpaid, un-written-off player who owes money', () => {
+    expect(canCover({ owedAmount: 12, paid: false, writtenOff: false })).toBe(true);
+  });
+
+  it('is false once the player has paid (the bug: ActionRow offered Cover anyway)', () => {
+    expect(canCover({ owedAmount: 12, paid: true, writtenOff: false })).toBe(false);
+  });
+
+  it('is false once already written off', () => {
+    expect(canCover({ owedAmount: 12, paid: false, writtenOff: true })).toBe(false);
+  });
+
+  it('is false when nothing is owed', () => {
+    expect(canCover({ owedAmount: 0, paid: false, writtenOff: false })).toBe(false);
+  });
+
+  it('is false when owedAmount is absent (never settled)', () => {
+    expect(canCover({ paid: false, writtenOff: false })).toBe(false);
+  });
+
+  it('is false for null (no action target)', () => {
+    expect(canCover(null)).toBe(false);
+  });
+});

--- a/__tests__/sessions-recent.test.ts
+++ b/__tests__/sessions-recent.test.ts
@@ -76,6 +76,32 @@ describe('GET /api/sessions/recent', () => {
     expect(session.anomalyCodes).toEqual(['cost_changed']);
   });
 
+  it('attributes players to the correct session — no cross-contamination', async () => {
+    // The N+1 → single-IN()-query refactor must group player rows by sessionId
+    // correctly. Two sessions with DISJOINT player sets and different mixes
+    // catch any leakage (a bad group/post-filter would mis-count).
+    seedSession('session-2026-05-13', { datetime: '2026-05-13T20:00:00-04:00', courts: 2, costPerCourt: 30 });
+    seedPlayer('session-2026-05-13', 'A1', { paid: true });
+    seedPlayer('session-2026-05-13', 'A2', { paid: true });
+    seedPlayer('session-2026-05-13', 'A3', { paid: false });
+
+    seedSession('session-2026-05-06', { datetime: '2026-05-06T20:00:00-04:00', courts: 1, costPerCourt: 40 });
+    seedPlayer('session-2026-05-06', 'B1', { paid: true });
+    seedPlayer('session-2026-05-06', 'B2', { paid: false, removed: true });   // excluded
+    seedPlayer('session-2026-05-06', 'B3', { paid: false, waitlisted: true }); // excluded
+
+    const res = await GET(makeAdminRequest('GET', 'http://localhost:3000/api/sessions/recent'));
+    const body = await res.json();
+    const byId: Record<string, { attendanceCount: number; paidPercent: number }> = Object.fromEntries(
+      body.map((s: { sessionId: string }) => [s.sessionId, s]),
+    );
+
+    expect(byId['session-2026-05-13'].attendanceCount).toBe(3);
+    expect(byId['session-2026-05-13'].paidPercent).toBe(67); // 2/3
+    expect(byId['session-2026-05-06'].attendanceCount).toBe(1); // removed + waitlisted excluded
+    expect(byId['session-2026-05-06'].paidPercent).toBe(100); // 1/1
+  });
+
   it('handles a session with zero active players', async () => {
     seedSession('session-2026-05-13', { datetime: '2026-05-13T20:00:00-04:00', courts: 2, costPerCourt: 32 });
     const req = makeAdminRequest('GET', 'http://localhost:3000/api/sessions/recent');

--- a/app/api/sessions/recent/route.ts
+++ b/app/api/sessions/recent/route.ts
@@ -43,34 +43,49 @@ export async function GET(req: NextRequest) {
       .sort((a, b) => (a.id < b.id ? 1 : a.id > b.id ? -1 : 0))
       .slice(0, limit);
 
-    const summaries: RecentSessionSummary[] = await Promise.all(
-      (sessions as Session[]).map(async (s) => {
-        const sessionId = s.id;
-        const { resources: players } = await playersContainer.items
-          .query({
-            query: 'SELECT c.paid, c.removed, c.waitlisted FROM c WHERE c.sessionId = @sessionId',
-            parameters: [{ name: '@sessionId', value: sessionId }],
-          })
-          .fetchAll();
+    // Single batched player fetch (was N+1 — one query per session inside
+    // Promise.all). Real Cosmos honors IN(); the mock store ignores it and
+    // returns every row, so we MUST post-filter by sessionIdSet — same contract
+    // as admin/ledger and stats/attendance. Group by sessionId so each summary
+    // counts only its own players.
+    type PlayerRow = { sessionId: string; paid?: boolean; removed?: boolean; waitlisted?: boolean };
+    const sessionIds = sessions.map((s) => s.id);
+    const sessionIdSet = new Set(sessionIds);
+    const playersBySession = new Map<string, PlayerRow[]>();
 
-        const active = (players as Array<{ paid?: boolean; removed?: boolean; waitlisted?: boolean }>)
-          .filter((p) => !p.removed && !p.waitlisted);
-        const paidCount = active.filter((p) => p.paid === true).length;
+    if (sessionIds.length > 0) {
+      const placeholders = sessionIds.map((_, i) => `@sid${i}`).join(',');
+      const { resources: rawPlayers } = await playersContainer.items
+        .query({
+          query: `SELECT c.sessionId, c.paid, c.removed, c.waitlisted FROM c WHERE c.sessionId IN (${placeholders})`,
+          parameters: sessionIds.map((id, i) => ({ name: `@sid${i}`, value: id })),
+        })
+        .fetchAll();
+      for (const p of rawPlayers as PlayerRow[]) {
+        if (!sessionIdSet.has(p.sessionId)) continue;
+        const arr = playersBySession.get(p.sessionId);
+        if (arr) arr.push(p);
+        else playersBySession.set(p.sessionId, [p]);
+      }
+    }
 
-        const courtTotal = (s.costPerCourt ?? 0) * (s.courts ?? 0);
-        const birdTotal = totalBirdCost(normalizeBirdUsages(s));
-        const totalCost = courtTotal + birdTotal;
+    const summaries: RecentSessionSummary[] = (sessions as Session[]).map((s) => {
+      const active = (playersBySession.get(s.id) ?? []).filter((p) => !p.removed && !p.waitlisted);
+      const paidCount = active.filter((p) => p.paid === true).length;
 
-        return {
-          sessionId,
-          date: s.datetime ?? '',
-          attendanceCount: active.length,
-          totalCost,
-          paidPercent: active.length > 0 ? Math.round((paidCount / active.length) * 100) : 0,
-          anomalyCodes: s.anomaliesAtAdvance ?? [],
-        };
-      })
-    );
+      const courtTotal = (s.costPerCourt ?? 0) * (s.courts ?? 0);
+      const birdTotal = totalBirdCost(normalizeBirdUsages(s));
+      const totalCost = courtTotal + birdTotal;
+
+      return {
+        sessionId: s.id,
+        date: s.datetime ?? '',
+        attendanceCount: active.length,
+        totalCost,
+        paidPercent: active.length > 0 ? Math.round((paidCount / active.length) * 100) : 0,
+        anomalyCodes: s.anomaliesAtAdvance ?? [],
+      };
+    });
 
     return NextResponse.json(summaries);
   } catch (error) {

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -26,6 +26,25 @@ interface Player {
   writtenOff?: boolean;
 }
 
+/**
+ * Single source of truth for "this player has an outstanding, coverable debt."
+ * Used by BOTH the "Cover their $X" ActionRow and the remove-intercept so the
+ * two surfaces can't drift — they previously did (the ActionRow omitted `!paid`
+ * and offered to write off a debt the player had already settled). Does not
+ * include the `NEXT_PUBLIC_FLAG_LEDGER` gate — that's a feature flag, not a
+ * property of the player — so callers keep gating on `ledgerFlagOn` themselves.
+ */
+export function canCover(
+  p: Pick<Player, 'owedAmount' | 'paid' | 'writtenOff'> | null | undefined,
+): boolean {
+  return (
+    typeof p?.owedAmount === 'number' &&
+    p.owedAmount > 0 &&
+    !p.writtenOff &&
+    !p.paid
+  );
+}
+
 interface SessionLite {
   id: string;
   datetime?: string;
@@ -280,13 +299,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
     // an orphan debt on the ledger. Offer "Cover & remove" first instead of a
     // plain confirm — same predicate as the "Cover their $X" ActionRow so the
     // two surfaces agree on what counts as an outstanding debt (v1.5/C).
-    if (
-      ledgerFlagOn &&
-      typeof actionTarget.owedAmount === 'number' &&
-      actionTarget.owedAmount > 0 &&
-      !actionTarget.writtenOff &&
-      !actionTarget.paid
-    ) {
+    if (ledgerFlagOn && canCover(actionTarget)) {
       setCoverMode('cover-and-remove');
       setCoverTarget(actionTarget);
       setActionTarget(null);
@@ -640,7 +653,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
                 {actionError}
               </p>
             )}
-            {ledgerFlagOn && typeof actionTarget?.owedAmount === 'number' && actionTarget.owedAmount > 0 && !actionTarget.writtenOff && (
+            {ledgerFlagOn && actionTarget && canCover(actionTarget) && (
               <ActionRow
                 icon="paid"
                 label={`Cover their $${actionTarget.owedAmount}`}

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import AdminBackHeader from '../AdminBackHeader';
-import { normalizeBirdUsages } from '@/lib/birdUsages';
+import { normalizeBirdUsages, mergeBirdUsageEdit } from '@/lib/birdUsages';
 import { renderGroupCanvas, renderGroupText, type ReceiptInput } from '@/lib/receiptTemplate';
 import { withLocalTz } from '@/lib/fmt';
 import type { BirdPurchase, Session } from '@/lib/types';
@@ -58,6 +58,10 @@ export default function SetupPage({ onBack }: SetupPageProps) {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState('');
   const [success, setSuccess] = useState(false);
+  // True when the session failed to load. Saving from this state would PUT the
+  // default form over the real session (wiping fields the form doesn't carry —
+  // incl. collapsing birdUsages), so Save is blocked until a reload succeeds.
+  const [loadError, setLoadError] = useState(false);
 
   // Session fields
   const [title, setTitle] = useState('');
@@ -97,6 +101,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
 
   const load = useCallback(async () => {
     setLoading(true);
+    setLoadError(false);
     try {
       const [sessionRes, birdsRes, sessionsRes, playersRes, membersRes, recentCostsRes] = await Promise.all([
         fetch(`${BASE}/api/session`, { cache: 'no-store' }),
@@ -106,6 +111,9 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         fetch(`${BASE}/api/members`, { cache: 'no-store' }),
         fetch(`${BASE}/api/sessions/costs`, { cache: 'no-store' }),
       ]);
+      // The session is the doc Save overwrites — if it didn't load, the form is
+      // showing defaults, not the real session. Flag it so Save stays blocked.
+      if (!sessionRes.ok) setLoadError(true);
       const session = sessionRes.ok ? await sessionRes.json() as Session : null;
       const birds = birdsRes.ok ? await birdsRes.json() as { purchases: BirdPurchase[]; currentStock?: number } : null;
       const allSessions = sessionsRes.ok ? await sessionsRes.json() as Session[] : [];
@@ -165,6 +173,10 @@ export default function SetupPage({ onBack }: SetupPageProps) {
       setRecipient(sessionRecipient ?? adminMember?.eTransferRecipient ?? null);
 
       if (costs?.costs) setRecentCosts(costs.costs);
+    } catch (err) {
+      // Network drop / parse failure — the form holds defaults, not the session.
+      console.warn('SetupPage load failed:', err);
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -240,11 +252,10 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         ...(costPerCourt !== null ? { costPerCourt } : {}),
       };
 
-      if (tubePurchase && tubes > 0) {
-        body.birdUsages = [{ purchaseId: tubePurchase.id, tubes }];
-      } else {
-        body.birdUsages = [];
-      }
+      // Merge the single-purchase edit into the session's FULL usage map so a
+      // session carrying tubes from ≥2 purchases isn't collapsed to one. The
+      // server re-derives cost from { purchaseId, tubes }.
+      body.birdUsages = mergeBirdUsageEdit(originalSessionTubes, tubePurchase?.id ?? null, tubes);
 
       const res = await fetch(`${BASE}/api/session`, {
         method: 'PUT',
@@ -508,6 +519,11 @@ export default function SetupPage({ onBack }: SetupPageProps) {
       )}
 
       {/* Save bar */}
+      {loadError && (
+        <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: '6px 4px 0' }}>
+          Couldn&apos;t load the current session — saving is disabled to avoid overwriting it. Refresh to retry.
+        </p>
+      )}
       {saveError && (
         <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: '6px 4px 0' }}>
           {saveError}
@@ -542,7 +558,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
           <button
             type="button"
             onClick={save}
-            disabled={saving}
+            disabled={saving || loadError}
             className="cc-btn cc-btn-primary"
             style={{ flex: 2, justifyContent: 'center' }}
           >

--- a/lib/birdUsages.ts
+++ b/lib/birdUsages.ts
@@ -30,6 +30,36 @@ export function totalBirdCost(usages: BirdUsage[]): number {
 }
 
 /**
+ * Apply a single-purchase tube edit to a session's full usage map WITHOUT
+ * dropping the other purchases. Returns the `{ purchaseId, tubes }` array that
+ * `PUT /api/session` accepts (the server re-derives cost from the purchase).
+ *
+ * SetupPage's single-purchase tube editor used to overwrite the whole
+ * `birdUsages` array with just the one edited entry, silently collapsing a
+ * session that legitimately carried tubes from ≥2 purchases (assignable via
+ * BirdsPage's AssignUsageSheet) down to one — understating cost. Merging
+ * against the loaded `originalSessionTubes` map preserves the untouched entries.
+ *
+ * - `editedTubes > 0`  → set/replace that purchase's entry
+ * - `editedTubes <= 0` → remove that purchase's entry
+ * - `editedPurchaseId === null` → no edit; the original map is returned as-is
+ *
+ * Does not mutate `original`.
+ */
+export function mergeBirdUsageEdit(
+  original: Map<string, number>,
+  editedPurchaseId: string | null,
+  editedTubes: number,
+): { purchaseId: string; tubes: number }[] {
+  const merged = new Map(original);
+  if (editedPurchaseId) {
+    if (editedTubes > 0) merged.set(editedPurchaseId, editedTubes);
+    else merged.delete(editedPurchaseId);
+  }
+  return Array.from(merged, ([purchaseId, tubes]) => ({ purchaseId, tubes }));
+}
+
+/**
  * Sums tubes used across the given sessions. Accepts either full sessions
  * (reads via `normalizeBirdUsages`) or already-normalized usage arrays.
  */


### PR DESCRIPTION
Workstream #5 of the 2026-06-02 audit (`docs/audit/README.md`) — three discrete, verified correctness/data bugs. One PR, one commit per bug, each independently revertible.

## Bug 1 — "Cover their $X" offered for already-paid players (`bd39a86`)
`PaymentsCard.tsx`: the standalone "Cover their $X" ActionRow gated on `owedAmount>0 && !writtenOff` but **omitted `!paid`**, while the remove-intercept included it — despite a comment claiming both use "the same predicate." An admin could write `writtenOff:true` over a debt the player had already paid (money/ledger inconsistency).
**Fix:** extract one `canCover(player)` predicate, call it from both surfaces so they can't drift again. Unit-tested (`PaymentsCard.canCover.test.tsx`).

## Bug 2 — SetupPage save collapses multi-purchase birdUsages (`142ee29`)
`SetupPage.tsx`: the single-purchase tube editor wrote `birdUsages = [{purchaseId,tubes}]` over the whole session doc, collapsing a session carrying tubes from ≥2 purchases (assignable via BirdsPage) to one — understating cost.
**Fix:** extract a pure `mergeBirdUsageEdit()` that merges the edit into the session's full usage map (preserving other purchases; server re-derives cost). The merge is only safe if the session loaded, so this also adds a **load-success guard** — `load()` had no `catch` and silently fell back to defaults, which would re-collapse on save AND overwrite the real session. Now sets a `loadError`, disables Save, and shows a "couldn't load — refresh" pill. Closes the related silent-load-failure finding bug 2 depends on. Helper unit-tested (5 cases).

## Bug 3 — /api/sessions/recent N+1 query (`24a708e`)
One Cosmos players-query **per session** inside `Promise.all` (up to 24) — the lone holdout vs `admin/ledger` and `stats/attendance`.
**Fix:** one batched `WHERE c.sessionId IN (@sid0..@sidN)` query (SELECT now returns `c.sessionId`), post-filter by `sessionIdSet` (the mock store ignores `IN()`), group by sessionId. Pure refactor — output unchanged; a new disjoint-two-session characterization test guards against player cross-contamination.

## Verified
730 tests pass (+12), `npm run lint` clean (the new WS#4 gate), `npm run build` green.

## Note for review
Bugs 1 & 2 touch visible **admin** UI (the action sheet hides "Cover" for paid players; SetupPage disables Save on load failure) — behavior-of-a-conditional changes, visible only under specific scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)