### PR TITLE
harden(security): fail-closed session secret, /bpm cookie scope, pinnable client-IP header

### DIFF
--- a/__tests__/admin.test.ts
+++ b/__tests__/admin.test.ts
@@ -198,8 +198,14 @@ describe('DELETE /api/admin (logout)', () => {
     const res = await DELETE(makeRequest('DELETE', URL_PATH));
     expect(res.status).toBe(200);
     expect((await res.json()).success).toBe(true);
-    // Both session cookies are cleared (set to empty with maxAge 0).
-    expect(res.cookies.get('member_session')).toBeTruthy();
-    expect(res.cookies.get('admin_session')).toBeTruthy();
+    // Both session cookies are cleared (set to empty with maxAge 0). Clears are
+    // append-only Set-Cookie headers (see lib/auth.ts appendClearCookie), so we
+    // read the raw header list rather than the name-keyed res.cookies map —
+    // the latter can't represent the same cookie cleared at two paths.
+    const setCookies = res.headers.getSetCookie();
+    const isCleared = (name: string) =>
+      setCookies.some((c) => c.startsWith(`${name}=;`) && /max-age=0/i.test(c));
+    expect(isCleared('member_session')).toBe(true);
+    expect(isCleared('admin_session')).toBe(true);
   });
 });

--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -6,6 +6,7 @@ import {
   isAdminAuthed,
   isAdminAuthedWithMember,
   clearAdminCookie,
+  clearMemberCookie,
   getAdminNames,
   isNameInAdminBootstrap,
 } from '../lib/auth';
@@ -86,6 +87,78 @@ describe('lib/auth — signed-payload cookie', () => {
     const setCookie = res.headers.get('set-cookie') ?? '';
     expect(setCookie).toContain('admin_session=');
     expect(setCookie.toLowerCase()).toMatch(/max-age=0/);
+  });
+
+  it('setAdminCookie scopes the cookie to the /bpm basePath', () => {
+    const res = NextResponse.json({});
+    setAdminCookie(res, 'member-grant', 'Grant');
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie.toLowerCase()).toContain('path=/bpm');
+  });
+
+  it('clearAdminCookie clears BOTH the /bpm and legacy / paths', () => {
+    const res = NextResponse.json({});
+    clearAdminCookie(res);
+    const all = res.headers.getSetCookie();
+    const adminClears = all.filter((c) => c.startsWith('admin_session='));
+    expect(adminClears).toHaveLength(2);
+    expect(adminClears.some((c) => /path=\/bpm/i.test(c))).toBe(true);
+    expect(adminClears.some((c) => /path=\/(;|$)/i.test(c))).toBe(true);
+    expect(adminClears.every((c) => /max-age=0/i.test(c))).toBe(true);
+  });
+
+  it('logout-style double clear keeps all four headers (no re-serialization drop)', () => {
+    // Regression guard: clearing two cookies on one response must not drop any
+    // path. clear* are append-only precisely so this holds — see lib/auth.ts.
+    const res = NextResponse.json({});
+    clearAdminCookie(res);
+    clearMemberCookie(res);
+    const all = res.headers.getSetCookie();
+    expect(all.filter((c) => c.startsWith('admin_session=')).length).toBe(2);
+    expect(all.filter((c) => c.startsWith('member_session=')).length).toBe(2);
+  });
+});
+
+describe('lib/auth — SESSION_SECRET fallback gating', () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    delete process.env.SESSION_SECRET;
+    // NODE_ENV is read-only in the types but writable at runtime; restore it.
+    (process.env as Record<string, string | undefined>).NODE_ENV = ORIGINAL_NODE_ENV;
+  });
+
+  function setNodeEnv(value: string | undefined) {
+    (process.env as Record<string, string | undefined>).NODE_ENV = value;
+  }
+
+  it('falls back to the dev sentinel in development/test (no real secret)', () => {
+    delete process.env.SESSION_SECRET;
+    setNodeEnv('development');
+    // Signing must not throw; the resulting cookie must still verify.
+    const res = NextResponse.json({});
+    expect(() => setAdminCookie(res, 'm', 'n')).not.toThrow();
+  });
+
+  it('throws rather than signing with the public sentinel in production', () => {
+    delete process.env.SESSION_SECRET;
+    setNodeEnv('production');
+    const res = NextResponse.json({});
+    expect(() => setAdminCookie(res, 'm', 'n')).toThrow(/SESSION_SECRET/);
+  });
+
+  it('throws when NODE_ENV is unset on a host with no secret (the dangerous case)', () => {
+    delete process.env.SESSION_SECRET;
+    setNodeEnv(undefined);
+    const res = NextResponse.json({});
+    expect(() => setAdminCookie(res, 'm', 'n')).toThrow(/SESSION_SECRET/);
+  });
+
+  it('uses a provided real secret regardless of NODE_ENV', () => {
+    process.env.SESSION_SECRET = SECRET;
+    setNodeEnv('production');
+    const res = NextResponse.json({});
+    expect(() => setAdminCookie(res, 'm', 'n')).not.toThrow();
   });
 });
 

--- a/__tests__/getClientIp.test.ts
+++ b/__tests__/getClientIp.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getClientIp } from '../lib/rateLimit';
+
+function reqWith(headers: Record<string, string>): Request {
+  return new Request('http://localhost:3000/api/anything', { headers });
+}
+
+describe('getClientIp — default (Azure) behaviour', () => {
+  afterEach(() => {
+    delete process.env.TRUSTED_IP_HEADER;
+  });
+
+  it('prefers x-client-ip', () => {
+    expect(getClientIp(reqWith({ 'x-client-ip': '1.2.3.4', 'x-forwarded-for': '9.9.9.9' }))).toBe(
+      '1.2.3.4',
+    );
+  });
+
+  it('falls back to the first x-forwarded-for entry', () => {
+    expect(getClientIp(reqWith({ 'x-forwarded-for': '5.6.7.8, 10.0.0.1' }))).toBe('5.6.7.8');
+  });
+
+  it('returns "unknown" when no IP headers are present', () => {
+    expect(getClientIp(reqWith({}))).toBe('unknown');
+  });
+});
+
+describe('getClientIp — TRUSTED_IP_HEADER override', () => {
+  afterEach(() => {
+    delete process.env.TRUSTED_IP_HEADER;
+  });
+
+  it('trusts ONLY the configured header and ignores spoofable x-forwarded-for', () => {
+    process.env.TRUSTED_IP_HEADER = 'cf-connecting-ip';
+    const ip = getClientIp(
+      reqWith({
+        'cf-connecting-ip': '203.0.113.7',
+        'x-client-ip': '6.6.6.6',
+        'x-forwarded-for': '6.6.6.6',
+      }),
+    );
+    expect(ip).toBe('203.0.113.7');
+  });
+
+  it('does NOT fall back to x-forwarded-for when the trusted header is absent', () => {
+    process.env.TRUSTED_IP_HEADER = 'cf-connecting-ip';
+    // An attacker can set x-forwarded-for, but with a pinned trusted header it
+    // must be ignored — otherwise rate limiting is bypassable by spoofing.
+    expect(getClientIp(reqWith({ 'x-forwarded-for': '6.6.6.6' }))).toBe('unknown');
+  });
+
+  it('is case-insensitive about the configured header name', () => {
+    process.env.TRUSTED_IP_HEADER = 'CF-Connecting-IP';
+    expect(getClientIp(reqWith({ 'cf-connecting-ip': '203.0.113.7' }))).toBe('203.0.113.7');
+  });
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -32,26 +32,66 @@ const COOKIE_NAME = 'admin_session';
 // again" friction. Re-PIN on Profile logout or natural 30d expiry.
 const COOKIE_MAX_AGE_S = 60 * 60 * 24 * 30;
 
+// Cookies are scoped to the app's basePath (`/bpm`, see next.config.js) rather
+// than the origin root, matching the `NEXT_LOCALE` cookie. `LEGACY_COOKIE_PATH`
+// is the root path our cookies used before this migration — we must keep
+// clearing it so anyone still holding a root-scoped cookie can actually sign
+// out (a `/bpm` clear does NOT delete a `/`-scoped cookie of the same name).
+const COOKIE_PATH = '/bpm';
+const LEGACY_COOKIE_PATH = '/';
+
 /**
- * Returns the HMAC secret. In production, the env var must be set or we
- * throw at module-load (callers can't recover from a missing secret in any
- * meaningful way). In dev, fall back to a hard-coded sentinel and log a
- * warning so local-only flows still work.
+ * Append a same-name cookie-clearing `Set-Cookie` header for both the current
+ * and legacy paths.
+ *
+ * Why append-only (never `res.cookies.set`): Next's `ResponseCookies` keeps an
+ * internal map keyed by cookie NAME alone, so it cannot represent the same
+ * cookie at two paths, and every `.set()` re-serializes the whole map —
+ * silently dropping any header we appended earlier. The logout route clears two
+ * cookies on one response, so a `.set()`-based clear of the second would wipe
+ * the first's legacy-path header. Building the headers by hand sidesteps that.
+ * (Verified empirically before writing this.) Do NOT call a `set*Cookie` helper
+ * AFTER a `clear*Cookie` on the same response — the re-serialization would drop
+ * these appended headers.
+ */
+function appendClearCookie(res: NextResponse, name: string): void {
+  const secure = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+  for (const path of [COOKIE_PATH, LEGACY_COOKIE_PATH]) {
+    res.headers.append(
+      'set-cookie',
+      `${name}=; Path=${path}; Max-Age=0; HttpOnly; SameSite=Strict${secure}`,
+    );
+  }
+}
+
+/**
+ * Returns the HMAC secret. A real `SESSION_SECRET` (>=32 chars) is always
+ * preferred. The hard-coded dev sentinel is only used for *explicitly* local
+ * environments (`NODE_ENV` of `development` or `test`).
+ *
+ * Security: previously the fallback fired for any `NODE_ENV !== 'production'`,
+ * which meant an internet-facing host booted with an unset/unexpected
+ * `NODE_ENV` (e.g. a misconfigured preview running a bare `next` server) would
+ * sign admin cookies with a *public constant from this repo* — anyone could
+ * forge a valid `admin_session`. We now fail closed: only the two known-local
+ * envs get the sentinel; everything else throws.
  */
 function getSessionSecret(): string {
   const secret = process.env.SESSION_SECRET;
   if (secret && secret.length >= 32) return secret;
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error(
-      'SESSION_SECRET environment variable is missing or too short (>=32 chars). ' +
-        'Generate with: openssl rand -hex 32',
+  const env = process.env.NODE_ENV;
+  if (env === 'development' || env === 'test') {
+    console.warn(
+      '[dev] SESSION_SECRET not set; falling back to a dev sentinel. ' +
+        'Sessions signed with this secret are NOT secure for production use.',
     );
+    return 'dev-fallback-secret-not-for-production-use-please';
   }
-  console.warn(
-    '[dev] SESSION_SECRET not set; falling back to a dev sentinel. ' +
-      'Sessions signed with this secret are NOT secure for production use.',
+  throw new Error(
+    `SESSION_SECRET environment variable is missing or too short (>=32 chars); ` +
+      `refusing to sign sessions with the public dev sentinel (NODE_ENV=${env ?? 'unset'}). ` +
+      'Generate with: openssl rand -hex 32',
   );
-  return 'dev-fallback-secret-not-for-production-use-please';
 }
 
 interface SessionPayload {
@@ -124,18 +164,12 @@ export function setAdminCookie(res: NextResponse, memberId: string, name: string
     sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: COOKIE_MAX_AGE_S,
-    path: '/',
+    path: COOKIE_PATH,
   });
 }
 
 export function clearAdminCookie(res: NextResponse): void {
-  res.cookies.set(COOKIE_NAME, '', {
-    httpOnly: true,
-    sameSite: 'strict',
-    secure: process.env.NODE_ENV === 'production',
-    maxAge: 0,
-    path: '/',
-  });
+  appendClearCookie(res, COOKIE_NAME);
 }
 
 // ── Member session ──
@@ -155,7 +189,7 @@ const COOKIE_OPTS = {
   httpOnly: true as const,
   sameSite: 'strict' as const,
   secure: process.env.NODE_ENV === 'production',
-  path: '/',
+  path: COOKIE_PATH,
 };
 
 export function setMemberCookie(res: NextResponse, memberId: string, name: string): void {
@@ -168,7 +202,7 @@ export function setMemberCookie(res: NextResponse, memberId: string, name: strin
 }
 
 export function clearMemberCookie(res: NextResponse): void {
-  res.cookies.set(MEMBER_COOKIE_NAME, '', { ...COOKIE_OPTS, maxAge: 0 });
+  appendClearCookie(res, MEMBER_COOKIE_NAME);
 }
 
 /**

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -29,15 +29,34 @@ export function checkRateLimit(key: string, maxRequests: number, windowMs: numbe
 }
 
 /**
- * Get the real client IP from Azure App Service headers.
+ * Get the real client IP from the trusted proxy header.
  *
  * ASSUMPTION: This app runs behind Azure App Service's load balancer, which
- * sets X-Client-IP to the actual client IP and strips it from external requests.
- * If deployed outside Azure (e.g., local tunnel, other cloud), these headers
- * are user-controlled and rate limiting can be bypassed by spoofing them.
+ * sets `X-Client-IP` to the actual client IP and strips any client-supplied
+ * value. Under that assumption these headers are trustworthy.
+ *
+ * RISK: if deployed behind a *different* proxy (or none — local tunnel, other
+ * cloud), `X-Client-IP`/`X-Forwarded-For` become fully client-controlled, so an
+ * attacker can rotate them to bypass per-IP rate limits (e.g. brute-forcing the
+ * recovery-code / PIN endpoints). To harden such a deployment, set
+ * `TRUSTED_IP_HEADER` to the single header your proxy guarantees (e.g.
+ * `cf-connecting-ip` behind Cloudflare). When set, ONLY that header is trusted
+ * and the spoofable `X-Forwarded-For` fallback is skipped. Left unset, behaviour
+ * is unchanged (Azure-compatible).
  */
 export function getClientIp(req: Request): string {
   const headers = req.headers as Headers;
+
+  const trustedHeader = process.env.TRUSTED_IP_HEADER?.trim().toLowerCase();
+  if (trustedHeader) {
+    const value = headers.get(trustedHeader);
+    if (value) {
+      const first = value.split(',')[0].trim();
+      if (first) return first;
+    }
+    return 'unknown';
+  }
+
   const clientIp = headers.get('x-client-ip');
   if (clientIp) return clientIp;
   const forwarded = headers.get('x-forwarded-for');


### PR DESCRIPTION
## Summary

Follow-up to the #141 security review — the three deployment-conditional / defense-in-depth items that were explicitly left **out of scope** there, now addressed. All three are latent (correct on Azure today) rather than live-exploitable, so this is hardening for "what if the host/proxy changes" plus a misconfig-proofing of the secret.

### 1 — `SESSION_SECRET` now fails closed
`getSessionSecret()` previously fell back to a **public constant from this repo** for any `NODE_ENV !== 'production'`. An internet-facing host booted with an unset or unexpected `NODE_ENV` (e.g. a misconfigured preview running a bare `next` server) would sign admin cookies with that constant — anyone could forge a valid `admin_session`.

**Fix:** only the two known-local envs (`development`, `test`) get the sentinel; everything else (including `unset`) **throws** rather than signing with a guessable key.

### 2 — Auth cookies scoped to `/bpm`
`admin_session` / `member_session` were set at the origin root (`path: '/'`); they're now scoped to the app's basePath (`/bpm`), matching the existing `NEXT_LOCALE` cookie convention.

**Migration care:** clears now emit **append-only** `Set-Cookie` headers for **both** `/bpm` and the legacy `/` path, so anyone still holding a pre-migration root-scoped cookie can actually sign out (a `/bpm` clear can't delete a `/`-scoped cookie of the same name). Append-only is required, not stylistic: Next's `ResponseCookies` map is keyed by cookie **name alone** and re-serializes the whole map on every `.set()` — so a `.set()`-based clear of the *second* cookie on the two-clear logout response silently drops the *first* cookie's appended legacy-path header. I verified this empirically before writing the helper. There's a regression test (`logout-style double clear keeps all four headers`) guarding it.

### 3 — Pinnable client-IP header
`getClientIp()` trusts `X-Client-IP` → `X-Forwarded-For`, which is correct behind Azure App Service (it strips client-supplied values) but fully spoofable behind a different/no proxy — letting an attacker rotate the header to bypass per-IP rate limits on the recovery/PIN endpoints.

**Fix:** optional `TRUSTED_IP_HEADER` env pins a single trusted header (e.g. `cf-connecting-ip` behind Cloudflare) and skips the spoofable `X-Forwarded-For` fallback. **Unset = unchanged Azure-compatible behaviour** (zero risk to current prod).

## Tests
- `getClientIp.test.ts` (new): default Azure precedence + `unknown` fallback; `TRUSTED_IP_HEADER` pins one header, ignores spoofed `X-Forwarded-For`, case-insensitive.
- `auth.test.ts`: `SESSION_SECRET` fallback gating across `NODE_ENV` (fallback in dev/test, throws in production + unset, real secret always wins); `/bpm` scoping; dual-path clear; double-clear no-drop regression guard.
- `admin.test.ts`: logout assertion rewired to read raw `Set-Cookie` headers (the append-only clears aren't visible via the name-keyed `res.cookies` map).
- Full suite **769 passing**, `npm run lint` clean (0 errors), no new `tsc` errors (the 7 pre-existing test-file errors are identical on `main`).

## Notes
- No schema changes, no DB writes, no API response-shape changes.
- `TRUSTED_IP_HEADER` is a new optional env var — worth adding to `.env.local.example` if you want it documented (left untouched here since `.env*` is hook-protected from automated edits).

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_