### PR TITLE
release(stable): v1.7 — full feature parity with bpm-next

### DIFF
--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -44,7 +44,11 @@ jobs:
           NEXT_PUBLIC_ETRANSFER_EMAIL: grantxyzou@gmail.com
           NEXT_PUBLIC_ENV: stable
           NEXT_PUBLIC_GIT_SHA: ${{ github.sha }}
-          NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: 'false'
+          # v1.7: stable is brought to FULL feature parity with bpm-next — every
+          # flag below mirrors deploy-next.yml. (NEXT_PUBLIC_ENV stays 'stable'
+          # so the preview banner remains off; it's an env identifier, not a
+          # feature flag.)
+          NEXT_PUBLIC_FLAG_DESIGN_PREVIEW: 'true'
           NEXT_PUBLIC_FLAG_COMMAND_CENTER: 'true'
           NEXT_PUBLIC_FLAG_SETTLE: 'true'
           # Ledger goes live on stable with v1.6 (2026-06-02). The v1.5 cut
@@ -57,6 +61,13 @@ jobs:
           # Skill self-assessment trend spine - promoted to stable with v1.7
           # (soaked since 2026-06-02, kill-gate cleared). vnext-only on v1.6.
           NEXT_PUBLIC_FLAG_SKILL_ASSESS: 'true'
+          # v1.7: parity flips — Value-Hub Slice-0 (racket/game-logger/partners)
+          # and the full skill-accuracy spine (canonical level → game calibration
+          # → progression stability) now live on stable, matching bpm-next.
+          NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE: 'true'
+          NEXT_PUBLIC_FLAG_SKILL_LEVEL: 'true'
+          NEXT_PUBLIC_FLAG_SKILL_CALIBRATION: 'true'
+          NEXT_PUBLIC_FLAG_SKILL_SMOOTHING: 'true'
 
       - name: Package standalone build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,19 @@ All infrastructure items above are behavioral no-ops on stable (PreviewBanner re
      Format: `- **Short title** — one-sentence what + why.` See v1.3 below for examples.
      Empty subheadings are fine; delete a section if you don't end up using it. -->
 
+*(empty — everything below shipped to stable in v1.7.)*
+
+---
+
+## v1.7 — Stable reaches full parity with `bpm-next` (2026-06-13)
+
+This cut flips **every** remaining feature flag on, so stable and `bpm-next` are now feature-identical (only `NEXT_PUBLIC_ENV` differs, keeping the preview banner off on stable). Headline: the **skill-accuracy spine** and **Value-Hub Slice-0** go live for everyone, on top of the full app-code audit remediation, accessibility pass, and security hardening accumulated since v1.6.
+
 ### Added
 
-- **Skill self-assessment** *(flag-gated `NEXT_PUBLIC_FLAG_SKILL_ASSESS`, dormant on stable)* — periodic anchor-card check-in across 14 skills, a then-vs-now trend radar, phase placement, and an AI "Your read" that folds in the assessment. *(soaking on `bpm-next`)*
-- **Value-Hub Slice-0** *(flag-gated `NEXT_PUBLIC_FLAG_VALUE_HUB`, dormant on stable)* — racket pick → recommendation card, 48h game logger, and partner-frequency Stats card. *(awaiting kill-criterion gate)*
-- **Accurate skill level** *(flag-gated `NEXT_PUBLIC_FLAG_SKILL_LEVEL` / `…_CALIBRATION` / `…_SMOOTHING`, dormant on stable)* — a private "Your level" card on Stats that folds your check-ins into one 1–5 level, sharpens it against your logged game results (with an opt-in "how your games compare" note), and smooths it so a single check-in can't swing your phase. Feeds the AI "Your read". *(soaking on `bpm-next`)*
+- **Skill self-assessment** *(flag-gated `NEXT_PUBLIC_FLAG_SKILL_ASSESS`, now on for everyone)* — periodic anchor-card check-in across 14 skills, a then-vs-now trend radar, phase placement, and an AI "Your read" that folds in the assessment. *(now live)*
+- **Value-Hub Slice-0** *(flag-gated `NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE`, now on for everyone)* — racket pick → recommendation card, 48h game logger, and partner-frequency Stats card. *(now live)*
+- **Accurate skill level** *(flag-gated `NEXT_PUBLIC_FLAG_SKILL_LEVEL` / `…_CALIBRATION` / `…_SMOOTHING`, now on for everyone)* — a private "Your level" card on Stats that folds your check-ins into one 1–5 level, sharpens it against your logged game results (with an opt-in "how your games compare" note), and smooths it so a single check-in can't swing your phase. Feeds the AI "Your read". *(now live)*
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Brings **bpm-stable** to **full feature parity with bpm-next** (per request). Flips the remaining dormant flags on in `deploy-stable.yml` so a `v1.7` tag deploys a stable build that's feature-identical to next:

| Flag | Before (stable) | After |
|---|---|---|
| `DESIGN_PREVIEW` | false | **true** |
| `VALUE_HUB_SLICE` | (off) | **true** |
| `SKILL_LEVEL` | (off) | **true** |
| `SKILL_CALIBRATION` | (off) | **true** |
| `SKILL_SMOOTHING` | (off) | **true** |

All others were already `true` on both. `NEXT_PUBLIC_ENV` stays `stable` (keeps the preview banner off — it's an environment identifier, not a feature flag).

**CHANGELOG:** cut the `Unreleased` section into a **v1.7** release entry — the skill-accuracy spine + Value-Hub Slice-0 now live for everyone, on top of the audit remediation, a11y pass, and security hardening since v1.6.

## Heads-up
- **`DESIGN_PREVIEW` is now on for stable too** — that exposes the unlinked `/bpm/design` specimen route to friends. Mirrors next exactly as asked; say the word if you'd rather keep that one dev-only and I'll flip it back to `false`.
- This is **zero-soak** for the spine + value-hub (merged today) — a deliberate trade to keep stable == next.

After merge: tag `main` → `bpm-stable-v1.7` → dispatch `deploy-stable`.

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_