### PR TITLE
fix(security): bind game logging to identity; strip admin-only session fields

### DIFF
--- a/__tests__/games.test.ts
+++ b/__tests__/games.test.ts
@@ -1,17 +1,36 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GET, POST } from '@/app/api/games/route';
-import { NextRequest } from 'next/server';
-import { resetMockStore, seedPointer, setupAdminPin, makeAdminRequest } from './helpers';
+import { NextRequest, NextResponse } from 'next/server';
+import { setMemberCookie } from '@/lib/auth';
+import { resetMockStore, seedPointer, setupAdminPin, seedAdminMember, makeAdminRequest } from './helpers';
 
 function get(url: string): NextRequest {
   return new NextRequest(new URL(url, 'http://localhost/bpm'));
 }
+function memberCookieValue(memberId: string, name: string): string {
+  const r = NextResponse.json({});
+  setMemberCookie(r, memberId, name);
+  return r.cookies.get('member_session')!.value;
+}
+/** Anonymous POST (no member cookie). */
 function post(body: unknown): NextRequest {
   return new NextRequest(new URL('/api/games', 'http://localhost/bpm'), {
     method: 'POST',
     body: JSON.stringify(body),
     headers: { 'content-type': 'application/json', 'x-client-ip': `games-${Math.random()}` },
+  });
+}
+/** POST signed in as a given member. */
+function postAs(memberId: string, name: string, body: unknown): NextRequest {
+  return new NextRequest(new URL('/api/games', 'http://localhost/bpm'), {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'content-type': 'application/json',
+      'x-client-ip': `games-${Math.random()}`,
+      cookie: `member_session=${memberCookieValue(memberId, name)}`,
+    },
   });
 }
 
@@ -27,10 +46,11 @@ const validGame = {
 describe('/api/games', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'true';
+    setupAdminPin(); // sets SESSION_SECRET so member cookies sign/verify deterministically
   });
 
-  it('POST logs a full-doubles result, GET lists it for the session', async () => {
-    const postRes = await POST(post(validGame));
+  it('POST logs a full-doubles result for a signed-in member, GET lists it', async () => {
+    const postRes = await POST(postAs('m-lin', 'Lin', validGame));
     expect(postRes.status).toBe(201);
 
     const getRes = await GET(get('/api/games?sessionId=session-2026-05-21'));
@@ -41,13 +61,25 @@ describe('/api/games', () => {
     expect(mine.scoreA).toBe(21);
   });
 
+  it('rejects an anonymous POST (no member cookie or admin) — rule 12', async () => {
+    const res = await POST(post(validGame));
+    expect(res.status).toBe(401);
+  });
+
+  it('forces loggedBy to the cookie identity, ignoring a spoofed body.loggedBy', async () => {
+    const res = await POST(postAs('m-viktor', 'Viktor', { ...validGame, loggedBy: 'Lin' }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.loggedBy).toBe('Viktor');
+  });
+
   it('rejects a result missing a team', async () => {
-    const res = await POST(post({ ...validGame, teamB: [] }));
+    const res = await POST(postAs('m-lin', 'Lin', { ...validGame, teamB: [] }));
     expect(res.status).toBe(400);
   });
 
   it('rejects non-numeric scores', async () => {
-    const res = await POST(post({ ...validGame, scoreA: 'lots' }));
+    const res = await POST(postAs('m-lin', 'Lin', { ...validGame, scoreA: 'lots' }));
     expect(res.status).toBe(400);
   });
 
@@ -64,10 +96,11 @@ describe('/api/games — sessionId override is admin-only (rule 7)', () => {
     setupAdminPin();
     resetMockStore();
     seedPointer('session-active');
+    seedAdminMember(); // isAdminAuthedWithMember re-fetches the member on the auth gate
   });
 
-  it('ignores a client sessionId override on an anonymous POST (writes to the active session)', async () => {
-    const res = await POST(post({ ...validGame, sessionId: 'session-evil' }));
+  it('ignores a client sessionId override on a (non-admin) member POST — writes to the active session', async () => {
+    const res = await POST(postAs('m-lin', 'Lin', { ...validGame, sessionId: 'session-evil' }));
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.sessionId).toBe('session-active');
@@ -83,9 +116,9 @@ describe('/api/games — sessionId override is admin-only (rule 7)', () => {
   });
 
   it('ignores a ?sessionId= override on an anonymous GET (reads the active session)', async () => {
-    // Log into the active session, then a foreign read attempt must not surface it
-    // under the foreign id — the anon GET resolves to the active session regardless.
-    await POST(post({ ...validGame, sessionId: 'session-evil' }));
+    // Log into the active session as a member, then a foreign read attempt must
+    // not surface it under the foreign id — the anon GET resolves to active.
+    await POST(postAs('m-lin', 'Lin', { ...validGame, sessionId: 'session-evil' }));
     const res = await GET(get('/api/games?sessionId=session-evil'));
     const body = await res.json();
     expect(body.games.every((g: { sessionId: string }) => g.sessionId === 'session-active')).toBe(true);

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -42,6 +42,41 @@ describe('GET /api/session', () => {
   });
 });
 
+describe('GET /api/session — admin-only field stripping', () => {
+  beforeEach(() => {
+    resetMockStore();
+    seedAdminMember();
+    seedPointer('session-2026-04-05');
+    seedSession('session-2026-04-05', {
+      title: 'Test Session',
+      approvedNames: ['Lin', 'Viktor'],
+      eTransferRecipient: { name: 'Grant', email: 'grant@example.com' },
+      anomaliesDismissed: ['cost_spike'],
+      settled: { at: '2026-04-05T00:00:00Z', costPerPerson: 8, totalCost: 48, playerNames: ['Lin'] },
+    });
+  });
+
+  it('strips eTransferRecipient and approvedNames for a non-admin caller', async () => {
+    const res = await GET(makeGetRequest('http://localhost:3000/api/session') as never);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.eTransferRecipient).toBeUndefined();
+    expect(data.approvedNames).toBeUndefined();
+    expect(data.anomaliesDismissed).toBeUndefined();
+    // Non-sensitive fields the player UI needs survive.
+    expect(data.title).toBe('Test Session');
+    expect(data.settled?.costPerPerson).toBe(8);
+  });
+
+  it('returns the full doc for an admin caller', async () => {
+    const res = await GET(makeGetRequest('http://localhost:3000/api/session', true) as never);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.eTransferRecipient?.email).toBe('grant@example.com');
+    expect(data.approvedNames).toEqual(['Lin', 'Viktor']);
+  });
+});
+
 describe('PUT /api/session', () => {
   beforeEach(() => {
     resetMockStore();

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, ensureContainer, getActiveSessionId } from '@/lib/cosmos';
-import { isAdminAuthed } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, verifyMemberAuth } from '@/lib/auth';
 import { isFlagOn } from '@/lib/flags';
 import { getClientIp, checkRateLimit } from '@/lib/rateLimit';
 import type { GameResult } from '@/lib/types';
@@ -69,8 +69,21 @@ export async function POST(req: NextRequest) {
       || !Number.isFinite(body.scoreA) || !Number.isFinite(body.scoreB)) {
       return NextResponse.json({ error: 'numeric_scores_required' }, { status: 400 });
     }
-    const loggedBy = typeof body.loggedBy === 'string' ? body.loggedBy.trim().slice(0, 50) : '';
-    if (!loggedBy) return NextResponse.json({ error: 'loggedBy_required' }, { status: 400 });
+    // Game logging is identity-bound (rule 12): the recorder must hold the
+    // member_session cookie (minted at sign-up, no PIN) or be an admin — never
+    // name-only, since member names are enumerable via GET /api/members. Mirror
+    // the gear endpoint's owner-or-admin pattern. The cookie name is the
+    // authoritative `loggedBy`; admins may log on behalf of another name.
+    const caller = verifyMemberAuth(req);
+    let loggedBy: string;
+    if (caller) {
+      loggedBy = caller.name;
+    } else if ((await isAdminAuthedWithMember(req)).authed) {
+      loggedBy = typeof body.loggedBy === 'string' ? body.loggedBy.trim().slice(0, 50) : '';
+      if (!loggedBy) return NextResponse.json({ error: 'loggedBy_required' }, { status: 400 });
+    } else {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
 
     // sessionId override is admin-only (rule 7); non-admins log to the active session.
     const sessionId = typeof body.sessionId === 'string' && body.sessionId && isAdminAuthed(req)

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, POINTER_ID, DEFAULT_SESSION } from '@/lib/cosmos';
-import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import type { BirdUsage, ETransferRecipient } from '@/lib/types';
 
 function isValidETransferRecipient(value: unknown): value is ETransferRecipient {
@@ -20,7 +20,25 @@ function isValidAnomalyDismissedList(value: unknown): value is string[] {
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+/**
+ * Removes admin-only fields from a session doc before it goes to a non-admin
+ * caller. `eTransferRecipient` is payment PII (rule 10) and `approvedNames` is
+ * the invite list (enables name enumeration); both are read only by admin
+ * components. Same strip convention as `deleteToken`/`pinHash` elsewhere.
+ * `settled` is intentionally kept — it carries the player's own cost.
+ */
+function stripForPublic<T extends Record<string, unknown>>(session: T) {
+  const {
+    eTransferRecipient: _etr,
+    approvedNames: _an,
+    anomaliesAtAdvance: _aaa,
+    anomaliesDismissed: _ad,
+    ...safe
+  } = session;
+  return safe;
+}
+
+export async function GET(req: NextRequest) {
   try {
     const sessionId = await getActiveSessionId();
     const container = getContainer('sessions');
@@ -30,8 +48,9 @@ export async function GET() {
         parameters: [{ name: '@id', value: sessionId }],
       })
       .fetchAll();
-    const session = resources.find((r) => r.id !== POINTER_ID);
-    return NextResponse.json(session ?? { ...DEFAULT_SESSION, id: sessionId, sessionId });
+    const session = resources.find((r) => r.id !== POINTER_ID)
+      ?? { ...DEFAULT_SESSION, id: sessionId, sessionId };
+    return NextResponse.json(isAdminAuthed(req) ? session : stripForPublic(session));
   } catch (error) {
     console.error('GET session error:', error);
     return NextResponse.json(DEFAULT_SESSION);


### PR DESCRIPTION
## Summary

Fixes two unauthenticated-access issues found in a security review. Both are **live on `bpm-next`** (gated by `NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE`, which is on there), exploitable with no special position, and violate the repo's own documented security rules.

### #1 — `POST /api/games` had no identity binding (rule 12)
Anyone unauthenticated could create a game result with any `loggedBy` name. Member names are enumerable via `GET /api/members`, so an attacker could forge game history under any member's identity and pollute the partner-frequency stats + AI "Your read" that consume this data.

**Fix:** require a `member_session` cookie (minted at sign-up, no PIN) or admin — mirroring the existing owner-or-admin pattern in `app/api/equipment/gear/route.ts`. The cookie identity is the authoritative `loggedBy`; admins may log on behalf. `verifyMemberAuth` is checked first (no DB round-trip), so the admin re-fetch only runs when there's no member cookie.

### #2 — `GET /api/session` leaked admin-only fields
The handler returned the full doc, exposing `eTransferRecipient` (payment PII, rule 10) and `approvedNames` (the invite list, which enables name enumeration) to any caller.

**Fix:** `stripForPublic()` omits `eTransferRecipient`, `approvedNames`, and the anomaly arrays for non-admin callers, using the same destructure-and-omit convention as the `deleteToken`/`pinHash` strips. Admins still get the full doc. Verified by grep that **only admin components** read these fields — no player-facing UI is affected. `settled` is intentionally kept (it carries the player's own cost).

## Tests
- `games.test.ts`: anonymous POST → **401**; member POST → 201 with `loggedBy` forced to the cookie identity (ignoring a spoofed body value); admin-on-behalf honored; sessionId-override cases rewired to use a member cookie.
- `session.test.ts`: non-admin GET omits the sensitive fields while keeping `title`/`settled`; admin GET includes them.
- Full suite green: **756 passed**. `npm run lint` clean (0 errors). No new `tsc` errors (the 8 pre-existing test-file errors are unchanged from `main`).

## Out of scope (explained, not fixed)
The review also flagged three deployment-conditional / hardening items left as potential follow-ups:
- **Rate-limit IP** trusts a spoofable `X-Client-IP` — correct on Azure App Service, latent risk only if the host changes.
- **`SESSION_SECRET`** dev fallback keys off `NODE_ENV` only — could sign forgeable admin cookies on an internet-facing preview deployed without it.
- **Auth cookies** use `path: '/'` instead of `/bpm` — defense-in-depth only.

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_