### PR TITLE
feat(gear): recommend off the canonical skill level, not Member.stage

### DIFF
--- a/__tests__/recommend-route.test.ts
+++ b/__tests__/recommend-route.test.ts
@@ -2,7 +2,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { GET } from '@/app/api/recommend/route';
 import { NextRequest } from 'next/server';
-import { getContainer } from '@/lib/cosmos';
+import { getContainer, ensureContainer } from '@/lib/cosmos';
+import { _resetCalibrationCache } from '@/lib/levelStore';
+import { resetMockStore } from './helpers';
 
 // Unique IP per request — recommend is rate-limited 10/min; convention per helpers.ts.
 function get(url: string): NextRequest {
@@ -11,17 +13,33 @@ function get(url: string): NextRequest {
   });
 }
 
+async function seedAssessment(memberId: string, name: string, overall: number) {
+  await ensureContainer('assessments', '/memberId');
+  await getContainer('assessments').items.upsert({
+    id: `a-${memberId}`,
+    memberId,
+    name,
+    takenAt: '2026-06-01T00:00:00Z',
+    overall,
+    ratings: [],
+  });
+}
+
 describe('GET /api/recommend', () => {
   beforeEach(async () => {
+    resetMockStore();
+    _resetCalibrationCache();
     process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'true';
+    delete process.env.NEXT_PUBLIC_FLAG_SKILL_CALIBRATION;
+    delete process.env.NEXT_PUBLIC_FLAG_SKILL_SMOOTHING;
     const catalog = getContainer('equipmentCatalog');
     await catalog.items.upsert({ id: 'wide', category: 'racket', brand: 'Y', model: 'All-Round', skillRange: [1, 6], msrp: 120 });
     await catalog.items.upsert({ id: 'beg', category: 'racket', brand: 'Y', model: 'Starter', skillRange: [1, 2], msrp: 80 });
+    await catalog.items.upsert({ id: 'adv', category: 'racket', brand: 'Y', model: 'Pro', skillRange: [5, 6], msrp: 220 });
   });
 
-  it('returns an all-rounder for a member with no stage', async () => {
-    const members = getContainer('members');
-    await members.items.upsert({ id: 'm-anon', name: 'Anon', active: true });
+  it('returns an all-rounder for a member with no level signal at all', async () => {
+    await getContainer('members').items.upsert({ id: 'm-anon', name: 'Anon', active: true });
     const res = await GET(get('/api/recommend?name=Anon'));
     const body = await res.json();
     expect(res.status).toBe(200);
@@ -29,12 +47,45 @@ describe('GET /api/recommend', () => {
     expect(typeof body.reason).toBe('string');
   });
 
-  it('returns a stage-appropriate racket for a rated member', async () => {
-    const members = getContainer('members');
-    await members.items.upsert({ id: 'm-beg', name: 'Newbie', active: true, stage: 2 });
+  it('still honors a legacy Member.stage when there are no check-ins (back-compat)', async () => {
+    await getContainer('members').items.upsert({ id: 'm-beg', name: 'Newbie', active: true, stage: 2 });
     const res = await GET(get('/api/recommend?name=Newbie'));
     const body = await res.json();
     expect(body.item.id).toBe('beg');
+  });
+
+  it('derives stage from self check-ins even when Member.stage is unset', async () => {
+    // No stage on the member — only an assessment. Proves the rec no longer
+    // depends on the legacy field: a 4.5 self-rating → stage ~5 → the Pro.
+    await getContainer('members').items.upsert({ id: 'm-rated', name: 'Rated', active: true });
+    await seedAssessment('m-rated', 'Rated', 4.5);
+    const res = await GET(get('/api/recommend?name=Rated'));
+    const body = await res.json();
+    expect(body.item.id).toBe('adv');
+  });
+
+  it('lets game calibration lift the recommended stage when the flag is on', async () => {
+    await getContainer('members').items.upsert({ id: 'm-climb', name: 'Climber', active: true });
+    await seedAssessment('m-climb', 'Climber', 2.0); // self-only → stage 2 → the Starter
+    await ensureContainer('gameResults', '/sessionId');
+    const games = getContainer('gameResults');
+    for (let i = 0; i < 12; i++) {
+      await games.items.upsert({
+        id: `g-${i}`, sessionId: 's', teamA: ['Climber'], teamB: ['Punching Bag'],
+        scoreA: 21, scoreB: 5, loggedBy: 'Climber', loggedAt: `2026-06-${String(10 + i).padStart(2, '0')}T00:00:00Z`,
+      });
+    }
+
+    // Flag OFF → self-only stage 2 → Starter.
+    _resetCalibrationCache();
+    const off = await (await GET(get('/api/recommend?name=Climber'))).json();
+    expect(off.item.id).toBe('beg');
+
+    // Flag ON → decisive wins lift the observed level → stage 3 → no longer the Starter.
+    process.env.NEXT_PUBLIC_FLAG_SKILL_CALIBRATION = 'true';
+    _resetCalibrationCache();
+    const on = await (await GET(get('/api/recommend?name=Climber'))).json();
+    expect(on.item.id).not.toBe('beg');
   });
 
   it('404s when the flag is off', async () => {

--- a/app/api/recommend/route.ts
+++ b/app/api/recommend/route.ts
@@ -3,6 +3,7 @@ import { getContainer, ensureContainer } from '@/lib/cosmos';
 import { isFlagOn } from '@/lib/flags';
 import { getClientIp, checkRateLimit } from '@/lib/rateLimit';
 import { recommendRacket } from '@/lib/recommend';
+import { getCanonicalLevel, type LevelSubject } from '@/lib/levelStore';
 import type { CatalogItem } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -16,6 +17,29 @@ function ensureCatalog(): Promise<void> {
     });
   }
   return ready;
+}
+
+/**
+ * Name → subject id, mirroring `resolveSubject` in app/api/stats/level/route.ts:
+ * the members directory is canonical; non-members fall back to a name-derived
+ * key so they still get a level. Queries by @name (the mock store honors @name,
+ * not @memberId).
+ */
+async function resolveSubject(name: string): Promise<LevelSubject> {
+  const trimmed = name.trim();
+  try {
+    const { resources } = await getContainer('members')
+      .items.query({
+        query: 'SELECT * FROM c WHERE LOWER(c.name) = @name',
+        parameters: [{ name: '@name', value: trimmed.toLowerCase() }],
+      })
+      .fetchAll();
+    const member = resources[0] as { id?: string } | undefined;
+    if (member?.id) return { memberId: member.id, name: trimmed };
+  } catch {
+    /* fall through to name-derived id */
+  }
+  return { memberId: `name:${trimmed.toLowerCase()}`, name: trimmed };
 }
 
 function reasonFor(item: CatalogItem, stage?: number): string {
@@ -38,17 +62,16 @@ export async function GET(req: NextRequest) {
     await ensureCatalog();
     const name = new URL(req.url).searchParams.get('name')?.trim().slice(0, 50) ?? '';
 
+    // Stage now rides the canonical skill level (folds self check-ins + game
+    // calibration + Member.stage as fallback) instead of the rarely-set
+    // Member.stage alone. null canonical stage → undefined → all-rounder pick.
+    // We read only `.stage` (a coarse 1–6) and return only {item, reason}, so
+    // nothing from the private CanonicalLevel leaks through this public route.
     let stage: number | undefined;
     if (name) {
-      const members = getContainer('members');
-      const { resources } = await members.items
-        .query({
-          query: 'SELECT c.stage FROM c WHERE LOWER(c.name) = LOWER(@name) AND c.active = true',
-          parameters: [{ name: '@name', value: name }],
-        })
-        .fetchAll();
-      const raw = resources[0]?.stage;
-      stage = typeof raw === 'number' ? raw : undefined;
+      const subject = await resolveSubject(name);
+      const canonical = await getCanonicalLevel(subject);
+      stage = typeof canonical.stage === 'number' ? canonical.stage : undefined;
     }
 
     const catalog = getContainer('equipmentCatalog');


### PR DESCRIPTION
## Summary

**Phase A of the skill-followups plan (#147)** — the gear recommender now rides the accurate **canonical skill level** instead of the rarely-set `Member.stage`.

`app/api/recommend/route.ts` read `Member.stage` directly; almost nobody sets it, so most players got the generic all-rounder. It now calls `getCanonicalLevel(subject).stage`, which folds self check-ins + game calibration with `Member.stage` as a fallback input inside the fold. `null` canonical stage → `undefined` → the existing all-rounder pick (graceful).

- **No new flag** (reuses `VALUE_HUB_SLICE`), **no new container**, **no schema change**.
- **Privacy:** the route reads only `.stage` (a coarse 1–6, derived) and still returns only `{ item, reason }` — nothing from the private `CanonicalLevel` (`basis`/`explanation`/`blindSpot`) is serialized through this public, rate-limited route.
- **Play-style inference deferred** — the catalog has no `playStyle` column and `getCanonicalLevel` returns only the folded scalar (documented as a separate slice in the plan).

## Tests (`__tests__/recommend-route.test.ts`)
- Derives stage from **self check-ins** when `Member.stage` is unset (proves the rewire) → picks the Pro.
- Legacy **`Member.stage` still honored** when there are no check-ins (back-compat).
- **Game calibration** lifts the pick when `SKILL_CALIBRATION` is on (off → Starter, on → not the Starter).
- No signal at all → all-rounder; flag-off → 404.
- Added `resetMockStore()` + `_resetCalibrationCache()` isolation to `beforeEach`.

Full suite **821 passing**, lint clean (0 errors), changed files typecheck clean.

Next in the plan: Phase B (drills), then Phase C (kudos).

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_