### PR TITLE
chore(ci): bump checkout + setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -16,12 +16,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.tag }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -28,10 +28,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
Kills the Node-20 deprecation warning surfaced on the bpm-next deploy run.

GitHub forces node24 by default as of 2026-06-16 and removes the node20 runtime on **2026-09-16**. The deploy jobs warned that `actions/checkout`, `actions/setup-node`, and `azure/webapps-deploy` still declared `node20`.

## Change
- `actions/checkout` v4 → **v5** (`93cb6ef`) — `using: node24` (verified)
- `actions/setup-node` v4 → **v5** (`a0853c2`) — `using: node24` (verified)
- Applied across `pr-ci`, `deploy-next`, `deploy-stable`. SHA-pinned + version comment preserved.

## Not included
- `azure/webapps-deploy`: the **Azure org enforces SAML SSO**, so its tag SHAs aren't readable via API to re-pin safely. It auto-runs on node24 now regardless. Revisit via Dependabot or after granting the token SAML access.

## Validation
`pr-ci.yml` itself now uses checkout+setup-node@v5, so **this PR's own CI run exercises the bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)