### PR TITLE
Normalize Stats tab card padding and spacing

### DIFF
--- a/components/stats/RacketRow.tsx
+++ b/components/stats/RacketRow.tsx
@@ -65,7 +65,7 @@ export default function RacketRow() {
           type="button"
           onClick={() => setSheetOpen(true)}
           className="glass-card"
-          style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 104, textAlign: 'left', cursor: 'pointer' }}
+          style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 112, textAlign: 'left', cursor: 'pointer' }}
         >
           <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('yourRacket')}</p>
           {loadError ? (

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -191,7 +191,7 @@ export default function SkillTrendCard() {
 
   // Card chrome wraps every state so the section reads consistently.
   const Frame = ({ children }: { children: React.ReactNode }) => (
-    <div className="glass-card p-5 space-y-4">
+    <div className="glass-card p-5 space-y-3">
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
           <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: 'var(--accent, #22c55e)', marginTop: 1 }}>

--- a/components/stats/StatsPlaceholder.tsx
+++ b/components/stats/StatsPlaceholder.tsx
@@ -16,7 +16,7 @@ function CompactComingSoonCard({ icon, title, subtitle, comingSoon }: CompactCar
     <div
       className="glass-card"
       style={{
-        padding: 14,
+        padding: 16,
         display: 'flex',
         flexDirection: 'column',
         gap: 6,

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -129,7 +129,7 @@ export default function StreakSummaryCard() {
       // present/loading); `.is-generating` spins it while the read is produced,
       // freezing in place when it lands. See `.insight-rim` in globals.css.
       className={`glass-card${showRim ? ' insight-rim' : ''}${generating ? ' is-generating' : ''}`}
-      style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 14 }}
+      style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}
       aria-busy={generating || undefined}
       aria-label={hasStreak ? `${streak} week attendance streak for ${name}` : `Insight for ${name}`}
     >

--- a/components/stats/cards/RacketRecCard.tsx
+++ b/components/stats/cards/RacketRecCard.tsx
@@ -29,7 +29,7 @@ export default function RacketRecCard({ name }: { name: string }) {
   }, [name]);
 
   return (
-    <div className="glass-card" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 104 }}>
+    <div className="glass-card" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 112 }}>
       <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('weRecommend')}</p>
       {loadError ? (
         <p className="text-red-400 text-xs" role="alert" style={{ margin: 0 }}>{t('recError')}</p>


### PR DESCRIPTION
## What

The cards under the **Stats** tab had drifted out of visual alignment. This normalizes them to the established design-system patterns with value-only edits (no structural/JSX changes, no `globals.css` changes).

### Section cards → canonical `glass-card p-5 space-y-3` (20px padding, 12px gaps)
- `SkillTrendCard` — `space-y-4` → `space-y-3`
- `StreakSummaryCard` — inline `padding: 16, gap: 14` → `padding: 20, gap: 12` (kept inline rather than converting to `p-5 space-y-3`: its body divider relies on flex `gap` + a conditional `paddingTop`, which `space-y-3` margins would double up; and the wrapper also carries the `insight-rim`/`is-generating` classes)

### Compact 2-col tiles → unify on `padding: 16, minHeight: 112`
- `CompactComingSoonCard` (StatsPlaceholder) — `padding: 14` → `16`
- `RacketRow` left tile — `minHeight: 104` → `112`
- `RacketRecCard` (same grid row) — `minHeight: 104` → `112`

This yields a clean hierarchy: **20px** section cards / **16px** compact tiles. `SkillsRadar`'s nested `p-3` cards (card-in-a-card inside a `p-5` LiveCard) were intentionally left alone.

## Why
Uneven padding/spacing between cards in the same scroll. Conforming the two outliers and the two tile paddings makes the tab read consistently.

## Verification
- `npm test` → **861 passed**. `StatsPlaceholder.test.tsx` asserts on text/roles only; no test references the changed class/style values.
- Booted the app offline (mock store) and screenshotted the Stats tab — the attendance section card and the two coming-soon tiles render with the intended consistent padding hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_