### PR TITLE
feat(stats): distributed AI insights — non-obvious, signal-grounded

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -51,6 +51,7 @@ jobs:
           NEXT_PUBLIC_FLAG_SKILL_SMOOTHING: 'true'
           NEXT_PUBLIC_FLAG_SKILL_DRILLS: 'true'
           NEXT_PUBLIC_FLAG_KUDOS: 'true'
+          NEXT_PUBLIC_FLAG_INSIGHT_CARDS: 'true'
 
       - name: Package standalone build
         run: |

--- a/__tests__/flags.test.ts
+++ b/__tests__/flags.test.ts
@@ -76,6 +76,15 @@ describe('feature flags', () => {
     process.env.NEXT_PUBLIC_FLAG_SKILL_ASSESS = '1';
     expect(isFlagOn('NEXT_PUBLIC_FLAG_SKILL_ASSESS')).toBe(false);
   });
+
+  it('recognizes NEXT_PUBLIC_FLAG_INSIGHT_CARDS', () => {
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS')).toBe(false);
+    process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS = 'true';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS')).toBe(true);
+    process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS = '1';
+    expect(isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS')).toBe(false);
+    delete process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS;
+  });
 });
 
 describe('environment detection', () => {

--- a/__tests__/insightSignals.test.ts
+++ b/__tests__/insightSignals.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { computeInsightSignals, signalsByCard } from '../lib/insightSignals';
+import type { StoredAssessment, Rating } from '../lib/assessment';
+
+/** Build a snapshot. `lows` are skillKeys forced to the lowest value so they
+ *  land in the bottom-3; everything else sits comfortably mid. */
+function mkSnap(takenAt: string, overall: number, lows: string[] = []): StoredAssessment {
+  const ratings: Rating[] = [
+    { skillKey: 'smashes', value: 4 },
+    { skillKey: 'clears_lifts', value: 4 },
+    { skillKey: 'drives', value: 3 },
+    { skillKey: 'serves_returns', value: 3 },
+    { skillKey: 'consistency', value: 3 },
+    { skillKey: 'footwork_split_step', value: 3 },
+  ];
+  for (const key of lows) {
+    const r = ratings.find((x) => x.skillKey === key);
+    if (r) r.value = 1;
+    else ratings.push({ skillKey: key, value: 1 });
+  }
+  return { takenAt, ratings, overall, phase: null };
+}
+
+const NOW = '2026-06-17T00:00:00.000Z';
+
+describe('computeInsightSignals — the non-obvious bar', () => {
+  it('stays SILENT on a single flat mid-band check-in (nothing non-obvious to say)', () => {
+    // overall 2.7 sits mid-switch; next band (commitment 3.4) is 0.7 away (> 0.6),
+    // so phase-gating does not fire. One snapshot → no trend/streak signals.
+    const signals = computeInsightSignals({ snapshots: [mkSnap('2026-01-01', 2.7)], now: NOW });
+    expect(signals).toEqual([]);
+  });
+
+  it('returns empty for no snapshots', () => {
+    expect(computeInsightSignals({ snapshots: [], now: NOW })).toEqual([]);
+  });
+
+  it('fires phase-gating when the next phase is close, naming the lever', () => {
+    const signals = computeInsightSignals({ snapshots: [mkSnap('2026-05-01', 3.2, ['net_play'])], now: NOW });
+    const gating = signals.find((s) => s.kind === 'phase-gating');
+    expect(gating).toBeDefined();
+    expect(gating!.card).toBe('level');
+    expect(gating!.facts.nextPhase).toBe('commitment');
+    expect(gating!.facts.gap).toBeCloseTo(0.2, 5);
+    expect(gating!.facts.weakest).toBe('Net Play');
+  });
+
+  it('fires sticky-weak when a skill stays in the bottom across check-ins', () => {
+    const signals = computeInsightSignals({
+      snapshots: [
+        mkSnap('2026-03-01', 2.6, ['net_play']),
+        mkSnap('2026-04-01', 2.7, ['net_play']),
+      ],
+      now: NOW,
+    });
+    const sticky = signals.find((s) => s.kind === 'sticky-weak');
+    expect(sticky).toBeDefined();
+    expect(sticky!.card).toBe('trend');
+    expect(sticky!.facts.skill).toBe('Net Play');
+    expect(Number(sticky!.facts.count)).toBeGreaterThanOrEqual(2);
+  });
+
+  it('fires an improving-streak across 3+ rising check-ins (greeting)', () => {
+    const signals = computeInsightSignals({
+      snapshots: [
+        mkSnap('2026-02-01', 2.0),
+        mkSnap('2026-03-01', 2.3),
+        mkSnap('2026-04-01', 2.6),
+        mkSnap('2026-05-01', 2.9),
+      ],
+      now: NOW,
+    });
+    const streak = signals.find((s) => s.kind === 'improving-streak');
+    expect(streak).toBeDefined();
+    expect(streak!.card).toBe('greeting');
+    expect(streak!.facts.sessions).toBe(3);
+    expect(streak!.facts.totalChange).toBeCloseTo(0.9, 5);
+  });
+
+  it('fires a declining-streak across 3+ falling check-ins, framed for a re-rate', () => {
+    const signals = computeInsightSignals({
+      snapshots: [
+        mkSnap('2026-02-01', 3.2),
+        mkSnap('2026-03-01', 2.9),
+        mkSnap('2026-04-01', 2.6),
+        mkSnap('2026-05-01', 2.3),
+      ],
+      now: NOW,
+    });
+    expect(signals.find((s) => s.kind === 'declining-streak')).toBeDefined();
+  });
+
+  it('fires a blind-spot from game calibration and is the dominant level signal', () => {
+    const canonicalLevel = {
+      level: 3.3, stage: 4, phase: 'commitment' as const, confidence: 'high' as const,
+      basis: { self: 3.0, game: 3.8, peer: null, legacyStage: null },
+      explanation: [], computedAt: NOW,
+    };
+    const signals = computeInsightSignals({ snapshots: [mkSnap('2026-05-01', 3.0)], canonicalLevel, now: NOW });
+    const blind = signals.find((s) => s.kind === 'blindspot');
+    expect(blind).toBeDefined();
+    expect(blind!.facts.direction).toBe('above');
+    expect(blind!.facts.delta).toBeCloseTo(0.8, 5);
+    // Higher-scoring than the phase-gating that also fires at 3.0 → wins the slot.
+    expect(signalsByCard(signals).level!.kind).toBe('blindspot');
+  });
+
+  it('does not fire a blind-spot for a small self-vs-game gap', () => {
+    const canonicalLevel = {
+      level: 3.0, stage: 4, phase: 'commitment' as const, confidence: 'high' as const,
+      basis: { self: 3.0, game: 3.2, peer: null, legacyStage: null },
+      explanation: [], computedAt: NOW,
+    };
+    const signals = computeInsightSignals({ snapshots: [mkSnap('2026-05-01', 3.0)], canonicalLevel, now: NOW });
+    expect(signals.find((s) => s.kind === 'blindspot')).toBeUndefined();
+  });
+
+  it('signalsByCard picks the highest-scoring signal per card', () => {
+    const signals = computeInsightSignals({
+      snapshots: [
+        mkSnap('2026-03-01', 2.6, ['net_play']),
+        mkSnap('2026-04-01', 2.7, ['net_play']),
+      ],
+      now: NOW,
+    });
+    const byCard = signalsByCard(signals);
+    expect(byCard.trend?.kind).toBe('sticky-weak');
+  });
+});

--- a/__tests__/stats-insight-cards.test.ts
+++ b/__tests__/stats-insight-cards.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { resetMockStore, getStore, seedMember, seedPointer, makeGetRequest } from './helpers';
+
+// Mock the Anthropic SDK so the route's single generate() call is deterministic.
+// `vi.hoisted` makes the spy available inside the hoisted vi.mock factory.
+const { mockCreate } = vi.hoisted(() => ({ mockCreate: vi.fn() }));
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    messages = { create: mockCreate };
+  },
+}));
+
+import { GET } from '../app/api/stats/insight/route';
+
+const BASE = 'http://localhost:3000/api/stats/insight';
+
+function textResponse(obj: unknown) {
+  return { content: [{ type: 'text', text: JSON.stringify(obj) }] };
+}
+
+function seedAssessment(memberId: string, takenAt: string, overall: number, lows: string[] = []) {
+  const store = getStore();
+  if (!store['assessments']) store['assessments'] = [];
+  const ratings = [
+    { skillKey: 'smashes', value: 4 },
+    { skillKey: 'clears_lifts', value: 4 },
+    { skillKey: 'drives', value: 3 },
+    { skillKey: 'consistency', value: 3 },
+    ...lows.map((skillKey) => ({ skillKey, value: 1 })),
+  ];
+  store['assessments'].push({ id: `a-${Math.random().toString(36).slice(2)}`, memberId, takenAt, ratings, overall, phase: null });
+}
+
+describe('/api/stats/insight — distributed insight cards', () => {
+  beforeEach(() => {
+    resetMockStore();
+    mockCreate.mockReset();
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+    process.env.NEXT_PUBLIC_FLAG_SKILL_ASSESS = 'true';
+    process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS = 'true';
+    seedPointer('session-2026-06-17');
+  });
+  afterAll(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.NEXT_PUBLIC_FLAG_SKILL_ASSESS;
+    delete process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS;
+  });
+
+  it('returns structured slices with server-set kinds when the flag is on', async () => {
+    const m = seedMember('Lin');
+    // overall 3.2 → phase-gating (level signal); net_play sticky → trend signal.
+    seedAssessment(m.id, '2026-04-01', 3.1, ['net_play']);
+    seedAssessment(m.id, '2026-05-01', 3.2, ['net_play']);
+    mockCreate.mockResolvedValue(
+      textResponse({
+        greeting: 'Quietly leveling up — nice work.',
+        level: { headline: 'A nudge from the next phase', support: 'Your weakest areas are the lever.' },
+        trend: { headline: 'Net play keeps lagging', support: 'It has trailed for two check-ins.' },
+      }),
+    );
+
+    const res = await GET(makeGetRequest(`${BASE}?name=Lin`));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.account).toBe(true);
+    expect(json.greeting).toBe('Quietly leveling up — nice work.');
+    expect(json.level.headline).toBe('A nudge from the next phase');
+    expect(json.level.kind).toBe('phase-gating'); // attached server-side, not from the model
+    expect(json.trend.kind).toBe('sticky-weak');
+    // Legacy shape absent on the cards path.
+    expect(json.recap).toBeUndefined();
+  });
+
+  it('forces a card slice to null when no signal backs it (silence > obvious)', async () => {
+    const m = seedMember('Akane');
+    // Single flat mid-band check-in → no signals at all.
+    seedAssessment(m.id, '2026-05-01', 2.7);
+    // The model hallucinates a level insight anyway; the route must drop it.
+    mockCreate.mockResolvedValue(
+      textResponse({
+        greeting: 'Good to see you back.',
+        level: { headline: 'You are crushing it', support: 'made up' },
+        trend: { headline: 'fabricated', support: 'nope' },
+      }),
+    );
+
+    const res = await GET(makeGetRequest(`${BASE}?name=Akane`));
+    const json = await res.json();
+    expect(json.greeting).toBe('Good to see you back.');
+    expect(json.level).toBeNull();
+    expect(json.trend).toBeNull();
+  });
+
+  it('caches: a second call is served from cache without re-generating', async () => {
+    const m = seedMember('Viktor');
+    seedAssessment(m.id, '2026-05-01', 3.2, ['net_play']);
+    mockCreate.mockResolvedValue(textResponse({ greeting: 'Hi Viktor.', level: null, trend: null }));
+
+    const first = await GET(makeGetRequest(`${BASE}?name=Viktor`));
+    expect((await first.json()).cached).toBe(false);
+    const second = await GET(makeGetRequest(`${BASE}?name=Viktor`));
+    const secondJson = await second.json();
+    expect(secondJson.cached).toBe(true);
+    expect(secondJson.greeting).toBe('Hi Viktor.');
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('regenerates when the flag flips off (cached cards doc lacks recap)', async () => {
+    const m = seedMember('Kento');
+    seedAssessment(m.id, '2026-05-01', 3.2, ['net_play']);
+    mockCreate.mockResolvedValue(textResponse({ greeting: 'Hi Kento.', level: null, trend: null }));
+    await GET(makeGetRequest(`${BASE}?name=Kento`)); // caches a cards-shaped doc
+
+    process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS = 'false';
+    mockCreate.mockResolvedValue(textResponse({ recap: 'Last week was solid.', focus: 'Work on net play.' }));
+    const res = await GET(makeGetRequest(`${BASE}?name=Kento`));
+    const json = await res.json();
+    expect(json.recap).toBe('Last week was solid.');
+    expect(json.focus).toBe('Work on net play.');
+    expect(json.greeting).toBeUndefined();
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('gates on account: an unknown name gets no insight and never calls the model', async () => {
+    const res = await GET(makeGetRequest(`${BASE}?name=Stranger`));
+    const json = await res.json();
+    expect(json.account).toBe(false);
+    expect(json.greeting).toBeNull();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/stats/insight/route.ts
+++ b/app/api/stats/insight/route.ts
@@ -8,6 +8,7 @@ import { summarizeAssessmentTrend, type AssessmentTrend, type StoredAssessment }
 import { getCanonicalLevel } from '@/lib/levelStore';
 import type { CanonicalLevel } from '@/lib/level';
 import { recommendDrills, type DrillPick } from '@/lib/drills';
+import { computeInsightSignals, signalsByCard, type InsightSignal, type SignalCard } from '@/lib/insightSignals';
 
 /**
  * Account-gated, passively-generated player insight. Replaces the old
@@ -39,6 +40,8 @@ export const dynamic = 'force-dynamic';
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 const MODEL = 'claude-sonnet-4-6';
 const MAX_OUTPUT_TOKENS = 400;
+// Structured card insights are several short fields rather than one blob.
+const MAX_OUTPUT_TOKENS_CARDS = 600;
 const ATTENDANCE_WEEKS = 52;
 
 // Lazy bootstrap — real Cosmos doesn't auto-create containers. PK /memberId
@@ -54,13 +57,28 @@ function ensureInsightsContainer(): Promise<void> {
   return insightsReady;
 }
 
+/** One distributed-insight slice: a styled chip's content. `kind` is set
+ *  server-side from the driving signal (drives the chip icon), never trusted
+ *  from the model. */
+interface CardInsight {
+  headline: string;
+  support?: string;
+  kind: string;
+}
+
 interface InsightDoc {
   id: string;
   memberId: string;
   name: string;
   sessionId: string;
-  recap: string;
-  focus: string;
+  /** Legacy "Your read" shape (flag off). Optional now — structured docs omit it. */
+  recap?: string;
+  focus?: string;
+  /** Distributed-insight shape (NEXT_PUBLIC_FLAG_INSIGHT_CARDS on). Additive —
+   *  legacy recap/focus docs simply lack these and regenerate once on a flag flip. */
+  greeting?: string | null;
+  level?: CardInsight | null;
+  trend?: CardInsight | null;
   generatedAt: string;
   /** `takenAt` of the latest self-assessment baked into this insight. Lets a
    *  fresh check-in invalidate the session cache so the read reflects it.
@@ -69,7 +87,7 @@ interface InsightDoc {
 }
 
 function emptyPayload(account: boolean) {
-  return NextResponse.json({ account, recap: null, focus: null, generatedAt: null });
+  return NextResponse.json({ account, recap: null, focus: null, greeting: null, level: null, trend: null, generatedAt: null });
 }
 
 /**
@@ -79,23 +97,22 @@ function emptyPayload(account: boolean) {
  * store ignores `@memberId` (same reason the assessments GET does). Failures are
  * non-fatal — the insight still generates from attendance/games alone.
  */
-async function fetchAssessmentTrend(memberId: string): Promise<AssessmentTrend | null> {
-  if (!isFlagOn('NEXT_PUBLIC_FLAG_SKILL_ASSESS')) return null;
+async function fetchAssessmentDocs(memberId: string): Promise<StoredAssessment[]> {
+  if (!isFlagOn('NEXT_PUBLIC_FLAG_SKILL_ASSESS')) return [];
   try {
     await ensureContainer('assessments', '/memberId');
     const { resources } = await getContainer('assessments').items
       .query({
-        query: 'SELECT c.memberId, c.takenAt, c.ratings, c.overall, c.phase FROM c WHERE c.memberId = @memberId',
+        query: 'SELECT c.memberId, c.takenAt, c.ratings, c.overall, c.phase, c.dimensionScores FROM c WHERE c.memberId = @memberId',
         parameters: [{ name: '@memberId', value: memberId }],
       })
       .fetchAll();
-    const docs = (resources as (StoredAssessment & { memberId?: string })[]).filter(
+    return (resources as (StoredAssessment & { memberId?: string })[]).filter(
       (d) => d && d.memberId === memberId && typeof d.takenAt === 'string',
     );
-    return summarizeAssessmentTrend(docs);
   } catch (err) {
     console.error('insight assessment read failed:', err);
-    return null;
+    return [];
   }
 }
 
@@ -138,9 +155,13 @@ export async function GET(req: NextRequest) {
 
   const activeSessionId = await getActiveSessionId();
 
+  const cardsOn = isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS');
+
   // ── Latest self-assessment (flag-gated). Fetched before the cache check so a
-  //    fresh check-in invalidates the session-cached read. ──
-  const trend = await fetchAssessmentTrend(member.id);
+  //    fresh check-in invalidates the session-cached read. Raw docs are kept so
+  //    the signal engine can fold the full history (sticky-weak, streaks). ──
+  const assessmentDocs = await fetchAssessmentDocs(member.id);
+  const trend = summarizeAssessmentTrend(assessmentDocs);
   const latestAssessmentAt = trend?.latestAt ?? null;
 
   // Canonical level (flag-gated). Same memberId-resolve as the trend; folds the
@@ -165,19 +186,22 @@ export async function GET(req: NextRequest) {
   // Nullish-normalize both sides: a pre-assessment cached doc (undefined) with a
   // new assessment present (a string) mismatches → regenerate to fold it in.
   const assessmentMatches = (existing?.lastAssessmentAt ?? null) === latestAssessmentAt;
-  if (existing && existing.sessionId === activeSessionId && existing.recap && assessmentMatches) {
-    return NextResponse.json({
-      account: true,
-      recap: existing.recap,
-      focus: existing.focus,
-      generatedAt: existing.generatedAt,
-      cached: true,
-    });
+  const cacheFresh = !!existing && existing.sessionId === activeSessionId && assessmentMatches;
+  // The cache is keyed by the shape the current flag wants: a flag flip leaves a
+  // doc with the wrong field set, which misses here and regenerates once.
+  if (cacheFresh && cardsOn && existing!.greeting) {
+    return NextResponse.json({ account: true, greeting: existing!.greeting, level: existing!.level ?? null, trend: existing!.trend ?? null, generatedAt: existing!.generatedAt, cached: true });
+  }
+  if (cacheFresh && !cardsOn && existing!.recap) {
+    return NextResponse.json({ account: true, recap: existing!.recap, focus: existing!.focus, generatedAt: existing!.generatedAt, cached: true });
   }
 
   if (!process.env.ANTHROPIC_API_KEY) {
-    // No key — serve any stale insight rather than nothing, but don't generate.
-    if (existing?.recap) {
+    // No key — serve any stale insight of the right shape rather than nothing.
+    if (cardsOn && existing?.greeting) {
+      return NextResponse.json({ account: true, greeting: existing.greeting, level: existing.level ?? null, trend: existing.trend ?? null, generatedAt: existing.generatedAt, stale: true });
+    }
+    if (!cardsOn && existing?.recap) {
       return NextResponse.json({ account: true, recap: existing.recap, focus: existing.focus, generatedAt: existing.generatedAt, stale: true });
     }
     return emptyPayload(true);
@@ -191,7 +215,32 @@ export async function GET(req: NextRequest) {
   // ── Gather the data snapshot (deterministic — fed verbatim to Claude). ──
   const snapshot = await buildSnapshot({ name: member.name, playersContainer, sessionsContainer, trend, canonicalLevel, drills });
 
-  // ── Generate (memory = previous recap+focus). ──
+  // ── Distributed insights (flag on): structured, signal-grounded slices. ──
+  if (cardsOn) {
+    const signals = signalsByCard(computeInsightSignals({ snapshots: assessmentDocs, canonicalLevel, now: new Date().toISOString() }));
+    let cards: { greeting: string | null; level: CardInsight | null; trend: CardInsight | null };
+    try {
+      cards = await generateCards(member.name, snapshot, signals, existing);
+    } catch (err) {
+      console.error('insight cards generation failed:', err);
+      if (existing?.greeting) {
+        return NextResponse.json({ account: true, greeting: existing.greeting, level: existing.level ?? null, trend: existing.trend ?? null, generatedAt: existing.generatedAt, stale: true });
+      }
+      return emptyPayload(true);
+    }
+    if (!cards.greeting && !cards.level && !cards.trend) return emptyPayload(true);
+
+    const generatedAt = new Date().toISOString();
+    const doc: InsightDoc = { id: member.id, memberId: member.id, name: member.name, sessionId: activeSessionId, greeting: cards.greeting, level: cards.level, trend: cards.trend, generatedAt, lastAssessmentAt: latestAssessmentAt };
+    try {
+      await insightsContainer.items.upsert(doc);
+    } catch (err) {
+      console.warn('insight cache write failed (non-fatal):', err);
+    }
+    return NextResponse.json({ account: true, greeting: cards.greeting, level: cards.level, trend: cards.trend, generatedAt, cached: false });
+  }
+
+  // ── Legacy "Your read" (flag off): recap + focus blob. ──
   let recap = '';
   let focus = '';
   try {
@@ -442,6 +491,102 @@ function buildSkillLine(s: Snapshot): string {
     return `Self-rated skills (0-6): ${Object.entries(s.skills).map(([k, v]) => `${k} ${v}`).join(', ')}.`;
   }
   return '';
+}
+
+/**
+ * Distributed-insight generation: a plain-language greeting + a short,
+ * NON-OBVIOUS chip per card, grounded in the pre-computed signals. The model
+ * only narrates the signals into plain words — it never selects them and never
+ * invents a pattern. `kind` is attached server-side from the signal (drives the
+ * chip icon), and any card without a signal is forced null (silence > obvious).
+ */
+async function generateCards(
+  name: string,
+  s: Snapshot,
+  signals: Record<SignalCard, InsightSignal | null>,
+  prev: InsightDoc | null,
+): Promise<{ greeting: string | null; level: CardInsight | null; trend: CardInsight | null }> {
+  const lastLine = s.lastSession
+    ? `Last completed session (${s.lastSession.date.slice(0, 10)}): ${name} ${s.lastSession.attended ? 'PLAYED' : 'did NOT play'}.`
+    : 'No completed sessions on record yet.';
+  const partnerLine = s.regularPartners.length
+    ? `Regular partners: ${s.regularPartners.map((p) => `${p.name} (${p.count})`).join(', ')}.`
+    : 'No regular partners yet.';
+  const skillLine = buildSkillLine(s);
+
+  const cards: SignalCard[] = ['greeting', 'level', 'trend'];
+  const signalBlock = cards
+    .map((card) => {
+      const sig = signals[card];
+      return sig
+        ? `- ${card}: [${sig.kind}] ${sig.hint} (grounded facts: ${JSON.stringify(sig.facts)})`
+        : `- ${card}: (no non-obvious signal — return null for this slot)`;
+    })
+    .join('\n');
+  const memoryLine = prev?.greeting ? `\n\nYour previous greeting to ${name}: "${prev.greeting}"` : '';
+
+  const prompt = `You are a warm, plain-spoken badminton companion writing short, scannable insights for ${name}, a casual weekly player. Use ONLY the facts below — never invent numbers, names, events, or patterns.
+
+DATA
+${lastLine}
+Season (last ${s.totalSessions} sessions): attended ${s.attended} (${s.attendanceRate}%), current streak ${s.currentStreak}, longest ${s.longestStreak}.
+${partnerLine}${skillLine ? `\n${skillLine}` : ''}
+
+NON-OBVIOUS SIGNALS (pre-computed — narrate the ones present; do not restate plain numbers):
+${signalBlock}${memoryLine}
+
+The whole point is value BEYOND the obvious: ${name} can already SEE their level number, phase, and skill ratings on the cards. NEVER restate those. Surface the relationship/pattern in the signals instead, in plain words.
+
+Return ONLY a JSON object, no markdown fences:
+{"greeting": "...", "level": {"headline": "...", "support": "..."} | null, "trend": {"headline": "...", "support": "..."} | null}
+- "greeting": ONE warm, plain-language sentence (max ~16 words) leading with the most interesting honest thing. Translate jargon (never "3.1 / switch / medium confidence"). If nothing is beyond the obvious, a brief encouraging line is fine.
+- "level" / "trend": ONLY if that signal is present above — "headline" ≤ 8 words (the punch), "support" ≤ 14 words (one grounding clause). If the slot says "return null", return null for it.
+- Plain, encouraging, specific. No emoji, no hashtags, no jargon. Do NOT repeat a raw rating number the card already shows.`;
+
+  const message = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: MAX_OUTPUT_TOKENS_CARDS,
+    messages: [{ role: 'user', content: prompt }],
+  });
+  const text = message.content[0]?.type === 'text' ? message.content[0].text.trim() : '';
+  const parsed = parseCards(text);
+
+  return {
+    greeting: parsed.greeting,
+    level: signals.level && parsed.level ? { ...parsed.level, kind: signals.level.kind } : null,
+    trend: signals.trend && parsed.trend ? { ...parsed.trend, kind: signals.trend.kind } : null,
+  };
+}
+
+/** Tolerant parse of the structured card payload. Each card slice is nullable
+ *  and requires a non-empty headline; support is optional. */
+function parseCards(text: string): {
+  greeting: string | null;
+  level: { headline: string; support?: string } | null;
+  trend: { headline: string; support?: string } | null;
+} {
+  const cleaned = text.replace(/```json/gi, '').replace(/```/g, '').trim();
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  const slice = start >= 0 && end > start ? cleaned.slice(start, end + 1) : cleaned;
+  const coerceCard = (v: unknown): { headline: string; support?: string } | null => {
+    if (!v || typeof v !== 'object') return null;
+    const o = v as { headline?: unknown; support?: unknown };
+    const headline = typeof o.headline === 'string' ? o.headline.trim() : '';
+    if (!headline) return null;
+    const support = typeof o.support === 'string' && o.support.trim() ? o.support.trim() : undefined;
+    return support ? { headline, support } : { headline };
+  };
+  try {
+    const obj = JSON.parse(slice) as { greeting?: unknown; level?: unknown; trend?: unknown };
+    return {
+      greeting: typeof obj.greeting === 'string' && obj.greeting.trim() ? obj.greeting.trim() : null,
+      level: coerceCard(obj.level),
+      trend: coerceCard(obj.trend),
+    };
+  } catch {
+    return { greeting: null, level: null, trend: null };
+  }
 }
 
 /** Tolerant JSON extraction — strips code fences, pulls the first {...} block. */

--- a/components/SkillsTab.tsx
+++ b/components/SkillsTab.tsx
@@ -8,6 +8,7 @@ import ShuttleLoader from '@/components/ShuttleLoader';
 import StatsPlaceholder from '@/components/stats/StatsPlaceholder';
 import AttendanceCardLive from '@/components/stats/cards/AttendanceCardLive';
 import StreakSummaryCard from '@/components/stats/StreakSummaryCard';
+import SummaryGreeting from '@/components/stats/SummaryGreeting';
 import PartnerFrequencyCard from '@/components/stats/cards/PartnerFrequencyCard';
 import GameLoggerCard from '@/components/stats/GameLoggerCard';
 import RacketRow from '@/components/stats/RacketRow';
@@ -163,8 +164,13 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
   const drillsOn = isFlagOn('NEXT_PUBLIC_FLAG_SKILL_DRILLS');
   // Kudos — positive-only peer recognition (received read here; give in the play slot).
   const kudosOn = isFlagOn('NEXT_PUBLIC_FLAG_KUDOS');
+  // Distributed AI insights: a plain-language greeting leads the Summary and the
+  // standalone "Your read" card is retired (its synthesis moves into the greeting
+  // + per-card chips; the streak still shows on AttendanceCardLive in Game stats).
+  const insightCardsOn = isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS');
   const heroSlot = skillAssessOn ? (
     <>
+      {insightCardsOn && <SummaryGreeting />}
       {levelOn && <LevelCard />}
       <SkillTrendCard />
       {drillsOn && <DrillsCard />}
@@ -207,7 +213,7 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
         heroSlot={heroSlot}
         gamePlaySlot={gamePlaySlot}
         attendanceContent={attendanceContent}
-        insightSlot={<StreakSummaryCard />}
+        insightSlot={insightCardsOn ? undefined : <StreakSummaryCard />}
       />
     );
   }

--- a/components/stats/InsightChip.tsx
+++ b/components/stats/InsightChip.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { CardSlice } from '@/lib/useInsight';
+
+/**
+ * A compact, styled AI-insight element attached to a Stats card — NOT a plain
+ * text line. A `kind`-driven icon + a bold headline + an optional muted support
+ * clause, on a subtle tinted surface. Short by construction (the API caps the
+ * text length). Renders only when its card slice is present; the parent card's
+ * core content always stands on its own.
+ *
+ * `kind` maps to a glyph already in the Material Symbols subset (app/layout.tsx)
+ * — never introduce a kind whose icon isn't in that list or it renders as raw
+ * text. Falls back to the generic AI glyph.
+ */
+
+const ICON_BY_KIND: Record<string, string> = {
+  blindspot: 'visibility',
+  'phase-gating': 'bolt',
+  'sticky-weak': 'school',
+};
+
+const ACCENT = 'var(--accent, #22c55e)';
+
+export default function InsightChip({ headline, support, kind }: CardSlice) {
+  const icon = ICON_BY_KIND[kind] ?? 'auto_fix_high';
+  return (
+    <div
+      className="animate-fadeIn"
+      style={{
+        display: 'flex',
+        gap: 10,
+        alignItems: 'flex-start',
+        padding: '10px 12px',
+        borderRadius: 12,
+        background: 'var(--inner-card-bg)',
+        border: '1px solid var(--inner-card-border)',
+      }}
+    >
+      <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: ACCENT, marginTop: 1, flexShrink: 0 }}>
+        {icon}
+      </span>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <p style={{ margin: 0, fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1.35 }}>{headline}</p>
+        {support && <p style={{ margin: '2px 0 0', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.4 }}>{support}</p>}
+      </div>
+      <span
+        aria-label="AI generated"
+        title="AI generated"
+        style={{
+          fontSize: 9,
+          padding: '2px 6px',
+          borderRadius: 100,
+          whiteSpace: 'nowrap',
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+          border: `1px solid ${ACCENT}`,
+          color: ACCENT,
+          flexShrink: 0,
+        }}
+      >
+        AI
+      </span>
+    </div>
+  );
+}

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { getIdentity } from '@/lib/identity';
 import type { CanonicalLevel } from '@/lib/level';
+import { isFlagOn } from '@/lib/flags';
+import { useInsight } from '@/lib/useInsight';
+import InsightChip from '@/components/stats/InsightChip';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const STATS_NAME_KEY = 'badminton_stats_preview_name';
@@ -47,6 +50,10 @@ export default function LevelCard() {
   const [loaded, setLoaded] = useState(false);
   const [showHow, setShowHow] = useState(false);
   const [showCompare, setShowCompare] = useState(false);
+  // Distributed AI insight — a short, non-obvious chip about the level. Shared
+  // (memoized) fetch across the greeting + the other card chips.
+  const insightsOn = isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS');
+  const { data: insight } = useInsight(insightsOn);
 
   useEffect(() => {
     setActiveName(resolveActiveName());
@@ -191,6 +198,8 @@ export default function LevelCard() {
           )}
         </div>
       )}
+
+      {insightsOn && insight?.level && <InsightChip {...insight.level} />}
 
       {level.explanation.length > 0 && (
         <div className="space-y-2">

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -7,6 +7,9 @@ import {
 } from 'recharts';
 import { getIdentity } from '@/lib/identity';
 import { SKILLS, topStrengths, workOnNext, type Rating, type Dimension, type Phase } from '@/lib/assessment';
+import { isFlagOn } from '@/lib/flags';
+import { useInsight } from '@/lib/useInsight';
+import InsightChip from '@/components/stats/InsightChip';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 import CheckInSheet from './CheckInSheet';
 
@@ -125,6 +128,9 @@ export default function SkillTrendCard() {
   const [loadError, setLoadError] = useState(false);
   const [sheetSkill, setSheetSkill] = useState<string | null>(null);
   const [checkInOpen, setCheckInOpen] = useState(false);
+  // Distributed AI insight — a short, non-obvious chip about the skill trend.
+  const insightsOn = isFlagOn('NEXT_PUBLIC_FLAG_INSIGHT_CARDS');
+  const { data: insight } = useInsight(insightsOn);
 
   useEffect(() => {
     setActiveName(resolveActiveName());
@@ -316,6 +322,8 @@ export default function SkillTrendCard() {
         <SkillList title={t('assess.strengths')} items={strengths} nowMap={nowMap} thenMap={thenMap} onPick={setSheetSkill} />
         <SkillList title={t('assess.workOn')} items={workOn} nowMap={nowMap} thenMap={thenMap} onPick={setSheetSkill} />
       </div>
+
+      {insightsOn && insight?.trend && <InsightChip {...insight.trend} />}
 
       {/* Full per-skill profile (spec §7.2/§7.5) — collapsible; also the
           accessible representation of the aria-hidden radar. */}

--- a/components/stats/SummaryGreeting.tsx
+++ b/components/stats/SummaryGreeting.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useInsight } from '@/lib/useInsight';
+
+/**
+ * The single plain-language AI takeaway at the top of the Stats Summary — the
+ * one-glance "where you're at + the one interesting thing" line. Leads the
+ * distributed-insight surface (the per-card chips carry the non-obvious detail).
+ *
+ * Additive + legible-fail: renders nothing while loading, on error, or when
+ * there's no greeting (anonymous viewer / no API key). The card below it always
+ * stands on its own. Carries the conic AI rim (`.insight-rim`) + a Beta marker
+ * so the AI provenance is honest.
+ */
+export default function SummaryGreeting() {
+  const { data } = useInsight(true);
+  const greeting = data?.greeting ?? null;
+  if (!greeting) return null;
+
+  return (
+    <div
+      className="glass-card insight-rim animate-fadeIn"
+      style={{ padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 12 }}
+      aria-label="Your AI summary"
+    >
+      <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
+        auto_fix_high
+      </span>
+      <p style={{ margin: 0, fontSize: 15, lineHeight: 1.45, color: 'var(--text-primary)', flex: 1, minWidth: 0 }}>{greeting}</p>
+      <span
+        style={{
+          fontSize: 10,
+          padding: '3px 8px',
+          borderRadius: 100,
+          whiteSpace: 'nowrap',
+          fontWeight: 600,
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+          border: '1px solid var(--accent, #22c55e)',
+          color: 'var(--accent, #22c55e)',
+          flexShrink: 0,
+        }}
+      >
+        Beta
+      </span>
+    </div>
+  );
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -27,7 +27,8 @@ export type FlagName =
   | 'NEXT_PUBLIC_FLAG_SKILL_CALIBRATION'
   | 'NEXT_PUBLIC_FLAG_SKILL_SMOOTHING'
   | 'NEXT_PUBLIC_FLAG_SKILL_DRILLS'
-  | 'NEXT_PUBLIC_FLAG_KUDOS';
+  | 'NEXT_PUBLIC_FLAG_KUDOS'
+  | 'NEXT_PUBLIC_FLAG_INSIGHT_CARDS';
 
 interface FlagMeta {
   description: string;
@@ -96,6 +97,11 @@ export const FLAGS: Record<FlagName, FlagMeta> = {
     owner: 'grant',
     plannedRemoval: 'after kudos is promoted to stable + lived-in for 2 weeks',
   },
+  NEXT_PUBLIC_FLAG_INSIGHT_CARDS: {
+    description: 'Distributed AI insights: dissolves the standalone "Your read" card into a one-line plain-language greeting at the top of the Stats Summary plus a short, NON-OBVIOUS insight chip attached to each card (level, skill trend). Server-side the /api/stats/insight route switches from {recap, focus} to structured {greeting, level, trend} slices, grounded in deterministically-computed signals (lib/insightSignals.ts) and nullable per card. On for bpm-next + dev; off on bpm-stable (legacy StreakSummaryCard) until promoted.',
+    owner: 'grant',
+    plannedRemoval: 'after distributed insights are promoted to stable + lived-in for 2 weeks',
+  },
 };
 
 function readFlag(name: FlagName): string | undefined {
@@ -124,6 +130,8 @@ function readFlag(name: FlagName): string | undefined {
       return process.env.NEXT_PUBLIC_FLAG_SKILL_DRILLS;
     case 'NEXT_PUBLIC_FLAG_KUDOS':
       return process.env.NEXT_PUBLIC_FLAG_KUDOS;
+    case 'NEXT_PUBLIC_FLAG_INSIGHT_CARDS':
+      return process.env.NEXT_PUBLIC_FLAG_INSIGHT_CARDS;
   }
 }
 

--- a/lib/insightSignals.ts
+++ b/lib/insightSignals.ts
@@ -1,0 +1,221 @@
+/**
+ * Non-obvious insight signals — the engine behind the distributed AI insights.
+ *
+ * The product bar (owner, 2026-06-17) is "value BEYOND the obvious": an insight
+ * must surface a pattern the player hasn't already noticed on the card, never a
+ * restatement of a number they can see. That bar is a content/grounding problem,
+ * so the *surprising angles* are computed here, deterministically, from data
+ * that already exists — and the AI only narrates the strongest one in plain
+ * words. This keeps insights grounded (never hallucinated) and unit-testable.
+ *
+ * Each signal is tagged with the `card` it belongs to and a `score` (0..1
+ * notability). A card with no signal above threshold gets nothing — the AI
+ * returns null for it and the chip simply doesn't render. Silence beats obvious.
+ *
+ * Pure module (no I/O). Forward-compatible: the blind-spot signal lights up once
+ * game calibration (Phase 2) feeds `canonicalLevel.basis.game`; until then it
+ * stays null and the engine just emits the self-only signals.
+ */
+
+import { SKILLS, workOnNext, type StoredAssessment, type Phase } from './assessment';
+import type { CanonicalLevel } from './level';
+
+const LABEL_BY_KEY = new Map(SKILLS.map((s) => [s.key, s.label]));
+const labelOf = (key: string): string => LABEL_BY_KEY.get(key) ?? key;
+
+export type SignalKind = 'blindspot' | 'phase-gating' | 'sticky-weak' | 'improving-streak' | 'declining-streak';
+export type SignalCard = 'level' | 'trend' | 'greeting';
+
+export interface InsightSignal {
+  kind: SignalKind;
+  /** Which card this insight attaches to (greeting = the top synthesis line). */
+  card: SignalCard;
+  /** 0..1 notability — higher = more worth surfacing. The route picks the
+   *  highest-scoring signal per card. */
+  score: number;
+  /** Grounded facts (numbers/labels) the narrator must stay within — never
+   *  invent beyond these. */
+  facts: Record<string, string | number>;
+  /** A plain-English seed the model rephrases. Never shown to users raw. */
+  hint: string;
+}
+
+export interface SignalInput {
+  /** Self-assessment snapshots (may be unsorted). */
+  snapshots: StoredAssessment[];
+  /** Canonical level — the blind-spot reads its self-vs-game basis. */
+  canonicalLevel?: CanonicalLevel | null;
+  now: string;
+}
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+
+/** Phase bands low→high (mirrors assessment.ts PHASE_BANDS; kept local so this
+ *  module stays pure and decoupled). */
+const PHASE_ORDER: { phase: Phase; min: number }[] = [
+  { phase: 'foundation', min: 1.0 },
+  { phase: 'exploration', min: 1.8 },
+  { phase: 'switch', min: 2.6 },
+  { phase: 'commitment', min: 3.4 },
+  { phase: 'advanced', min: 4.3 },
+];
+
+function sortedSnapshots(snapshots: StoredAssessment[]): StoredAssessment[] {
+  return snapshots
+    .filter((d): d is StoredAssessment => !!d && typeof d.takenAt === 'string')
+    .slice()
+    .sort((a, b) => a.takenAt.localeCompare(b.takenAt));
+}
+
+/** The lowest-rated skill keys (bottom `n`) in a snapshot. */
+function bottomKeys(snap: StoredAssessment, n = 3): string[] {
+  const ratings = Array.isArray(snap.ratings) ? snap.ratings : [];
+  return workOnNext(ratings, n).map((r) => r.skillKey);
+}
+
+/** The next phase above `overall`, and the gap to its band minimum. Null when
+ *  already at the top band. */
+function nextPhaseGap(overall: number): { nextPhase: Phase; gap: number } | null {
+  const next = PHASE_ORDER.find((b) => b.min > overall + 1e-9);
+  if (!next) return null;
+  return { nextPhase: next.phase, gap: round1(next.min - overall) };
+}
+
+/**
+ * Compute the candidate non-obvious signals. Returns a flat list; the route
+ * groups by `card` and surfaces the highest-scoring one each. An empty list
+ * (e.g. a single flat check-in mid-band) is the correct "nothing non-obvious to
+ * say" outcome.
+ */
+export function computeInsightSignals(input: SignalInput): InsightSignal[] {
+  const snaps = sortedSnapshots(input.snapshots);
+  const signals: InsightSignal[] = [];
+  if (snaps.length === 0) return signals;
+
+  const latest = snaps[snaps.length - 1];
+  const latestOverall = typeof latest.overall === 'number' ? latest.overall : null;
+
+  // ── Level card: blind-spot (self vs game-observed) ── forward-compatible;
+  // only fires once Phase-2 calibration populates basis.game.
+  const basis = input.canonicalLevel?.basis;
+  if (basis && typeof basis.self === 'number' && typeof basis.game === 'number') {
+    const delta = round1(basis.game - basis.self);
+    if (Math.abs(delta) >= 0.4) {
+      signals.push({
+        kind: 'blindspot',
+        card: 'level',
+        score: Math.min(1, Math.abs(delta) / 1.0),
+        facts: { self: basis.self, game: basis.game, delta: Math.abs(delta), direction: delta > 0 ? 'above' : 'below' },
+        hint:
+          delta > 0
+            ? `Your logged games put you ${Math.abs(delta)} above your own check-in rating — you may be underselling yourself.`
+            : `Your logged games sit ${Math.abs(delta)} under your check-in rating — recent results haven't caught up to how you rate yourself yet.`,
+      });
+    }
+  }
+
+  // ── Level card: phase-gating ── how close the next phase is, and the lever.
+  // Non-obvious: the card shows the phase + overall, never the gap or what
+  // would tip it. Only "close" gaps are notable (far ones are noise).
+  if (latestOverall !== null) {
+    const gating = nextPhaseGap(latestOverall);
+    if (gating && gating.gap > 0 && gating.gap <= 0.6) {
+      const weakest = workOnNext(Array.isArray(latest.ratings) ? latest.ratings : [], 2);
+      const weakLabels = weakest.map((r) => labelOf(r.skillKey)).filter(Boolean);
+      signals.push({
+        kind: 'phase-gating',
+        card: 'level',
+        score: 1 - gating.gap / 0.6,
+        facts: {
+          gap: gating.gap,
+          nextPhase: gating.nextPhase,
+          ...(weakLabels[0] ? { weakest: weakLabels[0] } : {}),
+        },
+        hint: `Only ${gating.gap} below the ${gating.nextPhase} band${
+          weakLabels.length ? ` — lifting your weakest areas (${weakLabels.join(', ')}) is what would tip you over` : ''
+        }.`,
+      });
+    }
+  }
+
+  // ── Trend card: sticky weak skill ── a skill that's stayed in your bottom
+  // few across multiple check-ins. The card shows the current work-on list,
+  // never its persistence over time.
+  if (snaps.length >= 2) {
+    const recent = snaps.slice(-3); // up to the last 3 check-ins
+    const latestBottom = bottomKeys(latest, 3);
+    let bestKey: string | null = null;
+    let bestCount = 0;
+    let bestValue = Infinity;
+    for (const key of latestBottom) {
+      if (!key) continue;
+      const count = recent.filter((s) => bottomKeys(s, 3).includes(key)).length;
+      const ratings = Array.isArray(latest.ratings) ? latest.ratings : [];
+      const value = ratings.find((r) => r.skillKey === key)?.value ?? Infinity;
+      // Prefer the most-persistent, then the lowest-rated, deterministically.
+      if (count > bestCount || (count === bestCount && value < bestValue)) {
+        bestKey = key;
+        bestCount = count;
+        bestValue = value;
+      }
+    }
+    if (bestKey && bestCount >= 2) {
+      const label = labelOf(bestKey);
+      signals.push({
+        kind: 'sticky-weak',
+        card: 'trend',
+        score: Math.min(1, bestCount / 3),
+        facts: { skill: label, count: bestCount, ...(Number.isFinite(bestValue) ? { value: bestValue } : {}) },
+        hint: `${label} has stayed among your lowest-rated areas across your last ${bestCount} check-ins — it's the steadiest place to aim.`,
+      });
+    }
+  }
+
+  // ── Greeting: improving / declining streak ── consecutive check-ins moving
+  // the same direction. The card shows only the latest delta, never the run.
+  if (snaps.length >= 3) {
+    const overalls = snaps.map((s) => (typeof s.overall === 'number' ? s.overall : null));
+    // Walk back from the latest counting same-direction steps.
+    const dirAt = (i: number): number => {
+      const a = overalls[i - 1];
+      const b = overalls[i];
+      if (a === null || b === null) return 0;
+      const d = b - a;
+      if (d > 0.05) return 1;
+      if (d < -0.05) return -1;
+      return 0;
+    };
+    const lastDir = dirAt(overalls.length - 1);
+    if (lastDir !== 0) {
+      let run = 0;
+      for (let i = overalls.length - 1; i >= 1; i--) {
+        if (dirAt(i) === lastDir) run += 1;
+        else break;
+      }
+      if (run >= 3) {
+        const start = overalls[overalls.length - 1 - run];
+        const end = overalls[overalls.length - 1];
+        const totalChange = start !== null && end !== null ? round1(Math.abs(end - start)) : 0;
+        signals.push({
+          kind: lastDir > 0 ? 'improving-streak' : 'declining-streak',
+          card: 'greeting',
+          score: Math.min(1, run / 4),
+          facts: { sessions: run, totalChange },
+          hint:
+            lastDir > 0
+              ? `Quietly on a roll — your overall has climbed ${run} check-ins straight, up ${totalChange} in total.`
+              : `Your overall has eased down ${run} check-ins running (${totalChange} total) — worth a fresh, honest re-rate.`,
+        });
+      }
+    }
+  }
+
+  return signals;
+}
+
+/** Group the flat signal list into the best signal per card. */
+export function signalsByCard(signals: InsightSignal[]): Record<SignalCard, InsightSignal | null> {
+  const pick = (card: SignalCard): InsightSignal | null =>
+    signals.filter((s) => s.card === card).sort((a, b) => b.score - a.score)[0] ?? null;
+  return { level: pick('level'), trend: pick('trend'), greeting: pick('greeting') };
+}

--- a/lib/useInsight.ts
+++ b/lib/useInsight.ts
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getIdentity, IDENTITY_EVENT } from '@/lib/identity';
+
+/**
+ * Shared client hook for the distributed AI insight (greeting + per-card chips).
+ *
+ * The greeting and the level/trend chips all consume the SAME insight payload,
+ * so this hook memoizes the fetch per (lowercased) name and shares the in-flight
+ * promise — three consumers trigger ONE network call to /api/stats/insight. The
+ * module cache is cleared on IDENTITY_EVENT (sign-in/out) so a new identity
+ * refetches. Resolution mirrors the other Stats cards: real identity → stats
+ * preview-name → null.
+ */
+
+const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
+const STATS_NAME_KEY = 'badminton_stats_preview_name';
+
+export interface CardSlice {
+  headline: string;
+  support?: string;
+  /** Drives the chip icon — set server-side from the driving signal. */
+  kind: string;
+}
+
+export interface InsightData {
+  account: boolean;
+  greeting: string | null;
+  level: CardSlice | null;
+  trend: CardSlice | null;
+}
+
+type Entry = { promise: Promise<InsightData | null> };
+const cache = new Map<string, Entry>();
+
+function resolveActiveName(): string | null {
+  const id = getIdentity();
+  if (id?.name) return id.name;
+  try {
+    const stored = localStorage.getItem(STATS_NAME_KEY);
+    if (stored && stored.trim()) return stored.trim();
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function load(name: string): Promise<InsightData | null> {
+  const key = name.toLowerCase();
+  const hit = cache.get(key);
+  if (hit) return hit.promise;
+  const promise = fetch(`${BASE}/api/stats/insight?name=${encodeURIComponent(name)}`, { cache: 'no-store' })
+    .then((r) => (r.ok ? (r.json() as Promise<InsightData>) : null))
+    .catch(() => null);
+  cache.set(key, { promise });
+  return promise;
+}
+
+/**
+ * @param enabled gate the fetch (e.g. the insight-cards flag). When false the
+ *   hook stays inert — no request, no state — so the legacy build pays nothing.
+ */
+export function useInsight(enabled = true): { data: InsightData | null; loading: boolean; error: boolean } {
+  const [activeName, setActiveName] = useState<string | null>(null);
+  const [state, setState] = useState<{ data: InsightData | null; loading: boolean; error: boolean }>({
+    data: null,
+    loading: false,
+    error: false,
+  });
+
+  useEffect(() => {
+    if (!enabled) return;
+    const update = () => {
+      cache.clear();
+      setActiveName(resolveActiveName());
+    };
+    setActiveName(resolveActiveName());
+    window.addEventListener(IDENTITY_EVENT, update);
+    return () => window.removeEventListener(IDENTITY_EVENT, update);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled || !activeName) {
+      setState({ data: null, loading: false, error: false });
+      return;
+    }
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true, error: false }));
+    load(activeName).then((data) => {
+      if (cancelled) return;
+      setState({ data: data ?? null, loading: false, error: data === null });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, activeName]);
+
+  return state;
+}


### PR DESCRIPTION
## What & why

Reframes the Stats AI feature around the goal of helping players **quickly understand and *learn* their skills** — specifically the owner feedback that the current "Your read" summary is *"nice, but they already know those things."*

The bar this round is **value beyond the obvious**: an insight must surface a pattern the player *hasn't* noticed, never restate a number that's already on the card. So instead of one standalone summary blob, we have:

- a one-line plain-language **greeting** at the top of the Summary (the single takeaway, jargon translated), and
- a short, **non-obvious insight chip** attached to the Level and Skill-trend cards.

All behind `NEXT_PUBLIC_FLAG_INSIGHT_CARDS` (off on stable, on for next + dev). Same single cached Claude call per member per session — no added cost.

## How the "non-obvious" bar is enforced

It's a content/grounding problem, so the surprising angles are computed **deterministically** in `lib/insightSignals.ts` — the model only *narrates* the strongest one per card in plain words, never invents a pattern:

- **blind-spot** — self-rating vs game-observed level (forward-compatible: lights up once Phase-2 calibration feeds `basis.game`)
- **phase-gating** — how close the next phase is + which weak areas are the lever
- **sticky-weak** — a skill that's stayed in your bottom few *across* check-ins (the card shows current work-on, never its persistence)
- **improving / declining streak** — consecutive check-ins moving one way (the card shows only the latest delta)

A card with **no signal gets `null`** — silence beats obvious. The chip's icon `kind` is set server-side from the driving signal, never trusted from the model.

## Changes

- `lib/insightSignals.ts` (new) — pure, testable signal engine
- `/api/stats/insight` — flag-on returns structured `{greeting, level, trend}` (each slice nullable); flag-off keeps `{recap, focus}`. A flag flip regenerates once.
- `lib/useInsight.ts` (new) — shared memoized hook so greeting + both chips = **one** fetch
- `InsightChip` (styled compact element) + `SummaryGreeting` (AI rim + Beta marker)
- `SkillsTab` — greeting leads the Summary; the standalone "Your read" is retired when the flag is on (streak still shows on `AttendanceCardLive`)
- flag registered in `lib/flags.ts` + `deploy-next.yml` (flag-sync clean)

## Testing

- `insightSignals.test.ts` — each signal fires; **stays silent on a flat/obvious check-in** (this is what enforces the bar)
- `stats-insight-cards.test.ts` — structured shape, server-set kinds, null-when-no-signal, caching, flag-flip regen, account gate (Anthropic SDK mocked)
- `flags.test.ts` — new flag both-branch
- ✅ full suite **791 pass**, ✅ app-code typecheck clean, ✅ `next build` clean, ✅ 0 lint errors

> Note: live AI text in-browser needs an `ANTHROPIC_API_KEY`; offline the greeting/chips correctly render nothing (legible-fail). The logic is covered by the route test with a mocked model.

## Follow-ups (out of scope, noted for the deeper "learn" goal)
- the practice → progress loop (did drilling a skill move its rating?)
- a first-run guided check-in flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_