### PR TITLE
chore(dev): played-thursday seed + one-command demo for the skill follow-ups

### DIFF
--- a/lib/cosmos.ts
+++ b/lib/cosmos.ts
@@ -83,19 +83,31 @@ function seedDevAdminIfRequested(containerName: string) {
  * Players container stays empty by design — the test scenario starts
  * "no one signed up yet."
  *
+ * Set `SEED_DEV_SCENARIO=played-thursday` for the same fixtures but a session
+ * that JUST happened (3h ago, signup closed) plus a 4-player roster and 3 kudos
+ * received by Lin — so the post-session surfaces (game logger, give-kudos +
+ * received-kudos cards, drills, calibration) all render. Sign in as Lin (2468)
+ * → Stats. See `scripts/dev-demo.sh`.
+ *
  * Plays well with SEED_DEV_ADMIN — they seed different docs and both can
  * be active simultaneously. Refuses when real Cosmos is configured.
  */
 function seedDevScenarioIfRequested(containerName: string) {
   if (g._devScenarioSeeded) return;
   if (process.env.COSMOS_CONNECTION_STRING) return;
-  if (process.env.SEED_DEV_SCENARIO !== 'fresh-thursday') return;
+  const scenario = process.env.SEED_DEV_SCENARIO;
+  if (scenario !== 'fresh-thursday' && scenario !== 'played-thursday') return;
+  // `played-thursday` is a session that JUST happened (3h ago) so the
+  // post-session windows are open — the game logger, the give-kudos card, and
+  // calibration all have live data. `fresh-thursday` is the upcoming (+48h)
+  // signup-open session. Both seed the same members + catalog + Lin check-ins.
+  const played = scenario === 'played-thursday';
   // Only seed once, on first access to any container we care about.
   if (containerName !== 'sessions' && containerName !== 'members') return;
 
   const now = new Date();
-  const sessionDate = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000); // +48h
-  const deadlineDate = new Date(now.getTime() + 24 * 60 * 60 * 1000); // +24h
+  const sessionDate = new Date(now.getTime() + (played ? -3 * 60 * 60 * 1000 : 2 * 24 * 60 * 60 * 1000));
+  const deadlineDate = new Date(now.getTime() + (played ? -27 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000));
   const datetime = sessionDate.toISOString();
   const deadline = deadlineDate.toISOString();
   const sessionId = sessionIdFromDate(datetime);
@@ -113,7 +125,7 @@ function seedDevScenarioIfRequested(containerName: string) {
       courts: 2,
       costPerCourt: 60,
       maxPlayers: 12,
-      signupOpen: true,
+      signupOpen: !played,
       locationVenue: "Wing's Badminton",
       locationAddress: '11820 Horseshoe Way, Richmond',
       showCostBreakdown: true,
@@ -224,11 +236,49 @@ function seedDevScenarioIfRequested(containerName: string) {
     );
   }
 
+  // played-thursday extras: a roster (so the post-session logger sees Lin as
+  // "attended") and a few kudos received by Lin (so the "Kudos you've received"
+  // card renders). The give-kudos card derives its co-players from the seeded
+  // game above, which now sits in the just-passed active session.
+  if (played) {
+    mockStore.players ??= [];
+    for (const name of ['Lin', 'Viktor', 'Carolina', 'Akane']) {
+      const dup = mockStore.players.find(
+        (p) => (p as { sessionId?: string }).sessionId === sessionId && (p as { name?: string }).name === name,
+      );
+      if (!dup) {
+        mockStore.players.push({
+          id: `dev-player-${name.toLowerCase()}`,
+          sessionId,
+          name,
+          removed: false,
+          signedUpAt: now.toISOString(),
+        });
+      }
+    }
+    mockStore.kudos ??= [];
+    if (mockStore.kudos.length === 0) {
+      const mkKudos = (raterName: string, tag: string) => ({
+        id: randomBytes(16).toString('hex'),
+        recipientMemberId: 'dev-member-lin',
+        recipientName: 'Lin',
+        raterMemberId: `dev-member-${raterName.toLowerCase()}`,
+        raterName,
+        sessionId,
+        tag,
+        createdAt: now.toISOString(),
+      });
+      mockStore.kudos.push(mkKudos('Viktor', 'clutch'), mkKudos('Carolina', 'great_defense'), mkKudos('Akane', 'clutch'));
+    }
+  }
+
   g._devScenarioSeeded = true;
   console.warn(
-    `[dev] SEED_DEV_SCENARIO=fresh-thursday: seeded session ${sessionId} (signupOpen, 0/12, deadline ${deadline.slice(0, 10)}) ` +
+    `[dev] SEED_DEV_SCENARIO=${scenario}: seeded session ${sessionId} ` +
+      `(${played ? 'just played (3h ago), signup closed' : 'signupOpen'}, deadline ${deadline.slice(0, 10)}) ` +
       `+ 6 famous-player invite-list members (Lin has PIN 2468, others have no PIN) ` +
-      `+ ${equipmentCatalogSeed.items.length}-racket catalog + 1 sample game + 2 skill-assessment snapshots for Lin. Mock store only.`,
+      `+ ${equipmentCatalogSeed.items.length}-racket catalog + 1 sample game + 2 skill-assessment snapshots for Lin` +
+      `${played ? ' + 4-player roster + 3 kudos received by Lin' : ''}. Mock store only.`,
   );
 }
 

--- a/scripts/dev-demo.sh
+++ b/scripts/dev-demo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# One-command local demo of the three skill follow-ups (gear, drills, kudos).
+#
+# Boots the offline mock store (no Cosmos) with a "just played" session so the
+# post-session surfaces render, every feature flag on, and an admin seeded.
+#
+#   bash scripts/dev-demo.sh            # drills + kudos (give + received) + level
+#   GEAR=1 bash scripts/dev-demo.sh     # the gear recommendation card
+#   PORT=3105 bash scripts/dev-demo.sh  # use a different port
+#
+# Then open http://localhost:<PORT>/bpm, go to Profile, and sign in as
+# Lin / 2468. Everything is private, so you MUST sign in to see the cards.
+#
+# Why two modes: the gear card is parked whenever the skill-assessment spine is
+# on (deliberate). GEAR=1 flips the spine off so the gear card shows; the
+# default leaves it on so the drills/kudos/level cards show.
+set -euo pipefail
+
+PORT="${PORT:-3100}"
+
+# The gear card only renders with the assessment spine OFF; everything else
+# needs it ON. Default = spine on (drills/kudos/level); GEAR=1 = spine off (gear).
+if [[ "${GEAR:-}" == "1" ]]; then
+  ASSESS=false
+  echo "▶ GEAR mode: assessment spine OFF — the gear recommendation card will show."
+else
+  ASSESS=true
+  echo "▶ Default mode: drills + kudos (give & received) + level will show."
+  echo "  (run with GEAR=1 to see the gear card instead.)"
+fi
+
+echo "▶ http://localhost:${PORT}/bpm  →  Profile → sign in as Lin / 2468 → Stats"
+echo ""
+
+NEXT_PUBLIC_BASE_PATH=/bpm \
+COSMOS_CONNECTION_STRING= \
+SEED_DEV_SCENARIO=played-thursday \
+SEED_DEV_ADMIN=Grant:1130 \
+SESSION_SECRET="${SESSION_SECRET:-dev-demo-session-secret-not-for-production-32}" \
+NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE=true \
+NEXT_PUBLIC_FLAG_SKILL_ASSESS="${ASSESS}" \
+NEXT_PUBLIC_FLAG_SKILL_LEVEL=true \
+NEXT_PUBLIC_FLAG_SKILL_CALIBRATION=true \
+NEXT_PUBLIC_FLAG_SKILL_SMOOTHING=true \
+NEXT_PUBLIC_FLAG_SKILL_DRILLS=true \
+NEXT_PUBLIC_FLAG_KUDOS=true \
+  npm run dev -- --port "${PORT}"


### PR DESCRIPTION
## Summary

Adds a one-command local demo so the three skill follow-ups (gear, drills, kudos) can be exercised in a browser — addressing the "I can't see them anywhere" friction (they're private + the kudos/logger cards are post-session-window-gated).

- **`SEED_DEV_SCENARIO=played-thursday`** (new, in `lib/cosmos.ts`) — same fixtures as `fresh-thursday` (6 famous members, **Lin / PIN 2468**, racket catalog, Lin's 2 check-ins, a sample game) but the session is dated **3h ago** (signup closed) so the **post-session windows are open**, plus a **4-player roster** and **3 kudos received by Lin**. Mock-store only; refuses when `COSMOS_CONNECTION_STRING` is set (same guard as `fresh-thursday`).
- **`scripts/dev-demo.sh`** — boots the mock store with every flag on:
  ```bash
  bash scripts/dev-demo.sh          # Level + Drills + Kudos (give & received)
  GEAR=1 bash scripts/dev-demo.sh   # the gear recommendation card
  ```
  Then open `http://localhost:3100/bpm` → Profile → sign in as **Lin / 2468** → Stats.

The two modes exist because the **gear card is parked whenever the assessment spine is on** (deliberate) — `GEAR=1` flips the spine off so the gear card renders; the default leaves it on for the drills/kudos/level cards.

## Verified live
Signed in as Lin against this seed: **level 3.1 (switch, high confidence)**, **3 drills**, **kudos received (clutch ×2, great_defense ×1)**, **gear pick (Li-Ning 3D Calibar 900)**, give-kudos co-players Viktor/Carolina/Akane.

Full suite **861 passing**, lint clean, `lib/cosmos.ts` typechecks clean. Dev-tooling only — no app behavior change, no schema change.

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_