### PR TITLE
fix(lint): WS#4 Harvest B — no-unused-vars → error + dead-code sweep (plugins measured & declined)

### DIFF
--- a/__tests__/components/BottomSheet/BottomSheet.test.tsx
+++ b/__tests__/components/BottomSheet/BottomSheet.test.tsx
@@ -2,7 +2,7 @@
 // @vitest-environment-options { "url": "http://localhost:3000/bpm" }
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
-import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '../../../components/BottomSheet';
+import { BottomSheet, BottomSheetBody } from '../../../components/BottomSheet';
 
 describe('BottomSheet — skeleton', () => {
   afterEach(cleanup);

--- a/__tests__/members.test.ts
+++ b/__tests__/members.test.ts
@@ -8,7 +8,7 @@ import {
   makeAdminRequest,
   makeGetRequest,
 } from './helpers';
-import { GET, POST, PATCH, DELETE } from '@/app/api/members/route';
+import { GET, POST } from '@/app/api/members/route';
 import { GET as ME_GET, PATCH as ME_PATCH } from '@/app/api/members/me/route';
 import { hashPin, verifyPin } from '@/lib/recoveryHash';
 import { setMemberCookie } from '@/lib/auth';

--- a/__tests__/players-self-pay.test.ts
+++ b/__tests__/players-self-pay.test.ts
@@ -6,7 +6,6 @@ import {
   seedSession,
   seedPlayer,
   makeRequest,
-  getStore,
 } from './helpers';
 import { PATCH } from '@/app/api/players/route';
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -93,7 +93,10 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         {/* Material Symbols Rounded — subsetted to the ~35 glyphs actually used.
-            Replaces the old full Material Icons webfont (~100 KB → ~15–20 KB). */}
+            Replaces the old full Material Icons webfont (~100 KB → ~15–20 KB).
+            Deliberate <link> (icon font, not body text) — next/font doesn't fit
+            the dynamic icon_names subset, so opt this one out of the rule. */}
+        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
         <link
           href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=add,add_shopping_cart,admin_panel_settings,arrow_back,arrow_forward,article_person,auto_fix_high,bar_chart,bolt,calendar_today,campaign,celebration,check_circle,chevron_left,chevron_right,close,dark_mode,delete,delete_forever,delete_outline,delete_sweep,download,edit,emoji_events,error,error_outline,event,expand_less,expand_more,format_list_bulleted,format_list_numbered,group,group_add,groups,help_outline,home,hourglass_empty,hourglass_top,how_to_reg,image,inventory_2,key,light_mode,local_fire_department,lock,lock_clock,logout,more_vert,paid,payments,person,person_add,person_remove,radio_button_unchecked,receipt_long,remove,request_quote,restore,schedule,school,science,search,send,share,shield,sports_tennis,star,subdirectory_arrow_left,translate,trending_up,verified,visibility,warning,watch_later&display=swap"
           rel="stylesheet"

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -211,10 +211,6 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
   } : session;
   const effectivePlayerCount = dv?.activePlayerCount ?? activePlayers.length;
 
-  const currentPlayerRecord = currentUser
-    ? players.find(p => p.name.toLowerCase() === currentUser.toLowerCase())
-    : null;
-
   const courtTotal = effectiveSession?.costPerCourt && effectiveSession.courts
     ? effectiveSession.costPerCourt * effectiveSession.courts : 0;
   const birdTotal = effectiveSession?.showCostBreakdown

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -375,7 +375,12 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
       <div>
         <PageHeader>
           <span
+            role="button"
+            tabIndex={0}
             onClick={onTitleTap}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onTitleTap?.(); }
+            }}
             style={{ cursor: 'default', userSelect: 'none' }}
           >
             BPM Badminton

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -25,7 +25,6 @@ interface Props {
 
 export default function ProfileTab({
   sessionId,
-  sessionLabel,
   isAdmin,
   onAdminTools,
 }: Props) {

--- a/components/ShuttleLoader.tsx
+++ b/components/ShuttleLoader.tsx
@@ -6,8 +6,6 @@
  * "BPM" = group name + beats per minute.
  */
 
-const BAR_COUNT = 14;
-
 // Height pattern mimicking a smash waveform: quiet → SPIKE → decay → quiet
 const SMASH_PATTERN = [0.15, 0.2, 0.25, 0.4, 0.7, 0.95, 1.0, 0.85, 0.55, 0.35, 0.25, 0.2, 0.15, 0.12];
 

--- a/components/SkillsRadar.tsx
+++ b/components/SkillsRadar.tsx
@@ -218,7 +218,7 @@ export default function SkillsRadar({
                 dot={{ r: 4, fill: '#4ade80', strokeWidth: 0 }}
               />
             ) : (
-              Array.from(overlayIds).map((id, i) => {
+              Array.from(overlayIds).map((id) => {
                 const player = players.find(p => p.id === id);
                 const idx = players.findIndex(p => p.id === id);
                 const color = PLAYER_COLORS[idx % PLAYER_COLORS.length];

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -18,29 +18,6 @@ function splitIso(iso?: string): { date: string; time: string } {
   return { date: iso.slice(0, 10), time: iso.slice(11, 16) };
 }
 
-function fmtPretty(date: string, time: string): string {
-  if (!date || !time) return '—';
-  try {
-    const d = new Date(`${date}T${time}`);
-    return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' }) +
-      ' · ' + d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-  } catch {
-    return `${date} · ${time}`;
-  }
-}
-
-function fmtTimeOnly(time: string): string {
-  if (!time) return '—';
-  try {
-    const [h, m] = time.split(':');
-    const d = new Date();
-    d.setHours(parseInt(h, 10), parseInt(m, 10));
-    return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-  } catch {
-    return time;
-  }
-}
-
 function hoursBetween(a: { date: string; time: string }, b: { date: string; time: string }): number | null {
   if (!a.date || !a.time || !b.date || !b.time) return null;
   try {

--- a/components/admin/MembersView.tsx
+++ b/components/admin/MembersView.tsx
@@ -7,15 +7,6 @@ import AdminBackHeader from './AdminBackHeader';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
-function Label({ text, children }: { text: string; children: React.ReactNode }) {
-  return (
-    <label className="block space-y-1">
-      <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
-      {children}
-    </label>
-  );
-}
-
 export default function MembersView({ onBack }: { onBack: () => void }) {
   // Members state
   const [members, setMembers] = useState<Member[]>([]);

--- a/components/admin/ResetAccessSheet.tsx
+++ b/components/admin/ResetAccessSheet.tsx
@@ -49,7 +49,7 @@ export default function ResetAccessSheet({ open, onClose, playerName, code, expi
       <BottomSheetBody className="p-5 pb-8">
         <div style={{ textAlign: 'center' }}>
           <p
-            role="text"
+            role="img"
             aria-label={`Recovery code: ${code.split('').join(' ')}`}
             style={{
               fontFamily: 'var(--font-mono)',

--- a/components/stats/cards/AttendanceCardLive.tsx
+++ b/components/stats/cards/AttendanceCardLive.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { getIdentity } from '@/lib/identity';
 import AttendanceSessionStrip, { recentSessions } from './AttendanceSessionStrip';
 
@@ -42,9 +42,6 @@ export default function AttendanceCardLive() {
   const [resolved, setResolved] = useState(false);
   const [data, setData] = useState<AttendanceResponse | null>(null);
   const [loading, setLoading] = useState(false);
-  const [members, setMembers] = useState<string[]>([]);
-  const [pickerValue, setPickerValue] = useState('');
-  const [showSuggestions, setShowSuggestions] = useState(false);
 
   const weeks = WEEKS;
 
@@ -52,29 +49,6 @@ export default function AttendanceCardLive() {
   useEffect(() => {
     setActiveName(resolveActiveName());
     setResolved(true);
-  }, []);
-
-  // Load member names for autocomplete (public endpoint, no auth needed).
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(`${BASE}/api/members`, { cache: 'no-store' });
-        if (!res.ok) return;
-        const payload = await res.json();
-        const list = Array.isArray(payload?.members) ? payload.members : payload;
-        if (cancelled) return;
-        const names = (list as Array<{ name?: string }>)
-          .map((m) => m?.name)
-          .filter((n): n is string => typeof n === 'string' && n.length > 0);
-        setMembers(names);
-      } catch {
-        /* autocomplete is optional */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
   // Fetch attendance whenever the active name changes.
@@ -104,25 +78,6 @@ export default function AttendanceCardLive() {
       cancelled = true;
     };
   }, [activeName, weeks]);
-
-  const suggestions = useMemo(() => {
-    const q = pickerValue.trim().toLowerCase();
-    if (!q) return members.slice(0, 6);
-    return members.filter((n) => n.toLowerCase().includes(q)).slice(0, 6);
-  }, [members, pickerValue]);
-
-  function confirmName(name: string) {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    try {
-      localStorage.setItem(STATS_NAME_KEY, trimmed);
-    } catch {
-      /* ignore */
-    }
-    setActiveName(trimmed);
-    setPickerValue('');
-    setShowSuggestions(false);
-  }
 
   function clearPickedName() {
     try {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,13 +2,14 @@ import coreWebVitals from 'eslint-config-next/core-web-vitals';
 import typescript from 'eslint-config-next/typescript';
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
+const config = [
   {
     ignores: [
       '.next/**',
       'node_modules/**',
       'docs/design-system/**',
       '.claude/**',
+      '.remember/**',
       'next-env.d.ts',
       'coverage/**',
     ],
@@ -38,4 +39,25 @@ export default [
       '@typescript-eslint/no-require-imports': 'off',
     },
   },
+  {
+    // Unused vars are now an ERROR (was warn) — but `_`-prefixed names stay
+    // exempt. That's load-bearing: the security strip pattern destructures
+    // secrets out via `const { deleteToken: _dt, pinHash: _ph, ...safe } = rec`
+    // (CLAUDE.md) — those `_`-names are intentionally unused and MUST NOT be
+    // deleted, or the secret re-enters `...safe`. Same for required-but-unused
+    // handler params (`_req`, `_session`, `_pk`).
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
 ];
+
+export default config;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -47,7 +47,6 @@ function getSessionSecret(): string {
         'Generate with: openssl rand -hex 32',
     );
   }
-  // eslint-disable-next-line no-console
   console.warn(
     '[dev] SESSION_SECRET not set; falling back to a dev sentinel. ' +
       'Sessions signed with this secret are NOT secure for production use.',

--- a/lib/receiptTemplate.ts
+++ b/lib/receiptTemplate.ts
@@ -43,18 +43,6 @@ function fmtDate(iso: string): string {
   }
 }
 
-function fmtTime(iso: string): string {
-  if (!iso) return '';
-  try {
-    return new Date(iso).toLocaleTimeString(undefined, {
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-  } catch {
-    return '';
-  }
-}
-
 function fmtMemo(template: string, dateIso: string, name: string): string {
   const dateShort = (() => {
     if (!dateIso) return '';


### PR DESCRIPTION
The deferred follow-up to WS#4 (the audit's ESLint repair). Tightens lint warnings into high-signal errors and clears them — **without** adopting the FP-heavy plugins.

## Part 1 — promote `no-unused-vars` to error + clear the harvest (`7650dd8`)
- `@typescript-eslint/no-unused-vars`: warn → **error**, with `^_` exemptions (args/vars/caughtErrors/destructuredArray). **Load-bearing:** the security strip pattern `const { deleteToken: _dt, pinHash: _ph, ...safe } = rec` (CLAUDE.md) destructures secrets into intentionally-unused `_`-names — exempting `^_` keeps the strip expressible instead of deleting it (which would re-leak the secret into `...safe`).
- Cleared all 15 dead-code errors: unused imports/locals across 11 files, plus a whole **dead name-picker subsystem in `AttendanceCardLive`** (state + a pointless `/api/members` fetch + memo + handler) left behind by a past UI removal — drops a network call on the stats card.
- `.remember/**` ignored; config default export named; `layout.tsx` Material-Symbols `<link>` opted out of `no-page-custom-font` (icon font, not body text); stale `eslint-disable` removed.
- **Deferred (stay `warn`, documented):** the 22 React-Compiler rules (`set-state-in-effect` etc. — app isn't on the compiler; rewriting effects is a separate opt-in initiative) + 1 `exhaustive-deps` (recharts memo perf-hint; mechanically adding the dep risks behavior).

## Part 2 — measured the plugins, declined both (data-driven)
| Plugin | Findings | Verdict |
|---|---|---|
| `eslint-plugin-security` | 72 — **59 `detect-object-injection` (82% FP)**, 11 fs-filename, 2 unsafe-regex | ❌ Firehose — not added |
| `jsx-a11y` strict (delta) | 23 — `no-autofocus`×6 (intentional), the WS#6 combobox `<li role=option>`×2 (correct-pattern FP), `no-redundant-roles`×7 | ❌ Mostly FP/intentional — not added |

Both measured via throwaway config and **uninstalled — zero dependency changes** (lockfile reverted, `npm ci` clean).

## Real a11y fixes the measurement surfaced (`1a27829`)
Fixed the ~2 genuinely-real findings even though we're not enabling the rule:
- `ResetAccessSheet`: invalid `role="text"` → `role="img"` (recovery code announced as one labelled unit).
- `HomeTab` title: 7-tap easter-egg `onClick` on a static `<span>` → added `role="button"` + `tabIndex` + Enter/Space `onKeyDown`.

## Verified
0 lint errors (was 15), 746 tests, `tsc` clean (7 pre-existing test errors), `npm run build` green. The `no-unused-vars` error rule now guards every future PR via the WS#4 CI lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)