### PR TITLE
fix(a11y): WS#6 — combobox roles + focus traps (closes the audit)

### DIFF
--- a/__tests__/components/CheckInSheet.a11y.test.tsx
+++ b/__tests__/components/CheckInSheet.a11y.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import CheckInSheet from '@/components/stats/CheckInSheet';
+import enMessages from '@/messages/en.json';
+
+beforeEach(() => {
+  // The sheet fetches /api/games for the "mirror" on open — return none.
+  global.fetch = vi.fn(async () => new Response(JSON.stringify({ games: [] }), { status: 200 })) as unknown as typeof fetch;
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('CheckInSheet rating anchors — a11y', () => {
+  it('anchors expose aria-pressed selection state and hide the decorative icon', () => {
+    render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <CheckInSheet name="Lin" open onClose={vi.fn()} onSaved={vi.fn()} />
+      </NextIntlClientProvider>,
+    );
+
+    // Advance from the intro to the first skill's rating anchors.
+    fireEvent.click(screen.getByRole('button', { name: 'Start check-in' }));
+
+    const anchors = () => screen.getAllByRole('button').filter((b) => b.hasAttribute('aria-pressed'));
+    expect(anchors()).toHaveLength(5);
+    expect(anchors()[0].getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(anchors()[0]);
+
+    const after = anchors();
+    expect(after[0].getAttribute('aria-pressed')).toBe('true');
+    expect(after[1].getAttribute('aria-pressed')).toBe('false');
+    // The check_circle selection icon is decorative — must not be announced.
+    expect(after[0].querySelector('.material-icons')?.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/__tests__/components/DemoMode.a11y.test.tsx
+++ b/__tests__/components/DemoMode.a11y.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import DemoMode from '@/components/DemoMode';
+
+afterEach(() => cleanup());
+
+describe('DemoMode — modal a11y', () => {
+  it('moves focus into the dialog on open (focus trap wiring)', () => {
+    render(<DemoMode onClose={vi.fn()} />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it('Escape closes the dialog', () => {
+    const onClose = vi.fn();
+    render(<DemoMode onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/NameAutocompleteInput.test.tsx
+++ b/__tests__/components/NameAutocompleteInput.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import NameAutocompleteInput from '@/components/home/NameAutocompleteInput';
+
+afterEach(() => cleanup());
+
+function renderInput(over: Partial<React.ComponentProps<typeof NameAutocompleteInput>> = {}) {
+  const onValueChange = vi.fn();
+  render(
+    <NameAutocompleteInput
+      id="name"
+      value=""
+      onValueChange={onValueChange}
+      suggestions={['Lin', 'Viktor', 'Carolina']}
+      placeholder="Your name"
+      ariaLabel="Your name"
+      {...over}
+    />,
+  );
+  return { onValueChange, input: screen.getByRole('combobox') as HTMLInputElement };
+}
+
+describe('NameAutocompleteInput — combobox a11y', () => {
+  it('exposes combobox roles; collapsed until focused', () => {
+    const { input } = renderInput();
+    expect(input.getAttribute('role')).toBe('combobox');
+    expect(input.getAttribute('aria-autocomplete')).toBe('list');
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('expands on focus and renders the suggestions as options', () => {
+    const { input } = renderInput();
+    fireEvent.focus(input);
+    expect(input.getAttribute('aria-expanded')).toBe('true');
+    const listbox = screen.getByRole('listbox');
+    expect(input.getAttribute('aria-controls')).toBe(listbox.id);
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('ArrowDown moves the active option (aria-activedescendant + aria-selected)', () => {
+    const { input } = renderInput();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // → first
+    const opts = screen.getAllByRole('option');
+    expect(input.getAttribute('aria-activedescendant')).toBe(opts[0].id);
+    expect(opts[0].getAttribute('aria-selected')).toBe('true');
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // → second
+    expect(input.getAttribute('aria-activedescendant')).toBe(opts[1].id);
+    expect(opts[1].getAttribute('aria-selected')).toBe('true');
+    expect(opts[0].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('ArrowUp from the first option wraps to the last', () => {
+    const { input } = renderInput();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // first
+    fireEvent.keyDown(input, { key: 'ArrowUp' });   // wrap → last
+    const opts = screen.getAllByRole('option');
+    expect(input.getAttribute('aria-activedescendant')).toBe(opts[2].id);
+  });
+
+  it('Enter selects the active option and cancels the event (no form submit)', () => {
+    const { input, onValueChange } = renderInput();
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // activate "Lin"
+    const notPrevented = fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onValueChange).toHaveBeenCalledWith('Lin');
+    expect(notPrevented).toBe(false); // preventDefault was called
+  });
+
+  it('Enter with NO active option falls through to form submit (does not cancel)', () => {
+    const { input, onValueChange } = renderInput();
+    fireEvent.focus(input); // open, but nothing highlighted
+    const notPrevented = fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true); // event left alone → the form's submit runs
+  });
+
+  it('Escape collapses the listbox', () => {
+    const { input } = renderInput();
+    fireEvent.focus(input);
+    expect(screen.getByRole('listbox')).toBeDefined();
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(input.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
+  it('still selects via mouse (onMouseDown — load-bearing vs blur)', () => {
+    const { input, onValueChange } = renderInput();
+    fireEvent.focus(input);
+    fireEvent.mouseDown(screen.getByText('Viktor'));
+    expect(onValueChange).toHaveBeenCalledWith('Viktor');
+  });
+});

--- a/__tests__/components/PreviewBanner.a11y.test.tsx
+++ b/__tests__/components/PreviewBanner.a11y.test.tsx
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import PreviewBanner from '@/components/PreviewBanner';
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_ENV = 'next'; // PreviewBanner only renders in preview env
+});
+afterEach(() => {
+  cleanup();
+  delete process.env.NEXT_PUBLIC_ENV;
+});
+
+describe('PreviewBanner report menu — a11y', () => {
+  const openMenu = () =>
+    fireEvent.click(screen.getByRole('button', { name: /report a bug/i }));
+
+  it('moves focus into the menu on open (focus management)', () => {
+    render(<PreviewBanner />);
+    openMenu();
+    const menu = screen.getByRole('menu');
+    expect(menu.contains(document.activeElement)).toBe(true);
+  });
+
+  it('Escape closes the menu', () => {
+    render(<PreviewBanner />);
+    openMenu();
+    expect(screen.queryByRole('menu')).not.toBeNull();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+});

--- a/components/DemoMode.tsx
+++ b/components/DemoMode.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import { useFocusTrap } from './BottomSheet/useFocusTrap';
 
 interface Props {
   onClose: () => void;
@@ -13,6 +14,12 @@ interface Props {
  * This is intentionally bare — content lands here in a future pass.
  */
 export default function DemoMode({ onClose }: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Trap Tab focus inside the modal + move focus to the close button on open
+  // (no clean trigger ref for the 7-tap title; the hook restores to the
+  // previously-focused element on unmount).
+  useFocusTrap(true, dialogRef);
+
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') onClose();
@@ -23,6 +30,7 @@ export default function DemoMode({ onClose }: Props) {
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="Demo mode"

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { isPreviewEnv } from '@/lib/flags';
+import { useFocusTrap } from './BottomSheet/useFocusTrap';
 
 const BANNER_HEIGHT = 28;
 const REPO = 'grantxyzou/badminton-app';
@@ -10,6 +11,11 @@ const FEEDBACK_EMAIL = 'xyzou2012@gmail.com';
 export default function PreviewBanner() {
   const show = isPreviewEnv();
   const [pickerOpen, setPickerOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  // Move focus into the menu on open, trap Tab inside, restore to the trigger
+  // on close (Escape is handled below; backdrop-click also closes).
+  useFocusTrap(pickerOpen, menuRef, triggerRef);
 
   useEffect(() => {
     if (!show) return;
@@ -67,6 +73,7 @@ export default function PreviewBanner() {
       >
         preview bpm vnext · {sha} not the stable site ·{' '}
         <button
+          ref={triggerRef}
           type="button"
           onClick={() => setPickerOpen((p) => !p)}
           aria-haspopup="menu"
@@ -99,6 +106,7 @@ export default function PreviewBanner() {
             }}
           />
           <div
+            ref={menuRef}
             role="menu"
             aria-label="Report options"
             style={{

--- a/components/home/NameAutocompleteInput.tsx
+++ b/components/home/NameAutocompleteInput.tsx
@@ -20,12 +20,15 @@ interface Props {
  * where the same JSX was duplicated across the waitlist + normal sign-up
  * branches (one of the bigger duplications flagged by #70).
  *
+ * Implements the WAI-ARIA combobox-with-listbox pattern (focus stays on the
+ * input; `aria-activedescendant` points at the highlighted option) so assistive
+ * tech announces "combobox, N options" and a keyboard user can ArrowDown/Up →
+ * Enter to pick a name. Enter only selects when an option is highlighted —
+ * otherwise it falls through so the sign-up form still submits. The mouse path
+ * uses `onMouseDown` (fires before the blur that closes the list).
+ *
  * Owns its own focus-driven `showSuggestions` state — the parent only
  * needs to pass the value, change handler, and the suggestion list.
- *
- * The dropdown uses inline styles for the glass background because the
- * tokens involved (`--dropdown-bg`, `--glass-border`) are not exposed via
- * Tailwind utility classes.
  */
 export default function NameAutocompleteInput({
   id,
@@ -37,6 +40,48 @@ export default function NameAutocompleteInput({
   errorId,
 }: Props) {
   const [showSuggestions, setShowSuggestions] = useState(false);
+  // Index of the keyboard-highlighted option, or -1 for none.
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const open = showSuggestions && suggestions.length > 0;
+  const listboxId = `${id}-listbox`;
+  const optionId = (i: number) => `${id}-option-${i}`;
+  // Guard against a stale index if the suggestion list shrank.
+  const active = open && activeIndex >= 0 && activeIndex < suggestions.length ? activeIndex : -1;
+
+  function selectSuggestion(name: string) {
+    onValueChange(name);
+    setShowSuggestions(false);
+    setActiveIndex(-1);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!open) {
+        setShowSuggestions(true);
+        return;
+      }
+      setActiveIndex((i) => (i + 1) % suggestions.length);
+    } else if (e.key === 'ArrowUp') {
+      if (!open) return;
+      e.preventDefault();
+      setActiveIndex((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (e.key === 'Enter') {
+      // Only intercept Enter when an option is highlighted; otherwise let it
+      // bubble so the enclosing sign-up form submits normally.
+      if (active >= 0) {
+        e.preventDefault();
+        selectSuggestion(suggestions[active]);
+      }
+    } else if (e.key === 'Escape') {
+      if (open) {
+        e.preventDefault();
+        setShowSuggestions(false);
+        setActiveIndex(-1);
+      }
+    }
+  }
 
   return (
     <div className="relative">
@@ -44,21 +89,32 @@ export default function NameAutocompleteInput({
         id={id}
         name="name"
         type="text"
-        placeholder={placeholder}
+        role="combobox"
         aria-label={ariaLabel}
         aria-describedby={errorId}
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={active >= 0 ? optionId(active) : undefined}
+        placeholder={placeholder}
         value={value}
         onChange={(e) => {
           onValueChange(e.target.value);
           setShowSuggestions(true);
+          setActiveIndex(-1);
         }}
+        onKeyDown={onKeyDown}
         onFocus={() => setShowSuggestions(true)}
         onBlur={() => setTimeout(() => setShowSuggestions(false), 100)}
         maxLength={50}
         autoComplete="off"
       />
-      {showSuggestions && suggestions.length > 0 && (
+      {open && (
         <ul
+          id={listboxId}
+          role="listbox"
+          aria-label={ariaLabel}
           className="absolute left-0 right-0 top-full mt-1 z-50 rounded-xl max-h-60 overflow-y-auto animate-scaleIn"
           style={{
             background: 'var(--dropdown-bg)',
@@ -67,19 +123,21 @@ export default function NameAutocompleteInput({
             border: '1px solid var(--glass-border)',
           }}
         >
-          {suggestions.map((s) => (
-            <li key={s}>
-              <button
-                type="button"
-                onMouseDown={() => {
-                  onValueChange(s);
-                  setShowSuggestions(false);
-                }}
-                className="w-full text-left px-4 py-2.5 text-sm transition-colors hover:bg-white/5"
-                style={{ color: 'var(--text-primary)' }}
-              >
-                {s}
-              </button>
+          {suggestions.map((s, i) => (
+            <li
+              key={s}
+              id={optionId(i)}
+              role="option"
+              aria-selected={i === active}
+              onMouseDown={() => selectSuggestion(s)}
+              onMouseEnter={() => setActiveIndex(i)}
+              className="w-full text-left px-4 py-2.5 text-sm transition-colors cursor-pointer"
+              style={{
+                color: 'var(--text-primary)',
+                background: i === active ? 'rgba(255,255,255,0.06)' : 'transparent',
+              }}
+            >
+              {s}
             </li>
           ))}
         </ul>

--- a/components/stats/CheckInSheet.tsx
+++ b/components/stats/CheckInSheet.tsx
@@ -189,6 +189,7 @@ export default function CheckInSheet({
                   <button
                     key={level}
                     type="button"
+                    aria-pressed={isActive}
                     onClick={() => select(level)}
                     className="w-full text-left rounded-xl transition-all active:scale-[0.98]"
                     style={{
@@ -200,7 +201,7 @@ export default function CheckInSheet({
                   >
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
                       <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 700, color: isActive ? 'var(--accent)' : 'var(--text-muted)' }}>{level}</span>
-                      {isActive && <span className="material-icons" style={{ fontSize: 15, color: 'var(--accent)' }}>check_circle</span>}
+                      {isActive && <span className="material-icons" aria-hidden="true" style={{ fontSize: 15, color: 'var(--accent)' }}>check_circle</span>}
                     </div>
                     <p style={{ fontSize: 13, lineHeight: 1.45, color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)', margin: 0 }}>{anchor}</p>
                   </button>

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -73,3 +73,24 @@ roles; hand-rolled dialogs without focus traps).
 6. **A11y**: combobox roles + focus traps.
 
 Each of 1–6 is a self-contained, testable workstream (TDD) — pick them off in order.
+
+## Remediation status (2026-06-03)
+
+All six named workstreams are **complete and merged to `main`** (each TDD'd, CI +
+claude-review green, rebase-merged):
+
+| WS | What | PR / commits |
+|---|---|---|
+| **WS#1** | Silent-failure cluster (7 spots → load errors, not lying empties) | merged `71b80dd` |
+| **WS#2** | `PUT /api/session` read-spread-upsert (stop wiping un-sent fields) | merged `0858ab0` |
+| **WS#3** | Admin-auth: mutating routes role-recheck; 2 unauth writes closed; members/me first-PIN claim | PR #126 |
+| **WS#4** | ESLint toolchain repair + CI lint gate (errors=0; 62 warnings deferred) | PR #128 |
+| **WS#5** | 3 correctness bugs: cover-paid predicate, SetupPage birdUsages collapse, sessions/recent N+1 | PR #131 |
+| **WS#6** | A11y: NameAutocomplete combobox, CheckInSheet aria, DemoMode + PreviewBanner focus traps | this PR |
+
+**Remaining tail (deliberately deferred — not named workstreams):**
+
+- **WS#4 "Harvest B"** — tighten the 62 lint warnings into errors: `react-hooks/exhaustive-deps` → error, strict `eslint-plugin-jsx-a11y`, add `eslint-plugin-security`, and the React-Compiler-readiness rules (currently `warn`). A larger, careful pass.
+- **Low-severity silent-failure GETs** still returning `200 + empty` on failure: `GET /api/releases`, `/api/aliases`, `/api/sessions/costs` (WS#1 covered only the 7-spot high-value cluster).
+- **`EnterCodeSheet` error mapping** (reads a 5xx as "wrong code" — was bundled with WS#5's order but not done) and **`CoverSheet` cover-and-remove** (two non-atomic PATCHes with a misleading error → collapse to one `{ writtenOff, removed }`).
+- The remaining medium/low findings in the phase docs (single-pass leads, not re-verified).


### PR DESCRIPTION
Final workstream (#6) of the 2026-06-02 audit. Four a11y findings, one commit each, plus a docs commit marking all six workstreams complete.

## A — NameAutocompleteInput is a real ARIA combobox (`9838ba0`)
The name autocomplete on the **primary sign-up path** exposed no combobox semantics (AT heard a plain field; keyboard users couldn't reach suggestions). Implemented the WAI-ARIA combobox-with-listbox / `aria-activedescendant` pattern: roles + `aria-expanded`/`aria-controls`/`aria-selected`, and ArrowDown/Up (wrap) → Enter → Escape. **Enter only intercepts when an option is highlighted** — otherwise it falls through so the sign-up form still submits (the sharpest case; tested). Options moved to `<li role=option>` to stay out of the tab order. 8 tests.

## B — CheckInSheet rating anchors announce selection (`dc39ae7`)
The five rating anchors signalled selection only visually. Added `aria-pressed={isActive}` + `aria-hidden` on the decorative check icon. Behind `SKILL_ASSESS`. Tested.

## C — DemoMode modal traps focus (`fd7d878`)
`role=dialog` overlay had Escape but no focus management. Reused the repo's `useFocusTrap` (focus to close button, trap Tab, restore on unmount). Tested.

## D — PreviewBanner report menu manages focus (`f831640`)
`role=menu` popover had roles + Escape but no focus management. Reused `useFocusTrap` (focus first menuitem, trap, restore to trigger). Preview env only. Tested.

## Reuse, not reinvention
C and D reuse `components/BottomSheet/useFocusTrap` — the same hook BottomSheet already ships — rather than hand-rolling traps.

## Verified
743 tests (+13), `npm run lint` clean (no new jsx-a11y errors; the rules are at `warn` per WS#4's Harvest B), `npm run build` green.

## Audit complete
`docs/audit/README.md` updated with a status table — **all six named workstreams done**; the remaining tail (WS#4 Harvest B, low-severity silent-failure GETs, EnterCodeSheet/CoverSheet) is documented as deliberately deferred.

## Note for review
Bug A is a **visible change on the sign-up name input** (keyboard arrow/Enter behavior) — worth a quick feel on localhost / the preview before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)