### PR TITLE
fix(audit): clear the deferred audit tail (3 low-sev items)

### DIFF
--- a/__tests__/components/CoverSheet.test.tsx
+++ b/__tests__/components/CoverSheet.test.tsx
@@ -103,7 +103,7 @@ describe('<CoverSheet />', () => {
     fetchSpy.mockRestore();
   });
 
-  it('"Cover & remove" PATCHes writtenOff then removed', async () => {
+  it('"Cover & remove" sends one atomic PATCH with writtenOff + removed', async () => {
     const onCovered = vi.fn();
     const onClose = vi.fn();
     const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(() =>
@@ -132,11 +132,12 @@ describe('<CoverSheet />', () => {
       fireEvent.click(screen.getByRole('button', { name: /Cover & remove/i }));
       await waitFor(() => expect(onCovered).toHaveBeenCalledOnce());
 
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
-      const firstBody = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body));
-      const secondBody = JSON.parse(String((fetchSpy.mock.calls[1][1] as RequestInit).body));
-      expect(firstBody.writtenOff).toBe(true);
-      expect(secondBody.removed).toBe(true);
+      // One call, not two — covered-and-removed must not be a non-atomic pair
+      // that can leave the player half-updated on a mid-sequence failure.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body));
+      expect(body.writtenOff).toBe(true);
+      expect(body.removed).toBe(true);
     } finally {
       fetchSpy.mockRestore();
     }

--- a/__tests__/components/EnterCodeSheet.test.tsx
+++ b/__tests__/components/EnterCodeSheet.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import enMessages from '@/messages/en.json';
+import EnterCodeSheet from '@/components/EnterCodeSheet';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function wrap(ui: React.ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {ui}
+    </NextIntlClientProvider>,
+  );
+}
+
+function fillAndSubmit() {
+  fireEvent.change(screen.getByPlaceholderText('Your name'), { target: { value: 'Lin' } });
+  fireEvent.change(screen.getByLabelText('Recovery code'), { target: { value: '123456' } });
+  fireEvent.click(screen.getByRole('button', { name: /Sign in with code/i }));
+}
+
+/**
+ * Audit-tail fix: the recover endpoint is rate-limited (10/hr), so telling a
+ * user their (possibly correct) code is "wrong" on a server outage burns their
+ * scarce attempts. A 5xx / network failure must surface as a retryable server
+ * error, NOT as errorInvalid.
+ */
+describe('<EnterCodeSheet /> error mapping', () => {
+  it('maps a 5xx to the retryable server error, not "wrong code"', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('boom', { status: 500 }));
+
+    wrap(<EnterCodeSheet open onClose={() => {}} sessionId="session-2026-06-04" />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't reach the server. Try again.")).toBeTruthy();
+    });
+    expect(screen.queryByText("That didn't match. Try again.")).toBeNull();
+  });
+
+  it('maps a network failure (fetch rejects) to the server error', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('offline'));
+
+    wrap(<EnterCodeSheet open onClose={() => {}} sessionId="session-2026-06-04" />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't reach the server. Try again.")).toBeTruthy();
+    });
+  });
+
+  it('still maps a genuine bad code (4xx) to "wrong code"', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('nope', { status: 401 }));
+
+    wrap(<EnterCodeSheet open onClose={() => {}} sessionId="session-2026-06-04" />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(screen.getByText("That didn't match. Try again.")).toBeTruthy();
+    });
+    expect(screen.queryByText("Couldn't reach the server. Try again.")).toBeNull();
+  });
+});

--- a/__tests__/route-load-errors.test.ts
+++ b/__tests__/route-load-errors.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as cosmos from '@/lib/cosmos';
 import { GET as getPlayers } from '@/app/api/players/route';
 import { GET as getSkills } from '@/app/api/skills/route';
+import { GET as getReleases } from '@/app/api/releases/route';
+import { GET as getAliases } from '@/app/api/aliases/route';
+import { GET as getCosts } from '@/app/api/sessions/costs/route';
 import { NextRequest } from 'next/server';
 import { resetMockStore, seedPointer, seedSession, setupAdminPin, makeGetRequest } from './helpers';
 
@@ -44,6 +47,39 @@ describe('read routes surface load failures instead of a lying empty state', () 
       throw new Error('cosmos down');
     });
     const res = await getSkills(makeGetRequest('http://localhost/api/skills', true));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  // Audit-tail deferred items: the three lower-value GETs that WS#1 skipped
+  // (still returned 200 + empty on failure). Same rule applies — a backend
+  // throw must not masquerade as "no data".
+  it('GET /api/releases returns 503 when the query throws (not 200 + [])', async () => {
+    vi.spyOn(cosmos, 'getContainer').mockImplementation(() => {
+      throw new Error('cosmos down');
+    });
+    const res = await getReleases(getReq('http://localhost/api/releases'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  it('GET /api/aliases returns 503 when the query throws (not 200 + [])', async () => {
+    vi.spyOn(cosmos, 'getContainer').mockImplementation(() => {
+      throw new Error('cosmos down');
+    });
+    const res = await getAliases(makeGetRequest('http://localhost/api/aliases', true));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  it('GET /api/sessions/costs returns 503 when the query throws (not 200 + empty)', async () => {
+    vi.spyOn(cosmos, 'getContainer').mockImplementation(() => {
+      throw new Error('cosmos down');
+    });
+    const res = await getCosts(makeGetRequest('http://localhost/api/sessions/costs', true));
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.error).toBeTruthy();

--- a/app/api/aliases/route.ts
+++ b/app/api/aliases/route.ts
@@ -14,8 +14,12 @@ export async function GET(req: NextRequest) {
       .fetchAll();
     return NextResponse.json(resources);
   } catch (error) {
+    // Surface the failure (503) instead of a lying 200 + empty list — an admin
+    // must not see "no aliases" (e-transfer name mappings) when the read
+    // actually failed (CLAUDE.md: "Lying empty state is forbidden"). Consumers
+    // already guard on res.ok.
     console.error('GET aliases error:', error);
-    return NextResponse.json([]);
+    return NextResponse.json({ error: 'Failed to load aliases' }, { status: 503 });
   }
 }
 

--- a/app/api/releases/route.ts
+++ b/app/api/releases/route.ts
@@ -66,8 +66,12 @@ export async function GET(_req: NextRequest) {
 
     return NextResponse.json(filtered);
   } catch (error) {
+    // Surface the failure (503) instead of a lying 200 + empty list — a user
+    // (or the admin ReleasesView) must not see "no releases" when the read
+    // actually failed (CLAUDE.md: "Lying empty state is forbidden"). Consumers
+    // already guard on res.ok, so they degrade to no-release-notes.
     console.error('GET releases error:', error);
-    return NextResponse.json([]);
+    return NextResponse.json({ error: 'Failed to load releases' }, { status: 503 });
   }
 }
 

--- a/app/api/sessions/costs/route.ts
+++ b/app/api/sessions/costs/route.ts
@@ -24,7 +24,10 @@ export async function GET(req: NextRequest) {
     const unique = Array.from(new Set(valid.map((r: { costPerCourt: number }) => r.costPerCourt))).sort((a, b) => a - b);
     return NextResponse.json({ costs: unique });
   } catch (error) {
+    // Surface the failure (503) instead of a lying 200 + empty list — a 200
+    // here reads as "no prior costs to suggest" when the read actually failed
+    // (CLAUDE.md: "Lying empty state is forbidden"). Consumers guard on res.ok.
     console.error('GET sessions/costs error:', error);
-    return NextResponse.json({ costs: [] });
+    return NextResponse.json({ error: 'Failed to load costs' }, { status: 503 });
   }
 }

--- a/components/EnterCodeSheet.tsx
+++ b/components/EnterCodeSheet.tsx
@@ -17,7 +17,7 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
   const t = useTranslations('recovery');
   const [name, setName] = useState('');
   const [code, setCode] = useState('');
-  const [error, setError] = useState<'invalid' | 'rate_limited' | 'admin_logged_in' | null>(null);
+  const [error, setError] = useState<'invalid' | 'rate_limited' | 'admin_logged_in' | 'server' | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
 
@@ -35,11 +35,19 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
       // /reset-access instead). Surface this distinctly so the user knows
       // they're not just typing the wrong code.
       if (res.status === 403) { setError('admin_logged_in'); return; }
+      // A 5xx means the server broke, NOT that the code is wrong. Mapping it to
+      // 'invalid' tells the user to re-type a code that may be correct — and
+      // recovery is rate-limited (10/hr), so burning attempts on a server
+      // outage is costly. Split server errors out as a retryable 'server'.
+      if (res.status >= 500) { setError('server'); return; }
       if (!res.ok) { setError('invalid'); return; }
       const body = await res.json();
       setIdentity({ name: name.trim(), token: body.deleteToken, sessionId });
       setSuccess(name.trim());
       setTimeout(() => { onClose(); setSuccess(null); }, 1500);
+    } catch {
+      // Network failure (fetch rejects) — also not the user's fault.
+      setError('server');
     } finally {
       setSubmitting(false);
     }
@@ -113,6 +121,11 @@ export default function EnterCodeSheet({ open, onClose, sessionId }: Props) {
             {error === 'admin_logged_in' && (
               <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
                 {t('errorAdminLoggedIn')}
+              </p>
+            )}
+            {error === 'server' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+                {t('errorNetwork')}
               </p>
             )}
           </div>

--- a/components/admin/AdvanceSessionForm.tsx
+++ b/components/admin/AdvanceSessionForm.tsx
@@ -71,7 +71,7 @@ export default function AdvanceSessionForm({ onBack }: Props) {
         setPrefillFailed(true);
       });
     fetch(`${BASE}/api/sessions/costs`, { cache: 'no-store' })
-      .then(r => r.json())
+      .then(r => r.ok ? r.json() : { costs: [] })
       .then((data: { costs: number[] }) => setRecentCosts(data.costs ?? []))
       .catch(() => {});
     // Skip dates from the auth-gated admin endpoint (not the public

--- a/components/admin/CoverSheet.tsx
+++ b/components/admin/CoverSheet.tsx
@@ -23,9 +23,10 @@ interface Props {
  * Unified confirm sheet for the v1.5 "Cover" workflow. Two modes:
  *  - cover-only: one primary button ("I got it") → PATCH writtenOff:true
  *  - cover-and-remove: triggered from roster Remove when player has unpaid
- *      owedAmount. Primary "Cover & remove" PATCHes writtenOff:true then
- *      removed:true. Secondary "Remove without covering" PATCHes removed:true
- *      only.
+ *      owedAmount. Primary "Cover & remove" PATCHes { writtenOff:true,
+ *      removed:true } in ONE atomic call (the players PATCH handler merges both
+ *      into a single upsert). Secondary "Remove without covering" PATCHes
+ *      removed:true only.
  *
  * Friend-voice copy per design §3 — "I got it" beats "Mark covered."
  */
@@ -74,8 +75,10 @@ export default function CoverSheet({
     setSubmitting(true);
     setError('');
     try {
-      await patch({ writtenOff: true });
-      await patch({ removed: true });
+      // One atomic PATCH, not two. Two sequential calls could leave the player
+      // covered-but-not-removed if the second failed — and the old catch then
+      // lied ("Couldn't cover") even though the cover had already landed.
+      await patch({ writtenOff: true, removed: true });
       onCovered();
       onClose();
     } catch {

--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -94,9 +94,13 @@ waitlist-PIN bug fix hiding in a stray branch (PIN'd members couldn't join a ful
 session's waitlist — #133); Dependabot triage (merged `next` 16.2.7 + dev-deps,
 closed + major-ignored Tailwind 4 / TS 6 / @types/node 25).
 
-**Remaining tail (deliberately deferred — low-value or judgment-call):**
+**Tail cleared** (commit `fa82e9c`, branch `fix/audit-tail-deferred`, +6 tests):
 
-- **Low-severity silent-failure GETs** still returning `200 + empty` on failure: `GET /api/releases`, `/api/aliases`, `/api/sessions/costs` (WS#1 covered only the 7-spot high-value cluster).
-- **`EnterCodeSheet` error mapping** (reads a 5xx as "wrong code") and **`CoverSheet` cover-and-remove** (two non-atomic PATCHes with a misleading error → collapse to one `{ writtenOff, removed }`).
+- ✅ **Low-severity silent-failure GETs** — `GET /api/releases`, `/api/aliases`, `/api/sessions/costs` now return `503 {error}` on a backend throw instead of a lying `200 + empty`. All consumers already guarded `res.ok`; AdvanceSessionForm's costs read got an explicit guard for parity. (3 cases added to `route-load-errors.test.ts`.)
+- ✅ **`EnterCodeSheet` error mapping** — a 5xx / network throw now maps to a retryable `'server'` state (`recovery.errorNetwork`) instead of `'invalid'` ("wrong code"), which had been burning the user's rate-limited (10/hr) recovery attempts on a server outage. (New `EnterCodeSheet.test.tsx`, 3 cases.)
+- ✅ **`CoverSheet` cover-and-remove** — collapsed the two non-atomic PATCHes into one atomic `{ writtenOff:true, removed:true }`, fixing both the half-updated-on-failure risk and the misleading "Couldn't cover" error fired after the cover had already landed.
+
+**Still deferred (genuinely out of audit scope):**
+
 - **React-Compiler readiness** (the ~22 `set-state-in-effect`/`purity`/`refs` warnings) — a separate opt-in initiative if/when the app adopts the React Compiler, NOT lint hygiene.
 - The remaining medium/low findings in the phase docs (single-pass leads, not re-verified).


### PR DESCRIPTION
Closes out the three deliberately-deferred items from the 2026-06-02 codebase audit (`docs/audit/README.md` tail). All low-severity / judgment-call, grouped here because they share the "don't let failures masquerade as success" theme.

## 1. Silent-failure GETs → 503 (not lying `200 + []`)
`GET /api/releases`, `/api/aliases`, `/api/sessions/costs` returned a confident `200 + empty` on a Cosmos throw — the exact "lying empty state" class behind the v1.3 outage (CLAUDE.md). WS#1 fixed the 7-spot high-value cluster; these were the deferred remainder. Catch blocks now return `503 { error }`.

All consumers already guard `res.ok` (verified across ProfileTab, HomeTab, ReleasesView, MembersView, RosterPage, useSessionNavigation, SetupPage), so they degrade gracefully — no crashes. AdvanceSessionForm's costs read gained an explicit `ok`-guard for parity.

## 2. EnterCodeSheet: 5xx → retryable, not "wrong code"
A `5xx` (or network throw) was mapped to `'invalid'` ("That didn't match"), telling the user to re-type a possibly-correct recovery code — costly because recovery is rate-limited **10/hr**. Split out a `'server'` state (reuses `recovery.errorNetwork`) and added a `catch` for network failures.

## 3. CoverSheet: atomic cover-and-remove
"Cover & remove" fired two sequential PATCHes (`writtenOff:true`, then `removed:true`). If the second failed, the player was covered-but-not-removed **and** the catch lied ("Couldn't cover") after the cover had already landed. Collapsed to one atomic `{ writtenOff:true, removed:true }` — the players PATCH handler merges both into a single upsert.

## Verification
- **+6 tests**: 3 `route-load-errors.test.ts` 503 cases, 3 new `EnterCodeSheet.test.tsx` mapping cases. CoverSheet test updated to assert one call with both fields.
- **752 tests pass**, lint clean, `next build` OK.
- The 2 pre-existing `tsc` errors (`players-signup-with-pin.test.ts`, `session.test.ts`) are in untouched files and don't gate the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)