### PR TITLE
feat(ops): in-app "Report a problem" → stored + emailed

### DIFF
--- a/__tests__/report.test.ts
+++ b/__tests__/report.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { POST } from '@/app/api/report/route';
+import { resetMockStore, makeRequest, getStore } from './helpers';
+
+const URL = 'http://localhost:3000/api/report';
+
+describe('POST /api/report — in-app problem reports', () => {
+  beforeEach(() => {
+    resetMockStore();
+  });
+
+  it('stores a valid report and returns 201', async () => {
+    const res = await POST(
+      makeRequest('POST', URL, { message: 'Sign-up button does nothing', name: 'Lin' }),
+    );
+    expect(res.status).toBe(201);
+
+    const store = getStore();
+    expect(store['feedback']?.length).toBe(1);
+    const saved = store['feedback'][0] as Record<string, unknown>;
+    expect(saved.message).toBe('Sign-up button does nothing');
+    expect(saved.name).toBe('Lin');
+    expect(typeof saved.createdAt).toBe('string');
+    expect(typeof saved.id).toBe('string');
+  });
+
+  it('rejects an empty / whitespace-only message with 400', async () => {
+    const res = await POST(makeRequest('POST', URL, { message: '   ' }));
+    expect(res.status).toBe(400);
+    expect(getStore()['feedback'] ?? []).toHaveLength(0);
+  });
+
+  it('rejects an over-long message with 400', async () => {
+    const res = await POST(makeRequest('POST', URL, { message: 'x'.repeat(2001) }));
+    expect(res.status).toBe(400);
+    expect(getStore()['feedback'] ?? []).toHaveLength(0);
+  });
+
+  it('captures optional context (tab, name) but tolerates its absence', async () => {
+    const res = await POST(makeRequest('POST', URL, { message: 'broke on stats', tab: 'skills' }));
+    expect(res.status).toBe(201);
+    const saved = getStore()['feedback'][0] as Record<string, unknown>;
+    expect(saved.tab).toBe('skills');
+    expect(saved.name).toBeUndefined();
+  });
+
+  it('succeeds even when email is not configured — store is the source of truth', async () => {
+    // No GMAIL_* env in the test environment, so the notifier no-ops. The
+    // request must still persist the report and report success — never a
+    // silent failure that drops a friend's message.
+    const res = await POST(makeRequest('POST', URL, { message: 'something is broken' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(getStore()['feedback']).toHaveLength(1);
+  });
+
+  it('rate-limits abusive repeats from a single IP', async () => {
+    const ip = 'report-abuse-test';
+    const mk = () => makeRequest('POST', URL, { message: 'spam' }, { 'X-Client-IP': ip });
+    let last = 0;
+    for (let i = 0; i < 12; i++) {
+      last = (await POST(mk())).status;
+    }
+    expect(last).toBe(429);
+  });
+});

--- a/app/api/report/route.ts
+++ b/app/api/report/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { randomBytes } from 'crypto';
+import { getContainer, ensureContainer } from '@/lib/cosmos';
+import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
+import { notifyReport } from '@/lib/reportEmail';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_MESSAGE = 2000;
+const RATE_MAX = 10;
+const RATE_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+// Lazy container bootstrap — real Cosmos doesn't auto-create containers, and
+// `feedback` is global (not session-scoped), so its partition key is `/id`.
+// Cache the promise so createIfNotExists fires at most once per instance.
+let feedbackReady: Promise<void> | null = null;
+function ensureFeedbackContainer(): Promise<void> {
+  if (!feedbackReady) {
+    feedbackReady = ensureContainer('feedback', '/id').catch((err) => {
+      feedbackReady = null;
+      throw err;
+    });
+  }
+  return feedbackReady;
+}
+
+/** Trim, drop-if-empty, and cap an optional free-text field. */
+function optionalStr(v: unknown, max: number): string | undefined {
+  if (typeof v !== 'string') return undefined;
+  const trimmed = v.trim();
+  return trimmed ? trimmed.slice(0, max) : undefined;
+}
+
+export async function POST(req: NextRequest) {
+  // Rate limit FIRST — this is a public, unauthenticated endpoint, so the limit
+  // is the only thing standing between a bored friend and a flood of texts.
+  const ip = getClientIp(req);
+  if (!checkRateLimit(`report:${ip}`, RATE_MAX, RATE_WINDOW_MS)) {
+    return NextResponse.json(
+      { error: 'Too many reports — please try again later.' },
+      { status: 429 },
+    );
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const raw = body.message;
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return NextResponse.json({ error: 'A message is required' }, { status: 400 });
+  }
+  const message = raw.trim();
+  // Reject (rather than silently truncate) an over-long body so a pasted log
+  // dump can't masquerade as a real report.
+  if (message.length > MAX_MESSAGE) {
+    return NextResponse.json({ error: 'Message is too long' }, { status: 400 });
+  }
+
+  const report = {
+    id: `report-${randomBytes(8).toString('hex')}`,
+    message,
+    name: optionalStr(body.name, 80),
+    tab: optionalStr(body.tab, 40),
+    url: optionalStr(body.url, 300),
+    createdAt: new Date().toISOString(),
+    ip,
+  };
+
+  // Persist FIRST — the store is the source of truth. If this throws, the error
+  // propagates (500) rather than pretending the report was captured.
+  await ensureFeedbackContainer();
+  await getContainer('feedback').items.create(report);
+
+  // Notify best-effort. An email hiccup must NOT fail the request — the report
+  // is already safely stored and will surface in the admin feed.
+  let emailed = false;
+  try {
+    emailed = (await notifyReport(report)).sent;
+  } catch (err) {
+    console.error('[report] email notification failed (report still stored):', err);
+  }
+
+  return NextResponse.json({ ok: true, emailed }, { status: 201 });
+}

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -7,6 +7,7 @@ import EnterCodeSheet from './EnterCodeSheet';
 import CreateAccountSheet from './CreateAccountSheet';
 import RecoveryPinSheet from './RecoveryPinSheet';
 import ReleaseNotesSheet from './ReleaseNotesSheet';
+import ReportProblemSheet from './ReportProblemSheet';
 import SignInForm from './SignInForm';
 import PageHeader from './primitives/PageHeader';
 import AdminConsoleHero from './admin/CommandCenter/AdminConsoleHero';
@@ -46,6 +47,7 @@ export default function ProfileTab({
   // open RecoveryPinSheet (set / change / remove + forgot-it handoff).
   const [recoveryPinOpen, setRecoveryPinOpen] = useState(false);
   const [releaseSheetOpen, setReleaseSheetOpen] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   const [releases, setReleases] = useState<Release[] | null>([]);
   const tSettings = useTranslations('profile.settings');
   const tNav = useTranslations('nav');
@@ -275,6 +277,17 @@ export default function ProfileTab({
             </button>
           </div>
         )}
+        {/* Reachable even when signed out — anonymous users hitting a sign-up
+            problem are exactly the reports worth catching. */}
+        <button
+          type="button"
+          onClick={() => setReportOpen(true)}
+          className="btn-ghost"
+          style={{ width: '100%', fontSize: 13 }}
+        >
+          {tSettings('reportProblem')}
+        </button>
+        <ReportProblemSheet open={reportOpen} onClose={() => setReportOpen(false)} />
       </div>
     );
   }
@@ -330,6 +343,7 @@ export default function ProfileTab({
               onClick: () => setEnterCodeOpen(true),
             },
             { icon: 'campaign', label: tSettings('releaseNotes'), onClick: () => setReleaseSheetOpen(true) },
+            { icon: 'flag', label: tSettings('reportProblem'), onClick: () => setReportOpen(true) },
             ...(isAdmin
               ? [{ icon: 'admin_panel_settings', label: tSettings('adminAccess'), onClick: onAdminTools }]
               : []),
@@ -355,6 +369,12 @@ export default function ProfileTab({
         open={releaseSheetOpen}
         releases={releases}
         onClose={() => setReleaseSheetOpen(false)}
+      />
+
+      <ReportProblemSheet
+        open={reportOpen}
+        onClose={() => setReportOpen(false)}
+        name={identity?.name}
       />
     </div>
   );

--- a/components/ReportProblemSheet.tsx
+++ b/components/ReportProblemSheet.tsx
@@ -1,0 +1,134 @@
+'use client';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { BottomSheet, BottomSheetHeader, BottomSheetBody } from './BottomSheet';
+import { useOnline } from '@/lib/useOnline';
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Reporter's name, if signed in — attached so I know who to follow up with. */
+  name?: string;
+}
+
+export default function ReportProblemSheet({ open, onClose, name }: Props) {
+  const t = useTranslations('report');
+  const online = useOnline();
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<'required' | 'server' | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  async function submit() {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      setError('required');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${BASE}/api/report`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: trimmed,
+          name: name?.trim() || undefined,
+          // Which tab they were on — the most useful context for reproducing.
+          tab:
+            typeof document !== 'undefined'
+              ? document.documentElement.getAttribute('data-tab') || undefined
+              : undefined,
+          url: typeof window !== 'undefined' ? window.location.pathname : undefined,
+        }),
+      });
+      if (!res.ok) {
+        setError('server');
+        return;
+      }
+      setSuccess(true);
+      setMessage('');
+      setTimeout(() => {
+        onClose();
+        setSuccess(false);
+      }, 1600);
+    } catch {
+      // Network failure (fetch rejects) — retryable, not the user's fault.
+      setError('server');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} ariaLabel={t('title')} className="max-w-lg mx-auto">
+      <BottomSheetHeader className="flex items-center justify-between p-4">
+        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('title')}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('close')}
+          style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+        >
+          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+        </button>
+      </BottomSheetHeader>
+      <BottomSheetBody className="p-5 pb-8">
+        {success ? (
+          <p style={{ textAlign: 'center', fontSize: 18, color: 'var(--text-primary)' }}>
+            {t('success')}
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: 0 }}>{t('help')}</p>
+            <textarea
+              aria-label={t('placeholder')}
+              placeholder={t('placeholder')}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={4}
+              maxLength={2000}
+              style={{
+                width: '100%',
+                padding: 12,
+                borderRadius: 10,
+                border: '1px solid var(--glass-border)',
+                background: 'var(--input-bg, rgba(255,255,255,0.05))',
+                color: 'var(--text-primary)',
+                resize: 'vertical',
+                fontFamily: 'inherit',
+                fontSize: 14,
+              }}
+            />
+            <button
+              type="button"
+              disabled={submitting || !message.trim() || !online}
+              onClick={submit}
+              className="cc-btn cc-btn-primary cc-btn-lg"
+              style={{ marginTop: 4 }}
+            >
+              {submitting ? t('sending') : t('send')}
+            </button>
+            {!online && (
+              <p role="status" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+                {t('offline')}
+              </p>
+            )}
+            {error === 'required' && (
+              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>
+                {t('errorRequired')}
+              </p>
+            )}
+            {error === 'server' && (
+              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+                {t('errorServer')}
+              </p>
+            )}
+          </div>
+        )}
+      </BottomSheetBody>
+    </BottomSheet>
+  );
+}

--- a/lib/reportEmail.ts
+++ b/lib/reportEmail.ts
@@ -1,0 +1,54 @@
+/**
+ * Best-effort email notification for an in-app problem report.
+ *
+ * Env-gated: returns `{ sent: false }` when `GMAIL_USER` / `GMAIL_APP_PASSWORD`
+ * are unset (local dev, tests) so the report path NEVER depends on SMTP being
+ * configured. `nodemailer` is imported lazily so it isn't loaded — or required
+ * to be installed — in environments that don't actually send.
+ *
+ * Transport is Gmail SMTP via an App Password (no new vendor account). Generate
+ * the App Password at myaccount.google.com → Security → App passwords, then set
+ * `GMAIL_USER`, `GMAIL_APP_PASSWORD`, and optionally `REPORT_EMAIL_TO` (defaults
+ * to the sending account) in Azure App Settings.
+ */
+export interface ReportNotification {
+  message: string;
+  name?: string;
+  tab?: string;
+  url?: string;
+  createdAt: string;
+}
+
+export async function notifyReport(report: ReportNotification): Promise<{ sent: boolean }> {
+  const user = process.env.GMAIL_USER;
+  const pass = process.env.GMAIL_APP_PASSWORD;
+  const to = process.env.REPORT_EMAIL_TO || user;
+  if (!user || !pass || !to) return { sent: false };
+
+  const nodemailer = (await import('nodemailer')).default;
+  const transport = nodemailer.createTransport({
+    service: 'gmail',
+    auth: { user, pass },
+  });
+
+  const body = [
+    report.message,
+    '',
+    '— context —',
+    `from: ${report.name || '(anonymous)'}`,
+    report.tab ? `tab: ${report.tab}` : null,
+    report.url ? `url: ${report.url}` : null,
+    `at: ${report.createdAt}`,
+  ]
+    .filter((line) => line !== null)
+    .join('\n');
+
+  await transport.sendMail({
+    from: `BPM Badminton <${user}>`,
+    to,
+    subject: `[BPM] Problem report${report.name ? ` from ${report.name}` : ''}`,
+    text: body,
+  });
+
+  return { sent: true };
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -185,8 +185,21 @@
       "recoveryCode": "Have a recovery code?",
       "releaseNotes": "What's new",
       "adminAccess": "Admin access",
-      "logout": "Log out"
+      "logout": "Log out",
+      "reportProblem": "Report a problem"
     }
+  },
+  "report": {
+    "title": "Report a problem",
+    "help": "Something not working? Tell me what happened and I'll take a look.",
+    "placeholder": "What went wrong?",
+    "send": "Send report",
+    "sending": "Sending…",
+    "success": "Thanks — got it. I'll look into it.",
+    "errorRequired": "Please describe what happened.",
+    "errorServer": "Couldn't send — please try again.",
+    "offline": "You're offline — reconnect to send.",
+    "close": "Close"
   },
   "pin": {
     "newLabel": "New PIN",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -185,8 +185,21 @@
       "recoveryCode": "有恢复码？",
       "releaseNotes": "更新日志",
       "adminAccess": "管理员访问",
-      "logout": "退出登录"
+      "logout": "退出登录",
+      "reportProblem": "报告问题"
     }
+  },
+  "report": {
+    "title": "报告问题",
+    "help": "有什么不正常吗？告诉我发生了什么，我会去看看。",
+    "placeholder": "出了什么问题？",
+    "send": "发送报告",
+    "sending": "发送中…",
+    "success": "谢谢——已收到，我会去查看。",
+    "errorRequired": "请描述发生了什么。",
+    "errorServer": "发送失败——请重试。",
+    "offline": "你已离线——重新联网后再发送。",
+    "close": "关闭"
   },
   "pin": {
     "newLabel": "新 PIN",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@formatjs/intl-localematcher": "^0.8.9",
         "next": "^16.2.7",
         "next-intl": "^4.12.0",
+        "nodemailer": "^9.0.0",
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^3.8.1"
@@ -21,6 +22,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
+        "@types/nodemailer": "^8.0.1",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.5.0",
@@ -2974,6 +2976,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -7574,6 +7586,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.0.tgz",
+      "integrity": "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@formatjs/intl-localematcher": "^0.8.9",
     "next": "^16.2.7",
     "next-intl": "^4.12.0",
+    "nodemailer": "^9.0.0",
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^3.8.1"
@@ -26,6 +27,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
+    "@types/nodemailer": "^8.0.1",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.5.0",


### PR DESCRIPTION
## What

Phase 2 of a lightweight monitoring setup so I hear about problems my friends hit (they won't file GitHub issues).

- **`POST /api/report`** — public, rate-limited (10/hr/IP), validates message (1–2000 chars), persists every report to a new global `feedback` Cosmos container (**source of truth — never a silent drop**), then best-effort emails me via Gmail SMTP. An email hiccup never fails the request; the report is already stored.
- **`lib/reportEmail.ts`** — env-gated, lazy `nodemailer` import. No SMTP needed in dev/tests, so the route's success never depends on email config.
- **`ReportProblemSheet`** + entry points in Profile (signed-in settings row **and** the anonymous view — sign-up-problem reporters land there). Send button gated on `useOnline()` per the offline-posture rule.
- **i18n** `report` namespace (en + zh-CN) + `profile.settings.reportProblem`.

## Companion (no deploy)

Infra-error half is set up separately via Azure Monitor: HTTP 5xx on stable → SMS + email action group. Test notification verified `Succeeded`.

## Env (set in Azure App Settings; unset = stored-but-not-emailed)

`GMAIL_USER`, `GMAIL_APP_PASSWORD`, `REPORT_EMAIL_TO`

## Tests

6 new (store, validation, over-long reject, optional context, **email-not-configured still-succeeds**, rate limit). Full suite **825 green**, lint clean, tsc clean (no new errors). Verified live: `POST` 201/400 + full UI round-trip via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)