### PR TITLE
feat(stats): canonical skill level — Phase 1 of the skill-accuracy spine

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -46,6 +46,7 @@ jobs:
           NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE: 'true'
           NEXT_PUBLIC_FLAG_NAV_RAIL: 'true'
           NEXT_PUBLIC_FLAG_SKILL_ASSESS: 'true'
+          NEXT_PUBLIC_FLAG_SKILL_LEVEL: 'true'
 
       - name: Package standalone build
         run: |

--- a/__tests__/games.test.ts
+++ b/__tests__/games.test.ts
@@ -1,17 +1,36 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GET, POST } from '@/app/api/games/route';
-import { NextRequest } from 'next/server';
-import { resetMockStore, seedPointer, setupAdminPin, makeAdminRequest } from './helpers';
+import { NextRequest, NextResponse } from 'next/server';
+import { setMemberCookie } from '@/lib/auth';
+import { resetMockStore, seedPointer, setupAdminPin, seedAdminMember, makeAdminRequest } from './helpers';
 
 function get(url: string): NextRequest {
   return new NextRequest(new URL(url, 'http://localhost/bpm'));
 }
+function memberCookieValue(memberId: string, name: string): string {
+  const r = NextResponse.json({});
+  setMemberCookie(r, memberId, name);
+  return r.cookies.get('member_session')!.value;
+}
+/** Anonymous POST (no member cookie). */
 function post(body: unknown): NextRequest {
   return new NextRequest(new URL('/api/games', 'http://localhost/bpm'), {
     method: 'POST',
     body: JSON.stringify(body),
     headers: { 'content-type': 'application/json', 'x-client-ip': `games-${Math.random()}` },
+  });
+}
+/** POST signed in as a given member. */
+function postAs(memberId: string, name: string, body: unknown): NextRequest {
+  return new NextRequest(new URL('/api/games', 'http://localhost/bpm'), {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: {
+      'content-type': 'application/json',
+      'x-client-ip': `games-${Math.random()}`,
+      cookie: `member_session=${memberCookieValue(memberId, name)}`,
+    },
   });
 }
 
@@ -27,10 +46,11 @@ const validGame = {
 describe('/api/games', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'true';
+    setupAdminPin(); // sets SESSION_SECRET so member cookies sign/verify deterministically
   });
 
-  it('POST logs a full-doubles result, GET lists it for the session', async () => {
-    const postRes = await POST(post(validGame));
+  it('POST logs a full-doubles result for a signed-in member, GET lists it', async () => {
+    const postRes = await POST(postAs('m-lin', 'Lin', validGame));
     expect(postRes.status).toBe(201);
 
     const getRes = await GET(get('/api/games?sessionId=session-2026-05-21'));
@@ -41,13 +61,25 @@ describe('/api/games', () => {
     expect(mine.scoreA).toBe(21);
   });
 
+  it('rejects an anonymous POST (no member cookie or admin) — rule 12', async () => {
+    const res = await POST(post(validGame));
+    expect(res.status).toBe(401);
+  });
+
+  it('forces loggedBy to the cookie identity, ignoring a spoofed body.loggedBy', async () => {
+    const res = await POST(postAs('m-viktor', 'Viktor', { ...validGame, loggedBy: 'Lin' }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.loggedBy).toBe('Viktor');
+  });
+
   it('rejects a result missing a team', async () => {
-    const res = await POST(post({ ...validGame, teamB: [] }));
+    const res = await POST(postAs('m-lin', 'Lin', { ...validGame, teamB: [] }));
     expect(res.status).toBe(400);
   });
 
   it('rejects non-numeric scores', async () => {
-    const res = await POST(post({ ...validGame, scoreA: 'lots' }));
+    const res = await POST(postAs('m-lin', 'Lin', { ...validGame, scoreA: 'lots' }));
     expect(res.status).toBe(400);
   });
 
@@ -64,10 +96,11 @@ describe('/api/games — sessionId override is admin-only (rule 7)', () => {
     setupAdminPin();
     resetMockStore();
     seedPointer('session-active');
+    seedAdminMember(); // isAdminAuthedWithMember re-fetches the member on the auth gate
   });
 
-  it('ignores a client sessionId override on an anonymous POST (writes to the active session)', async () => {
-    const res = await POST(post({ ...validGame, sessionId: 'session-evil' }));
+  it('ignores a client sessionId override on a (non-admin) member POST — writes to the active session', async () => {
+    const res = await POST(postAs('m-lin', 'Lin', { ...validGame, sessionId: 'session-evil' }));
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.sessionId).toBe('session-active');
@@ -83,9 +116,9 @@ describe('/api/games — sessionId override is admin-only (rule 7)', () => {
   });
 
   it('ignores a ?sessionId= override on an anonymous GET (reads the active session)', async () => {
-    // Log into the active session, then a foreign read attempt must not surface it
-    // under the foreign id — the anon GET resolves to the active session regardless.
-    await POST(post({ ...validGame, sessionId: 'session-evil' }));
+    // Log into the active session as a member, then a foreign read attempt must
+    // not surface it under the foreign id — the anon GET resolves to active.
+    await POST(postAs('m-lin', 'Lin', { ...validGame, sessionId: 'session-evil' }));
     const res = await GET(get('/api/games?sessionId=session-evil'));
     const body = await res.json();
     expect(body.games.every((g: { sessionId: string }) => g.sessionId === 'session-active')).toBe(true);

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -224,6 +224,21 @@ export function adminCookieValue(): string {
   return `${headerB64}.${sigB64}`;
 }
 
+/**
+ * Build a valid `member_session` cookie value for a given member identity.
+ * Same signed-payload format as the admin cookie (so it exercises the real
+ * `verifyMemberAuth` path), but bound to an arbitrary name/id — used to test
+ * member-scoped read gates like /api/stats/level.
+ */
+export function memberCookieValue(name: string, memberId = `member-${name.toLowerCase()}`): string {
+  const now = Math.floor(Date.now() / 1000);
+  const payload = { memberId, name, iat: now, exp: now + 60 * 60 * 24 * 30 };
+  const headerB64 = base64urlEncode(Buffer.from(JSON.stringify(payload), 'utf8'));
+  const sig = createHmac('sha256', TEST_SESSION_SECRET).update(headerB64).digest();
+  const sigB64 = base64urlEncode(sig);
+  return `${headerB64}.${sigB64}`;
+}
+
 export function makeRequest(
   method: string,
   url: string,

--- a/__tests__/level.test.ts
+++ b/__tests__/level.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { deriveLevel, levelToStage, stageToLevel, type LevelInputs } from '../lib/level';
+
+const NOW = '2026-06-13T00:00:00.000Z';
+function daysAgo(n: number): string {
+  return new Date(Date.parse(NOW) - n * 86_400_000).toISOString();
+}
+function base(over: Partial<LevelInputs> = {}): LevelInputs {
+  return { selfSnapshots: [], now: NOW, ...over };
+}
+
+describe('scale bridge', () => {
+  it('levelToStage aligns each phase boundary to ~+1 stage', () => {
+    expect(levelToStage(1.0)).toBe(1);
+    expect(levelToStage(1.8)).toBe(2); // exploration
+    expect(levelToStage(2.6)).toBe(3); // switch
+    expect(levelToStage(3.4)).toBe(4); // commitment
+    expect(levelToStage(5.0)).toBe(6);
+  });
+
+  it('levelToStage clamps out-of-range input to [1,6]', () => {
+    expect(levelToStage(0)).toBe(1);
+    expect(levelToStage(99)).toBe(6);
+  });
+
+  it('stageToLevel inverts roughly and clamps to [1,5]', () => {
+    expect(stageToLevel(1)).toBe(1);
+    expect(stageToLevel(3)).toBeCloseTo(2.6);
+    expect(stageToLevel(6)).toBe(5);
+    expect(stageToLevel(99)).toBe(5);
+  });
+});
+
+describe('deriveLevel — self only (Phase 1)', () => {
+  it('uses the latest snapshot overall as the level', () => {
+    const r = deriveLevel(base({ selfSnapshots: [{ takenAt: daysAgo(40), overall: 2.5 }, { takenAt: daysAgo(2), overall: 3.0 }] }));
+    expect(r.level).toBe(3.0);
+    expect(r.basis.self).toBe(3.0);
+    expect(r.phase).toBe('switch'); // 3.0 ≥ 2.6
+    expect(r.stage).toBe(levelToStage(3.0));
+  });
+
+  it('ignores null-overall snapshots when picking the latest', () => {
+    const r = deriveLevel(base({ selfSnapshots: [{ takenAt: daysAgo(1), overall: null }, { takenAt: daysAgo(5), overall: 2.0 }] }));
+    expect(r.level).toBe(2.0);
+  });
+
+  it('is medium confidence on one check-in, high on two or more', () => {
+    const one = deriveLevel(base({ selfSnapshots: [{ takenAt: daysAgo(3), overall: 3.0 }] }));
+    expect(one.confidence).toBe('medium');
+    const two = deriveLevel(base({ selfSnapshots: [{ takenAt: daysAgo(40), overall: 2.8 }, { takenAt: daysAgo(3), overall: 3.0 }] }));
+    expect(two.confidence).toBe('high');
+  });
+
+  it('docks confidence one notch when the latest check-in is stale (>180d) but keeps the value', () => {
+    const r = deriveLevel(base({ selfSnapshots: [{ takenAt: daysAgo(400), overall: 2.8 }, { takenAt: daysAgo(200), overall: 3.0 }] }));
+    // latest (200d old) is stale → high would drop to medium; value unchanged.
+    expect(r.level).toBe(3.0);
+    expect(r.confidence).toBe('medium');
+    expect(r.explanation.some((l) => /6 months/.test(l))).toBe(true);
+  });
+});
+
+describe('deriveLevel — fallbacks', () => {
+  it('falls back to the legacy stage at low confidence when there are no snapshots', () => {
+    const r = deriveLevel(base({ legacyStage: 3 }));
+    expect(r.level).toBe(stageToLevel(3));
+    expect(r.confidence).toBe('low');
+    expect(r.basis.legacyStage).toBe(3);
+    expect(r.basis.self).toBeNull();
+  });
+
+  it('returns a null level (not a fake zero) when there is nothing to go on', () => {
+    const r = deriveLevel(base());
+    expect(r.level).toBeNull();
+    expect(r.stage).toBeNull();
+    expect(r.phase).toBeNull();
+    expect(r.explanation[0]).toMatch(/check-in/i);
+  });
+});
+
+describe('deriveLevel — blend renormalization (Phase 2 forward-compat)', () => {
+  it('weights self 0.5 and game 0.3 at full game volume, renormalized', () => {
+    const r = deriveLevel(base({
+      selfSnapshots: [{ takenAt: daysAgo(2), overall: 3.0 }],
+      gameCalibration: { observedLevel: 4.0, games: 10, lastGameAt: daysAgo(2) },
+    }));
+    // (3.0*0.5 + 4.0*0.3) / 0.8 = 3.375 → 3.4
+    expect(r.level).toBe(3.4);
+    expect(r.basis.game).toBe(4.0);
+    expect(r.confidence).toBe('high'); // game presence forces high
+  });
+
+  it('ramps the game weight with volume', () => {
+    const r = deriveLevel(base({
+      selfSnapshots: [{ takenAt: daysAgo(2), overall: 3.0 }],
+      gameCalibration: { observedLevel: 4.0, games: 5, lastGameAt: daysAgo(2) },
+    }));
+    // w_game = 0.3*0.5 = 0.15 → (1.5 + 0.6)/0.65 = 3.23 → 3.2
+    expect(r.level).toBe(3.2);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const inp = base({ selfSnapshots: [{ takenAt: daysAgo(2), overall: 3.3 }], legacyStage: 4 });
+    expect(deriveLevel(inp)).toEqual(deriveLevel(inp));
+  });
+});

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -42,6 +42,41 @@ describe('GET /api/session', () => {
   });
 });
 
+describe('GET /api/session — admin-only field stripping', () => {
+  beforeEach(() => {
+    resetMockStore();
+    seedAdminMember();
+    seedPointer('session-2026-04-05');
+    seedSession('session-2026-04-05', {
+      title: 'Test Session',
+      approvedNames: ['Lin', 'Viktor'],
+      eTransferRecipient: { name: 'Grant', email: 'grant@example.com' },
+      anomaliesDismissed: ['cost_spike'],
+      settled: { at: '2026-04-05T00:00:00Z', costPerPerson: 8, totalCost: 48, playerNames: ['Lin'] },
+    });
+  });
+
+  it('strips eTransferRecipient and approvedNames for a non-admin caller', async () => {
+    const res = await GET(makeGetRequest('http://localhost:3000/api/session') as never);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.eTransferRecipient).toBeUndefined();
+    expect(data.approvedNames).toBeUndefined();
+    expect(data.anomaliesDismissed).toBeUndefined();
+    // Non-sensitive fields the player UI needs survive.
+    expect(data.title).toBe('Test Session');
+    expect(data.settled?.costPerPerson).toBe(8);
+  });
+
+  it('returns the full doc for an admin caller', async () => {
+    const res = await GET(makeGetRequest('http://localhost:3000/api/session', true) as never);
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.eTransferRecipient?.email).toBe('grant@example.com');
+    expect(data.approvedNames).toEqual(['Lin', 'Viktor']);
+  });
+});
+
 describe('PUT /api/session', () => {
   beforeEach(() => {
     resetMockStore();

--- a/__tests__/stats-level-route.test.ts
+++ b/__tests__/stats-level-route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { GET } from '../app/api/stats/level/route';
+import {
+  resetMockStore, getStore, seedMember, setupAdminPin, makeRequest, makeGetRequest, memberCookieValue,
+} from './helpers';
+
+const BASE = 'http://localhost:3000/api/stats/level';
+
+function getAs(name: string, cookieName?: string) {
+  // A GET carrying a member_session cookie bound to `cookieName` (defaults to
+  // the queried name → owns it).
+  const cookie = `member_session=${memberCookieValue(cookieName ?? name)}`;
+  return makeRequest('GET', `${BASE}?name=${encodeURIComponent(name)}`, undefined, { Cookie: cookie });
+}
+
+function seedAssessment(memberId: string, overall: number, takenAt: string) {
+  const store = getStore();
+  if (!store['assessments']) store['assessments'] = [];
+  store['assessments'].push({ id: `a-${Math.random().toString(36).slice(2)}`, memberId, overall, takenAt });
+}
+
+describe('/api/stats/level', () => {
+  beforeEach(() => {
+    resetMockStore();
+    setupAdminPin();
+    process.env.NEXT_PUBLIC_FLAG_SKILL_LEVEL = 'true';
+  });
+  afterAll(() => {
+    delete process.env.NEXT_PUBLIC_FLAG_SKILL_LEVEL;
+  });
+
+  it('404s when the flag is off', async () => {
+    process.env.NEXT_PUBLIC_FLAG_SKILL_LEVEL = 'false';
+    const res = await GET(getAs('Lin'));
+    expect(res.status).toBe(404);
+  });
+
+  it('400s when no name is supplied', async () => {
+    const res = await GET(makeRequest('GET', BASE));
+    expect(res.status).toBe(400);
+  });
+
+  it('403s when there is no member cookie and the caller is not admin', async () => {
+    const res = await GET(makeRequest('GET', `${BASE}?name=Lin`));
+    expect(res.status).toBe(403);
+  });
+
+  it('403s when the member cookie is for a different name', async () => {
+    const res = await GET(getAs('Lin', 'Viktor'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the level to the owning member (matching cookie)', async () => {
+    const m = seedMember('Lin');
+    seedAssessment(m.id, 3.0, '2026-06-01T00:00:00.000Z');
+    const res = await GET(getAs('Lin'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.level.level).toBe(3.0);
+    expect(body.level.phase).toBe('switch');
+  });
+
+  it('lets an admin browse another player without a member cookie', async () => {
+    const m = seedMember('Viktor');
+    seedAssessment(m.id, 4.5, '2026-06-01T00:00:00.000Z');
+    const res = await GET(makeGetRequest(`${BASE}?name=Viktor`, true));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.level.level).toBe(4.5);
+    expect(body.level.phase).toBe('advanced');
+  });
+
+  it('returns a null level (with a CTA) for an owner who has no check-ins yet', async () => {
+    seedMember('Akane');
+    const res = await GET(getAs('Akane'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.level.level).toBeNull();
+    expect(body.level.explanation[0]).toMatch(/check-in/i);
+  });
+
+  it('resolves a non-member name via the name-fallback id (still owner-gated)', async () => {
+    // No seeded member → subject id is name:ghost; the cookie for "Ghost" still
+    // owns the name, so the gate passes and the level is null.
+    const res = await GET(getAs('Ghost'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.level.level).toBeNull();
+  });
+});

--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getContainer, ensureContainer, getActiveSessionId } from '@/lib/cosmos';
-import { isAdminAuthed } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, verifyMemberAuth } from '@/lib/auth';
 import { isFlagOn } from '@/lib/flags';
 import { getClientIp, checkRateLimit } from '@/lib/rateLimit';
 import type { GameResult } from '@/lib/types';
@@ -69,8 +69,21 @@ export async function POST(req: NextRequest) {
       || !Number.isFinite(body.scoreA) || !Number.isFinite(body.scoreB)) {
       return NextResponse.json({ error: 'numeric_scores_required' }, { status: 400 });
     }
-    const loggedBy = typeof body.loggedBy === 'string' ? body.loggedBy.trim().slice(0, 50) : '';
-    if (!loggedBy) return NextResponse.json({ error: 'loggedBy_required' }, { status: 400 });
+    // Game logging is identity-bound (rule 12): the recorder must hold the
+    // member_session cookie (minted at sign-up, no PIN) or be an admin — never
+    // name-only, since member names are enumerable via GET /api/members. Mirror
+    // the gear endpoint's owner-or-admin pattern. The cookie name is the
+    // authoritative `loggedBy`; admins may log on behalf of another name.
+    const caller = verifyMemberAuth(req);
+    let loggedBy: string;
+    if (caller) {
+      loggedBy = caller.name;
+    } else if ((await isAdminAuthedWithMember(req)).authed) {
+      loggedBy = typeof body.loggedBy === 'string' ? body.loggedBy.trim().slice(0, 50) : '';
+      if (!loggedBy) return NextResponse.json({ error: 'loggedBy_required' }, { status: 400 });
+    } else {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
 
     // sessionId override is admin-only (rule 7); non-admins log to the active session.
     const sessionId = typeof body.sessionId === 'string' && body.sessionId && isAdminAuthed(req)

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, POINTER_ID, DEFAULT_SESSION } from '@/lib/cosmos';
-import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
+import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import type { BirdUsage, ETransferRecipient } from '@/lib/types';
 
 function isValidETransferRecipient(value: unknown): value is ETransferRecipient {
@@ -20,7 +20,25 @@ function isValidAnomalyDismissedList(value: unknown): value is string[] {
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+/**
+ * Removes admin-only fields from a session doc before it goes to a non-admin
+ * caller. `eTransferRecipient` is payment PII (rule 10) and `approvedNames` is
+ * the invite list (enables name enumeration); both are read only by admin
+ * components. Same strip convention as `deleteToken`/`pinHash` elsewhere.
+ * `settled` is intentionally kept — it carries the player's own cost.
+ */
+function stripForPublic<T extends Record<string, unknown>>(session: T) {
+  const {
+    eTransferRecipient: _etr,
+    approvedNames: _an,
+    anomaliesAtAdvance: _aaa,
+    anomaliesDismissed: _ad,
+    ...safe
+  } = session;
+  return safe;
+}
+
+export async function GET(req: NextRequest) {
   try {
     const sessionId = await getActiveSessionId();
     const container = getContainer('sessions');
@@ -30,8 +48,9 @@ export async function GET() {
         parameters: [{ name: '@id', value: sessionId }],
       })
       .fetchAll();
-    const session = resources.find((r) => r.id !== POINTER_ID);
-    return NextResponse.json(session ?? { ...DEFAULT_SESSION, id: sessionId, sessionId });
+    const session = resources.find((r) => r.id !== POINTER_ID)
+      ?? { ...DEFAULT_SESSION, id: sessionId, sessionId };
+    return NextResponse.json(isAdminAuthed(req) ? session : stripForPublic(session));
   } catch (error) {
     console.error('GET session error:', error);
     return NextResponse.json(DEFAULT_SESSION);

--- a/app/api/stats/insight/route.ts
+++ b/app/api/stats/insight/route.ts
@@ -5,6 +5,8 @@ import { getContainer, getActiveSessionId, ensureContainer } from '@/lib/cosmos'
 import { topPartners } from '@/lib/recommend';
 import { isFlagOn } from '@/lib/flags';
 import { summarizeAssessmentTrend, type AssessmentTrend, type StoredAssessment } from '@/lib/assessment';
+import { getCanonicalLevel } from '@/lib/levelStore';
+import type { CanonicalLevel } from '@/lib/level';
 
 /**
  * Account-gated, passively-generated player insight. Replaces the old
@@ -140,6 +142,16 @@ export async function GET(req: NextRequest) {
   const trend = await fetchAssessmentTrend(member.id);
   const latestAssessmentAt = trend?.latestAt ?? null;
 
+  // Canonical level (flag-gated). Same memberId-resolve as the trend; folds the
+  // self-assessments into one private headline number. Non-fatal — the insight
+  // still generates without it. Cheap on the cached path (only runs on miss).
+  const canonicalLevel = isFlagOn('NEXT_PUBLIC_FLAG_SKILL_LEVEL')
+    ? await getCanonicalLevel({ memberId: member.id, name: member.name }).catch((err) => {
+        console.error('insight level read failed:', err);
+        return null;
+      })
+    : null;
+
   // ── Cache: return the stored insight if it's for the current session AND no
   //    newer assessment has landed since it was generated. ──
   let existing: InsightDoc | null = null;
@@ -171,7 +183,7 @@ export async function GET(req: NextRequest) {
   }
 
   // ── Gather the data snapshot (deterministic — fed verbatim to Claude). ──
-  const snapshot = await buildSnapshot({ name: member.name, playersContainer, sessionsContainer, trend });
+  const snapshot = await buildSnapshot({ name: member.name, playersContainer, sessionsContainer, trend, canonicalLevel });
 
   // ── Generate (memory = previous recap+focus). ──
   let recap = '';
@@ -211,6 +223,9 @@ interface Snapshot {
   /** Self-assessment trend (1–5). The preferred skill source — when present the
    *  legacy `skills` read is skipped and `skills` is null. */
   assessment: AssessmentTrend | null;
+  /** Canonical level (1–5) — the private headline, when the level flag is on.
+   *  Narrated as a one-line header above the self-assessment detail. */
+  canonicalLevel: CanonicalLevel | null;
   /** Legacy admin-entered skills (0–6). Fallback only — populated when there is
    *  no self-assessment. Never narrated alongside `assessment` (two scales). */
   skills: Record<string, number> | null;
@@ -221,11 +236,13 @@ async function buildSnapshot({
   playersContainer,
   sessionsContainer,
   trend,
+  canonicalLevel,
 }: {
   name: string;
   playersContainer: ReturnType<typeof getContainer>;
   sessionsContainer: ReturnType<typeof getContainer>;
   trend: AssessmentTrend | null;
+  canonicalLevel: CanonicalLevel | null;
 }): Promise<Snapshot> {
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - ATTENDANCE_WEEKS * 7);
@@ -317,7 +334,7 @@ async function buildSnapshot({
     }
   }
 
-  return { totalSessions, attended, attendanceRate, currentStreak, longestStreak, lastSession, regularPartners, assessment: trend, skills };
+  return { totalSessions, attended, attendanceRate, currentStreak, longestStreak, lastSession, regularPartners, assessment: trend, canonicalLevel, skills };
 }
 
 async function generate(name: string, s: Snapshot, prev: InsightDoc | null): Promise<{ recap: string; focus: string }> {
@@ -363,6 +380,16 @@ Return ONLY a JSON object, no markdown fences:
  * narrated movement agrees with the radar the player is looking at.
  */
 function buildSkillLine(s: Snapshot): string {
+  // Canonical level is a one-line HEADER (1–5) above the self-assessment detail.
+  // It and the self-assessment share the 1–5 scale, so they never conflict the
+  // way the legacy 0–6 skills would — but we still never emit the 0–6 line
+  // alongside it (that branch is the no-assessment fallback below).
+  const lvl = s.canonicalLevel;
+  const levelHeader =
+    lvl && lvl.level !== null
+      ? `Canonical level: ${lvl.level.toFixed(1)} / 5${lvl.phase ? ` (${lvl.phase} phase` : ''}${lvl.phase ? `, ${lvl.confidence} confidence)` : ''}. `
+      : '';
+
   const a = s.assessment;
   if (a) {
     const fmt = (n: number | null) => (n === null ? '—' : n.toFixed(1));
@@ -379,7 +406,7 @@ function buildSkillLine(s: Snapshot): string {
     } else {
       parts.push(`holding steady since the previous check-in (was ${fmt(a.prevOverall)})`);
     }
-    let line = `${parts.join('; ')}.`;
+    let line = `${levelHeader}${parts.join('; ')}.`;
     if (a.strengths.length) line += ` Strongest: ${a.strengths.map((r) => `${r.label} (${r.value})`).join(', ')}.`;
     if (a.workOn.length) line += ` Working on (lowest-rated): ${a.workOn.map((r) => `${r.label} (${r.value})`).join(', ')}.`;
     return line;

--- a/app/api/stats/level/route.ts
+++ b/app/api/stats/level/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer } from '@/lib/cosmos';
+import { isFlagOn } from '@/lib/flags';
+import { getClientIp, checkRateLimit } from '@/lib/rateLimit';
+import { isAdminAuthed, verifyMemberAuth } from '@/lib/auth';
+import { getCanonicalLevel, type LevelSubject } from '@/lib/levelStore';
+
+/**
+ * Canonical level for a member — private by design (CLAUDE.md privacy stance):
+ * served only to the member themselves (a matching `member_session` cookie) or
+ * an admin. Never ranked, never listed. Read-only ⇒ the cheap sync
+ * `isAdminAuthed` is fine (rule 3).
+ *
+ * Order follows the security rules: rate limit (rule 4) → flag (404 when off) →
+ * privacy gate (rule 12 posture) → resolve subject → derive.
+ */
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Name → subject id. Mirrors `resolveSubject` in app/api/assessments/route.ts:
+ * the members directory is canonical; non-members fall back to a name-derived
+ * key so they still get a (self-only) level. Queries by @name, which the mock
+ * store honors (it does NOT honor @memberId).
+ */
+async function resolveSubject(name: string): Promise<LevelSubject> {
+  const trimmed = name.trim();
+  try {
+    const { resources } = await getContainer('members')
+      .items.query({
+        query: 'SELECT * FROM c WHERE LOWER(c.name) = @name',
+        parameters: [{ name: '@name', value: trimmed.toLowerCase() }],
+      })
+      .fetchAll();
+    const member = resources[0] as { id?: string } | undefined;
+    if (member?.id) return { memberId: member.id, name: trimmed };
+  } catch {
+    /* fall through to name-derived id */
+  }
+  return { memberId: `name:${trimmed.toLowerCase()}`, name: trimmed };
+}
+
+export async function GET(req: NextRequest) {
+  const ip = getClientIp(req);
+  if (!checkRateLimit(`stats-level:${ip}`, 60, 60 * 1000)) {
+    return NextResponse.json({ error: 'rate_limited' }, { status: 429 });
+  }
+
+  if (!isFlagOn('NEXT_PUBLIC_FLAG_SKILL_LEVEL')) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const name = new URL(req.url).searchParams.get('name')?.trim().slice(0, 50) ?? '';
+  if (!name) return NextResponse.json({ error: 'name_required' }, { status: 400 });
+
+  // Privacy gate: the calling device must own this name (member cookie) or be
+  // an admin. A known-not-authed caller gets 403 (the client renders an
+  // actionable "sign in again" state — unknown ≠ known-false).
+  const member = verifyMemberAuth(req);
+  const ownsName = member?.name?.trim().toLowerCase() === name.toLowerCase();
+  if (!ownsName && !isAdminAuthed(req)) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  try {
+    const subject = await resolveSubject(name);
+    const level = await getCanonicalLevel(subject);
+    return NextResponse.json({ level });
+  } catch (error) {
+    console.error('GET stats/level error:', error);
+    return NextResponse.json({ error: 'load_failed' }, { status: 500 });
+  }
+}

--- a/components/SkillsTab.tsx
+++ b/components/SkillsTab.tsx
@@ -18,6 +18,8 @@ import StatsSignedOut from '@/components/stats/StatsSignedOut';
 const SkillsRadar = dynamic(() => import('@/components/SkillsRadar'), { ssr: false });
 // Recharts needs window → ssr:false, same as SkillsRadar.
 const SkillTrendCard = dynamic(() => import('@/components/stats/SkillTrendCard'), { ssr: false });
+// Client-only (reads localStorage identity), same posture as SkillTrendCard.
+const LevelCard = dynamic(() => import('@/components/stats/LevelCard'), { ssr: false });
 
 // Hidden for now — admin Add Player + SkillsRadar overlay/compare mode are
 // scoped out of the user-facing Stats tab while we figure out whether self-
@@ -152,7 +154,16 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
   // Hero slot. When the skill-assessment spine is on, the self-assessment
   // trend hero is the headline; otherwise the legacy streak + AI summary.
   const skillAssessOn = isFlagOn('NEXT_PUBLIC_FLAG_SKILL_ASSESS');
-  const heroSlot = skillAssessOn ? <SkillTrendCard /> : <StreakSummaryCard />;
+  // Phase 1 canonical level — the private headline read, above the trend radar.
+  const levelOn = isFlagOn('NEXT_PUBLIC_FLAG_SKILL_LEVEL');
+  const heroSlot = skillAssessOn ? (
+    <>
+      {levelOn && <LevelCard />}
+      <SkillTrendCard />
+    </>
+  ) : (
+    <StreakSummaryCard />
+  );
 
   // Value-Hub Slice-0 splits across the Stats tab's two registers:
   //   • Gear view → RacketRow (your racket + recommendation)

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { getIdentity } from '@/lib/identity';
+import type { CanonicalLevel } from '@/lib/level';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const STATS_NAME_KEY = 'badminton_stats_preview_name';
+
+/** Same identity chain as the other stats cards: real identity → stats
+ *  preview-name → null. Real identity wins so the level keys to the real player. */
+function resolveActiveName(): string | null {
+  const id = getIdentity();
+  if (id?.name) return id.name;
+  try {
+    const stored = localStorage.getItem(STATS_NAME_KEY);
+    if (stored && stored.trim()) return stored.trim();
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+type LoadState =
+  | { kind: 'idle' }
+  | { kind: 'ok'; level: CanonicalLevel }
+  | { kind: 'error' }
+  | { kind: 'needsAuth' };
+
+const CONF_COLOR: Record<CanonicalLevel['confidence'], string> = {
+  low: 'var(--text-muted)',
+  medium: 'var(--accent-amber, #f59e0b)',
+  high: 'var(--accent, #22c55e)',
+};
+
+/**
+ * Private "Your level" card — the canonical 1–5 read folded from the member's
+ * self check-ins (+ legacy stage fallback). Legible-fail throughout: an explicit
+ * error pill on load failure and an actionable "sign in again" state on 403,
+ * never a confident-but-wrong zero (lying-empty-state rule).
+ */
+export default function LevelCard() {
+  const t = useTranslations('stats');
+  const [activeName, setActiveName] = useState<string | null>(null);
+  const [state, setState] = useState<LoadState>({ kind: 'idle' });
+  const [loaded, setLoaded] = useState(false);
+  const [showHow, setShowHow] = useState(false);
+
+  useEffect(() => {
+    setActiveName(resolveActiveName());
+  }, []);
+
+  const load = useCallback(() => {
+    if (!activeName) return;
+    fetch(`${BASE}/api/stats/level?name=${encodeURIComponent(activeName)}`, { cache: 'no-store' })
+      .then(async (r) => {
+        if (r.status === 403) return { _needsAuth: true } as const;
+        if (!r.ok) throw new Error(String(r.status));
+        return r.json();
+      })
+      .then((d) => {
+        if (d?._needsAuth) setState({ kind: 'needsAuth' });
+        else if (d?.level) setState({ kind: 'ok', level: d.level as CanonicalLevel });
+        else setState({ kind: 'error' });
+        setLoaded(true);
+      })
+      .catch(() => {
+        setState({ kind: 'error' });
+        setLoaded(true);
+      });
+  }, [activeName]);
+
+  useEffect(() => { load(); }, [load]);
+
+  if (!activeName || !loaded) return null;
+
+  const Frame = ({ children }: { children: React.ReactNode }) => (
+    <div className="glass-card p-5 space-y-3">
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: 'var(--accent, #22c55e)', marginTop: 1 }}>
+          emoji_events
+        </span>
+        <div>
+          <h3 className="bpm-h3 m-0">{t('level.title')}</h3>
+          <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '2px 0 0', lineHeight: 1.35 }}>{t('level.purpose')}</p>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+
+  if (state.kind === 'error') {
+    return (
+      <Frame>
+        <p className="text-red-400 text-xs" role="alert">{t('level.error')}</p>
+      </Frame>
+    );
+  }
+
+  if (state.kind === 'needsAuth') {
+    return (
+      <Frame>
+        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('level.needsAuth')}</p>
+      </Frame>
+    );
+  }
+
+  if (state.kind !== 'ok') return null;
+  const { level } = state;
+
+  // No level yet — surface the explanation's call-to-action, not a fake "0".
+  if (level.level === null) {
+    return (
+      <Frame>
+        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>
+          {level.explanation[0] ?? t('level.empty')}
+        </p>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame>
+      <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
+        {level.phase && (
+          <span
+            style={{
+              fontSize: 11, padding: '3px 10px', borderRadius: 100, fontWeight: 600,
+              letterSpacing: '0.04em', textTransform: 'uppercase',
+              border: `1px solid ${level.phase === 'switch' ? 'var(--accent-amber)' : 'var(--accent)'}`,
+              color: level.phase === 'switch' ? 'var(--accent-amber)' : 'var(--accent)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {t(`assess.phase.${level.phase}`)}
+          </span>
+        )}
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, marginLeft: 'auto' }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 30, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>
+            {level.level.toFixed(1)}
+          </span>
+          <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>{t('level.ofFive')}</span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span
+          aria-hidden="true"
+          style={{ width: 8, height: 8, borderRadius: 100, background: CONF_COLOR[level.confidence], flexShrink: 0 }}
+        />
+        <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+          {t(`level.confidence.${level.confidence}`)}
+        </span>
+      </div>
+
+      {level.explanation.length > 0 && (
+        <div className="space-y-2">
+          <button
+            type="button"
+            onClick={() => setShowHow((v) => !v)}
+            aria-expanded={showHow}
+            className="cc-btn cc-btn-ghost"
+            style={{ width: '100%', justifyContent: 'center' }}
+          >
+            {showHow ? t('level.hideDetails') : t('level.howTitle')}
+          </button>
+          {showHow && (
+            <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}>
+              {level.explanation.map((line, i) => (
+                <li key={i} style={{ fontSize: 12, lineHeight: 1.45, color: 'var(--text-secondary)' }}>{line}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </Frame>
+  );
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -22,7 +22,8 @@ export type FlagName =
   | 'NEXT_PUBLIC_FLAG_LEDGER'
   | 'NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE'
   | 'NEXT_PUBLIC_FLAG_NAV_RAIL'
-  | 'NEXT_PUBLIC_FLAG_SKILL_ASSESS';
+  | 'NEXT_PUBLIC_FLAG_SKILL_ASSESS'
+  | 'NEXT_PUBLIC_FLAG_SKILL_LEVEL';
 
 interface FlagMeta {
   description: string;
@@ -66,6 +67,11 @@ export const FLAGS: Record<FlagName, FlagMeta> = {
     owner: 'grant',
     plannedRemoval: 'after skill-assessment P0 is promoted to stable + lived-in for 2 weeks',
   },
+  NEXT_PUBLIC_FLAG_SKILL_LEVEL: {
+    description: 'Canonical skill level (Phase 1 of the skill-accuracy spine): one derived 1–5 level per member, computed on read by folding self-assessment snapshots (+ legacy Member.stage fallback). Surfaces a private "Your level" card on Stats and prepends the level to the AI insight. Read API is privacy-gated (member cookie / admin). On for bpm-next + dev; off on bpm-stable until promoted.',
+    owner: 'grant',
+    plannedRemoval: 'after the skill-level spine is promoted to stable + lived-in for 2 weeks',
+  },
 };
 
 function readFlag(name: FlagName): string | undefined {
@@ -84,6 +90,8 @@ function readFlag(name: FlagName): string | undefined {
       return process.env.NEXT_PUBLIC_FLAG_NAV_RAIL;
     case 'NEXT_PUBLIC_FLAG_SKILL_ASSESS':
       return process.env.NEXT_PUBLIC_FLAG_SKILL_ASSESS;
+    case 'NEXT_PUBLIC_FLAG_SKILL_LEVEL':
+      return process.env.NEXT_PUBLIC_FLAG_SKILL_LEVEL;
   }
 }
 

--- a/lib/level.ts
+++ b/lib/level.ts
@@ -1,0 +1,180 @@
+/**
+ * Canonical skill level — one accurate, explainable number per member.
+ *
+ * Pure module (no I/O) so it unit-tests directly and is reused by the API route,
+ * the insight narrator, and (later) the gear recommender. Computed on read by
+ * folding data that already exists (self-assessment snapshots now; game
+ * calibration + peer in later phases). No materialized rating doc, no job.
+ *
+ * Scale: `level` is 1–5 (the self-assessment scale, `lib/assessment.ts`). It is
+ * the canonical headline. `stage` (1–6) is a BRIDGE for the gear recommender,
+ * which matches against catalog `skillRange` on a 1–6 axis — see `levelToStage`.
+ *
+ * Blend (forward-compatible — later phases just light up terms):
+ *   w_self = 0.5
+ *   w_game = 0.3 × min(1, gamesLast180d / 10)   (Phase 2)
+ *   w_peer = 0.2 × min(1, ratersLast180d / 3)   (Phase 5)
+ *   level  = Σ(wᵢ × componentᵢ) / Σ(wᵢ)          over PRESENT components only
+ * Missing sources are omitted and the weights renormalized. With no sources we
+ * fall back to `stageToLevel(Member.stage)` at low confidence; with no stage
+ * either, `level` is null (take a check-in).
+ */
+
+import { placePhase, type Phase } from './assessment';
+
+export interface LevelInputs {
+  /** Self-assessment snapshots (may be unsorted). Phase 1 reads the latest
+   *  non-null `overall`; Phase 3 swaps in a smoothed value. */
+  selfSnapshots: { takenAt: string; overall: number | null }[];
+  /** Phase 2 — game-calibrated observed level + volume. */
+  gameCalibration?: { observedLevel: number; games: number; lastGameAt: string | null } | null;
+  /** Phase 5 — peer-rating aggregate. */
+  peerLevel?: { median: number; raters: number } | null;
+  /** `Member.stage` (1–6). Fallback input only, never written. */
+  legacyStage?: number | null;
+  /** Injected for deterministic staleness math. ISO 8601. */
+  now: string;
+}
+
+export interface CanonicalLevel {
+  /** 1–5, one decimal — the canonical headline. Null when there's nothing to go on. */
+  level: number | null;
+  /** 1–6 bridge for gear `skillRange` / stage consumers. */
+  stage: number | null;
+  /** Reuses the self-assessment phase bands. */
+  phase: Phase | null;
+  confidence: 'low' | 'medium' | 'high';
+  /** What each source contributed (null = not present), for transparency. */
+  basis: { self: number | null; game: number | null; peer: number | null; legacyStage: number | null };
+  /** Human-readable lines rendered under "How this is calculated". */
+  explanation: string[];
+  computedAt: string;
+}
+
+const STALE_DAYS = 180;
+const round1 = (n: number) => Math.round(n * 10) / 10;
+const clampLevel = (n: number) => Math.min(5, Math.max(1, n));
+const clampStage = (n: number) => Math.min(6, Math.max(1, n));
+
+/** Level (1–5) → stage (1–6). Each self-assessment phase boundary ≈ +1 stage. */
+export function levelToStage(level: number): number {
+  return clampStage(Math.round(1 + (clampLevel(level) - 1) * 1.25));
+}
+
+/** Stage (1–6) → level (1–5). Inverse-ish of `levelToStage`, used for the
+ *  legacy-stage fallback seed. */
+export function stageToLevel(stage: number): number {
+  return round1(clampLevel(1 + (clampStage(stage) - 1) * 0.8));
+}
+
+/** Latest snapshot with a non-null `overall`, by `takenAt`. */
+function latestSelf(snapshots: { takenAt: string; overall: number | null }[]): { takenAt: string; overall: number } | null {
+  const sorted = snapshots
+    .filter((s) => s && typeof s.takenAt === 'string' && typeof s.overall === 'number')
+    .slice()
+    .sort((a, b) => a.takenAt.localeCompare(b.takenAt));
+  const latest = sorted[sorted.length - 1];
+  return latest ? { takenAt: latest.takenAt, overall: latest.overall as number } : null;
+}
+
+function ageDays(fromIso: string, nowIso: string): number {
+  const from = Date.parse(fromIso);
+  const now = Date.parse(nowIso);
+  if (Number.isNaN(from) || Number.isNaN(now)) return 0;
+  return (now - from) / 86_400_000;
+}
+
+const NOTCH_DOWN: Record<CanonicalLevel['confidence'], CanonicalLevel['confidence']> = {
+  high: 'medium',
+  medium: 'low',
+  low: 'low',
+};
+
+/**
+ * Derive the canonical level from whatever sources are present. The blend is
+ * forward-compatible: Phase 1 only ever passes self + legacyStage, so the game
+ * and peer terms stay null and renormalize away.
+ */
+export function deriveLevel(inputs: LevelInputs): CanonicalLevel {
+  const { selfSnapshots, gameCalibration, peerLevel, legacyStage, now } = inputs;
+  const explanation: string[] = [];
+
+  const self = latestSelf(selfSnapshots ?? []);
+  const selfLevel = self?.overall ?? null;
+  const gameLevel = gameCalibration ? clampLevel(gameCalibration.observedLevel) : null;
+  const peerLevelVal = peerLevel ? clampLevel(peerLevel.median) : null;
+
+  // Weighted blend over present components.
+  const terms: { value: number; weight: number }[] = [];
+  if (selfLevel !== null) terms.push({ value: selfLevel, weight: 0.5 });
+  if (gameLevel !== null && gameCalibration) {
+    terms.push({ value: gameLevel, weight: 0.3 * Math.min(1, gameCalibration.games / 10) });
+  }
+  if (peerLevelVal !== null && peerLevel) {
+    terms.push({ value: peerLevelVal, weight: 0.2 * Math.min(1, peerLevel.raters / 3) });
+  }
+  const usable = terms.filter((t) => t.weight > 0);
+  const totalWeight = usable.reduce((s, t) => s + t.weight, 0);
+
+  const basis = {
+    self: selfLevel !== null ? round1(selfLevel) : null,
+    game: gameLevel !== null ? round1(gameLevel) : null,
+    peer: peerLevelVal !== null ? round1(peerLevelVal) : null,
+    legacyStage: typeof legacyStage === 'number' ? legacyStage : null,
+  };
+
+  // No usable measured sources → fall back to the legacy stage, else null.
+  if (totalWeight === 0) {
+    if (typeof legacyStage === 'number') {
+      const level = stageToLevel(legacyStage);
+      explanation.push('Estimated from your saved skill stage — take a check-in to make this yours.');
+      return {
+        level,
+        stage: levelToStage(level),
+        phase: placePhase(level),
+        confidence: 'low',
+        basis,
+        explanation,
+        computedAt: now,
+      };
+    }
+    explanation.push('Take a skill check-in to see your level.');
+    return { level: null, stage: null, phase: null, confidence: 'low', basis, explanation, computedAt: now };
+  }
+
+  const level = round1(clampLevel(usable.reduce((s, t) => s + t.value * t.weight, 0) / totalWeight));
+
+  // Confidence from the strength of evidence, then docked for staleness.
+  let confidence: CanonicalLevel['confidence'] =
+    (selfSnapshots?.filter((s) => typeof s.overall === 'number').length ?? 0) >= 2 ? 'high' : 'medium';
+  if (gameLevel !== null) confidence = 'high';
+
+  if (self && ageDays(self.takenAt, now) > STALE_DAYS) {
+    confidence = NOTCH_DOWN[confidence];
+    explanation.push('Your last check-in was over 6 months ago — refresh it to sharpen this.');
+  }
+
+  // Narration of what fed the number.
+  if (basis.self !== null) {
+    const count = selfSnapshots.filter((s) => typeof s.overall === 'number').length;
+    explanation.unshift(
+      count > 1
+        ? `From your self check-ins (latest ${basis.self.toFixed(1)} / 5, ${count} on record).`
+        : `From your self check-in (${basis.self.toFixed(1)} / 5).`,
+    );
+  }
+  if (basis.game !== null && gameCalibration) {
+    explanation.push(`Adjusted by your logged games (${gameCalibration.games} game${gameCalibration.games === 1 ? '' : 's'}).`);
+  }
+  if (basis.peer !== null) explanation.push('Includes how regular partners see your play.');
+
+  return {
+    level,
+    stage: levelToStage(level),
+    phase: placePhase(level),
+    confidence,
+    basis,
+    explanation,
+    computedAt: now,
+  };
+}

--- a/lib/levelStore.ts
+++ b/lib/levelStore.ts
@@ -1,0 +1,64 @@
+/**
+ * Server-only I/O for the canonical level. EVERY consumer (API route, insight
+ * narrator, future gear rec) goes through `getCanonicalLevel` so the number is
+ * computed one way. Pure math lives in `lib/level.ts`; this file only fetches.
+ *
+ * Reads mirror the established patterns:
+ *  - assessments by `memberId` with a JS-side filter (the mock store ignores
+ *    `@memberId`), same as `fetchAssessmentTrend` in the insight route and the
+ *    assessments GET.
+ *  - `Member.stage` by id (real members only; `name:`-derived ids have none).
+ *
+ * Failures are non-fatal: a read error degrades a source to absent rather than
+ * throwing, so the level still derives from whatever survived.
+ */
+
+import { getContainer, ensureContainer } from './cosmos';
+import { deriveLevel, type CanonicalLevel } from './level';
+
+/** Subject identity, as resolved by the route (`resolveSubject` shape). */
+export interface LevelSubject {
+  /** Real `members` id, or a `name:<lower>` fallback for non-members. */
+  memberId: string;
+  name: string;
+}
+
+async function fetchSelfSnapshots(memberId: string): Promise<{ takenAt: string; overall: number | null }[]> {
+  try {
+    await ensureContainer('assessments', '/memberId');
+    const { resources } = await getContainer('assessments').items
+      .query({
+        query: 'SELECT c.memberId, c.takenAt, c.overall FROM c WHERE c.memberId = @memberId',
+        parameters: [{ name: '@memberId', value: memberId }],
+      })
+      .fetchAll();
+    return (resources as { memberId?: string; takenAt?: string; overall?: number | null }[])
+      .filter((d) => d && d.memberId === memberId && typeof d.takenAt === 'string')
+      .map((d) => ({ takenAt: d.takenAt as string, overall: typeof d.overall === 'number' ? d.overall : null }));
+  } catch (err) {
+    console.error('level: assessment read failed:', err);
+    return [];
+  }
+}
+
+/** `Member.stage` for a real member id, else null (name-derived ids, misses,
+ *  and errors all degrade to "no legacy stage"). */
+async function fetchLegacyStage(memberId: string): Promise<number | null> {
+  if (memberId.startsWith('name:')) return null;
+  try {
+    const { resource } = await getContainer('members').item(memberId, memberId).read<{ stage?: number }>();
+    return typeof resource?.stage === 'number' ? resource.stage : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The single entry point. Folds the member's self-assessments + legacy stage
+ *  into a canonical level. Phase 2+ will add game/peer reads here. */
+export async function getCanonicalLevel(subject: LevelSubject): Promise<CanonicalLevel> {
+  const [selfSnapshots, legacyStage] = await Promise.all([
+    fetchSelfSnapshots(subject.memberId),
+    fetchLegacyStage(subject.memberId),
+  ]);
+  return deriveLevel({ selfSnapshots, legacyStage, now: new Date().toISOString() });
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -199,6 +199,21 @@
   "stats": {
     "heading": "Your stats",
     "subhead": "Interesting metrics that you didn't ask for (beta)",
+    "level": {
+      "title": "Your level",
+      "purpose": "One read on where your game is right now — just for you.",
+      "ofFive": "/ 5",
+      "howTitle": "How this is calculated",
+      "hideDetails": "Hide",
+      "confidence": {
+        "low": "Rough estimate",
+        "medium": "Getting clearer",
+        "high": "Well-calibrated"
+      },
+      "empty": "Take a skill check-in to see your level.",
+      "error": "Couldn't load — refresh to retry",
+      "needsAuth": "Sign in again to see your level."
+    },
     "comingSoon": "Coming soon",
     "moreComing": "other metrics in the making",
     "progression": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -199,6 +199,21 @@
   "stats": {
     "heading": "你的数据",
     "subhead": "你没问过但很有趣的数据(beta)",
+    "level": {
+      "title": "你的水平",
+      "purpose": "一眼看清你现在的水平——只给你自己看。",
+      "ofFive": "/ 5",
+      "howTitle": "如何计算",
+      "hideDetails": "收起",
+      "confidence": {
+        "low": "粗略估计",
+        "medium": "逐渐清晰",
+        "high": "已校准"
+      },
+      "empty": "完成一次技能自评即可看到你的水平。",
+      "error": "加载失败——刷新重试",
+      "needsAuth": "请重新登录以查看你的水平。"
+    },
     "comingSoon": "即将推出",
     "moreComing": "更多指标制作中",
     "progression": {


### PR DESCRIPTION
## What & why

The skill system today can't support accurate AI coaching or (later) gear recs because the signals are fragmented: self-assessment (1–5), legacy admin skills (0–6), and `Member.stage` (1–6) never agree, and self-ratings are never grounded. This is **Phase 1 of the accuracy spine** (full plan + self-critique in the planning doc): one **canonical 1–5 level** per member, computed on read.

Plan decisions locked with the maintainer beforehand:
- **Spine only** first (Phase 1 here → Phase 2 game calibration → Phase 3 stability later).
- Numeric peer rating **cut** (replaced by a future positive-only kudos mechanic).
- Privacy-first: the level is **private** — member-or-admin only, never ranked.

## What's in this PR (Phase 1)

- **`lib/level.ts`** — pure `deriveLevel` + `levelToStage`/`stageToLevel` bridge. Forward-compatible weighted blend (self 0.5 / game 0.3 / peer 0.2, renormalized over present sources) so Phase 2/5 just light up terms. No I/O, fully unit-tested.
- **`lib/levelStore.ts`** — single server-only entry point `getCanonicalLevel`; every consumer goes through it. Reads assessments (memberId, JS-filter — mock-store parity) + `Member.stage`, non-fatal degradation.
- **`app/api/stats/level/route.ts`** — `rate-limit → flag (404 off) → privacy gate (member cookie / admin) → resolve subject (name-fallback) → derive`.
- **`components/stats/LevelCard.tsx`** — private headline card above the trend radar. Legible-fail throughout (explicit error pill; 403 → actionable "sign in again"; null level → CTA, never a fake `0`).
- **AI insight** — prepends a one-line canonical-level header; never mixes the 0–6 scale.
- **Flag** `NEXT_PUBLIC_FLAG_SKILL_LEVEL` registered (`lib/flags.ts`) + wired into `deploy-next.yml` (flag-sync hook passes).
- **i18n** `stats.level.*` in `en` + `zh-CN` (parity test green).

## Tests
- `__tests__/level.test.ts` — blend renormalization, the level↔stage bridge at every phase boundary, confidence + staleness docking, legacy-stage & null fallbacks, determinism.
- `__tests__/stats-level-route.test.ts` — flag 404, missing-name 400, the cookie/admin privacy gate (owner ✓, mismatch ✗, admin browse ✓), name-fallback.
- Full suite: **776 passing (106 files)**; new app code typechecks clean.

## Notes for review
- The privacy gate returns **403** on a known-not-authed caller (cookie expired but localStorage identity persists); the card renders an actionable state rather than a scary error — honoring "unknown ≠ known-false".
- No schema change, no migration, no new container — pure folds over existing data (same posture as `lib/recommend.ts`).

Draft while Phase 2 (game calibration) is built on top.

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_