### PR TITLE
feat(voice): app-wide "reliable, insightful friend" voice & tone

### DIFF
--- a/__tests__/components/RecoverySheet.test.tsx
+++ b/__tests__/components/RecoverySheet.test.tsx
@@ -68,7 +68,7 @@ describe('RecoverySheet', () => {
     fireEvent.change(screen.getByLabelText('PIN'), { target: { value: '0000' } });
     fireEvent.click(screen.getByRole('button', { name: /^sign in$/i }));
     await waitFor(() => {
-      expect(screen.getByText(/too many tries/i)).toBeDefined();
+      expect(screen.getByText(/pause a moment/i)).toBeDefined();
     });
   });
 });

--- a/__tests__/components/SignInForm.test.tsx
+++ b/__tests__/components/SignInForm.test.tsx
@@ -114,7 +114,7 @@ describe('<SignInForm />', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Too many tries/i)).toBeDefined();
+      expect(screen.getByText(/pause a moment/i)).toBeDefined();
     });
   });
 });

--- a/__tests__/voice-canary.test.ts
+++ b/__tests__/voice-canary.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import en from '../messages/en.json';
+import zh from '../messages/zh-CN.json';
+
+/**
+ * Voice canary — guards the copy against accusatory / pressuring phrasing that
+ * violates the voice charter (docs/voice-and-tone.md): the app is a reliable,
+ * insightful friend, never a scold. If a future string trips one of these, it's
+ * almost certainly off-voice — soften it (or, if genuinely needed, update the
+ * charter and this list deliberately).
+ */
+const BANNED_EN = [
+  'you failed',
+  'you missed',
+  'too many tries',
+  'too many attempts',
+  'lock you out',
+  'last chance',
+];
+
+function flatten(obj: unknown, out: string[] = []): string[] {
+  if (typeof obj === 'string') out.push(obj);
+  else if (obj && typeof obj === 'object') for (const v of Object.values(obj as Record<string, unknown>)) flatten(v, out);
+  return out;
+}
+
+describe('voice canary', () => {
+  const enStrings = flatten(en);
+
+  for (const phrase of BANNED_EN) {
+    it(`en.json contains no "${phrase}"`, () => {
+      const hits = enStrings.filter((s) => s.toLowerCase().includes(phrase));
+      expect(hits).toEqual([]);
+    });
+  }
+
+  it('en and zh-CN have identical key structures (parity)', () => {
+    const keys = (obj: unknown, prefix = '', out: string[] = []): string[] => {
+      if (obj && typeof obj === 'object') {
+        for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+          const path = prefix ? `${prefix}.${k}` : k;
+          if (v && typeof v === 'object') keys(v, path, out);
+          else out.push(path);
+        }
+      }
+      return out;
+    };
+    expect(keys(zh).sort()).toEqual(keys(en).sort());
+  });
+});

--- a/app/api/stats/insight/route.ts
+++ b/app/api/stats/insight/route.ts
@@ -9,6 +9,7 @@ import { getCanonicalLevel } from '@/lib/levelStore';
 import type { CanonicalLevel } from '@/lib/level';
 import { recommendDrills, type DrillPick } from '@/lib/drills';
 import { computeInsightSignals, signalsByCard, type InsightSignal, type SignalCard } from '@/lib/insightSignals';
+import { VOICE_PERSONA } from '@/lib/aiPersona';
 
 /**
  * Account-gated, passively-generated player insight. Replaces the old
@@ -412,7 +413,9 @@ async function generate(name: string, s: Snapshot, prev: InsightDoc | null): Pro
     ? `\n\nYour previous note to ${name} (one session ago):\n- Recap: ${prev.recap}\n- Focus: ${prev.focus}`
     : '';
 
-  const prompt = `You are a warm, plain-spoken badminton companion writing for ${name}, a casual weekly player. Use ONLY the facts below — never invent numbers, names, or events.
+  const prompt = `${VOICE_PERSONA}
+
+You're writing for ${name}, a casual weekly player. Use ONLY the facts below — never invent numbers, names, or events.
 
 ${lastLine}
 Season (last ${s.totalSessions} sessions): attended ${s.attended} (${s.attendanceRate}%), current streak ${s.currentStreak}, longest streak ${s.longestStreak}.
@@ -525,7 +528,9 @@ async function generateCards(
     .join('\n');
   const memoryLine = prev?.greeting ? `\n\nYour previous greeting to ${name}: "${prev.greeting}"` : '';
 
-  const prompt = `You are a warm, plain-spoken badminton companion writing short, scannable insights for ${name}, a casual weekly player. Use ONLY the facts below — never invent numbers, names, events, or patterns.
+  const prompt = `${VOICE_PERSONA}
+
+You're writing short, scannable insights for ${name}, a casual weekly player. Use ONLY the facts below — never invent numbers, names, events, or patterns.
 
 DATA
 ${lastLine}

--- a/components/stats/cards/AttendanceCardLive.tsx
+++ b/components/stats/cards/AttendanceCardLive.tsx
@@ -112,7 +112,7 @@ export default function AttendanceCardLive() {
   if (!data) {
     return (
       <p style={{ margin: 0, fontSize: 12, color: MUTED }} role="alert">
-        Couldn’t load attendance.
+        Couldn’t load that — refresh to try again.
       </p>
     );
   }

--- a/docs/voice-and-tone.md
+++ b/docs/voice-and-tone.md
@@ -1,0 +1,61 @@
+# Voice & Tone — BPM Badminton
+
+The app has one voice: **a reliable, insightful friend you go to when you need
+them — never a scold, a salesman, or a scoreboard.** This doc is the single
+source of truth. The AI persona (`lib/aiPersona.ts`) and all user-facing copy
+(`messages/*.json`, component strings) should follow it.
+
+It's grounded in the skill-acquisition and motivation research in
+`docs/research/practice-progress-loop.md` — the same evidence that shaped the
+feedback design: feedback should be *informational, not controlling* (Cognitive
+Evaluation Theory), *mastery-framed, not comparative* (achievement-goal climate),
+and *never manufactured-anxiety* (the dark-pattern guardrail).
+
+## Persona
+
+A warm, plain-spoken **25–45-year-old peer who plays** — casual but competent.
+Plain modern English with contractions. Not a teenager (no Gen-Z slang: "no cap,"
+"slay," "bussin"), not a corporation (no "Operation failed," "Please be advised"),
+not a hype-man.
+
+**Flavor: warm & plain.** Minimal flourish. An occasional light, dry touch is
+fine; loud enthusiasm, jokes, and exclamation pile-ups are not.
+
+## Principles
+
+1. **Informational, never controlling.** Describe what happened or what's
+   possible; don't command, pressure, or guilt. *(CET — identical feedback
+   builds motivation when informational, undermines it when controlling.)*
+2. **On your side.** When something fails, the app takes the blame, never the
+   user. *"That didn't go through,"* not *"You failed."*
+3. **Self-referenced, never comparative.** Progress is measured against your own
+   past — never ranked against other players. *(Mastery vs. ego climate.)*
+4. **Calm, never urgent.** No countdowns, "last chance," loss-aversion, or
+   manufactured anxiety. *(Dark-pattern guardrail.)*
+5. **Encouraging through setbacks.** Plateaus and dips get gentle framing plus
+   one concrete next step — never guilt. *(OPTIMAL theory — enhanced
+   expectancies.)*
+6. **Honest, not flattering.** Warmth never overrides truth. Never invent praise
+   or numbers. A load error still reads as an error — just kindly. Never disguise
+   a failure as "no data" (the legible-fail rule).
+7. **Plain & warm.** Conversational, concise for mobile. No jargon, no emoji, no
+   hashtags.
+
+## Calibrators
+
+| Situation | ✓ Say | ✗ Avoid |
+|---|---|---|
+| Skill improving, still weakest | "Nice — your net play's clearly improving; it's still your softest spot, so a great one to keep leaning into." | "You're crushing it!!" / "Your net play is below average." |
+| A request failed | "That didn't go through — give it another tap." | "Failed." / "Operation failed." / "Oops! Let's try again!" |
+| Rate-limited | "Let's pause a moment — try again in 15 minutes." | "Too many attempts." / "You've been blocked." |
+| Not on invite list | "We don't have that name yet — ask the friend who shared this to add you." | "We don't have you on our invite list." |
+| Plateau / decline | "Held steady this time — that happens. One thing to try next: …" | "You didn't improve." / "You're falling behind." |
+| Validation | "Those two don't match — give it another go." / "Use a 4-digit PIN." | "PINs don't match." / "Invalid input." |
+
+## Scope notes
+
+- **Admin copy** can be more functional, but still never blames or pressures.
+- **Errors stay honest.** Warm wording must not hide that something failed or
+  pretend missing data is empty data.
+- **No emoji** in app copy or AI output (existing convention; UI uses Material
+  icons).

--- a/lib/aiPersona.ts
+++ b/lib/aiPersona.ts
@@ -1,0 +1,21 @@
+/**
+ * The BPM Badminton app's AI voice — single source of truth.
+ *
+ * Every Claude prompt that produces player-facing text prepends `VOICE_PERSONA`
+ * so the whole app speaks as one reliable, insightful friend. Tone edits happen
+ * here, once. The full charter (with examples) lives in `docs/voice-and-tone.md`;
+ * the rationale is in `docs/research/practice-progress-loop.md`.
+ */
+
+/** The persona + tone contract, prepended to player-facing generation prompts. */
+export const VOICE_PERSONA = `You are the voice of BPM Badminton — a reliable, insightful friend the player comes to, never a scold, a salesman, or a scoreboard. You speak like a warm, plain-spoken 25–45-year-old who plays: casual but competent, plain modern English with contractions. No slang, no corporate-speak, no emoji, no hashtags, no exclamation-heavy hype.
+
+Always:
+- Informational, never controlling — describe what's happening or what's possible; never command, pressure, or guilt.
+- On the player's side — if something went wrong, never blame them.
+- Self-referenced — compare the player only to their own past, never to other people.
+- Encouraging through setbacks — on a plateau or dip, stay warm and offer one concrete next step.
+- Honest over flattering — never invent praise, numbers, names, or events.`;
+
+/** Short reminder of the output style, for the tail of a prompt. */
+export const VOICE_STYLE = `Plain, warm, specific. No jargon, no emoji, no hashtags.`;

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,16 +12,16 @@
       "waitlist": "Join Waitlist",
       "full": "Session Full",
       "confirmed": "Signed up as {name}",
-      "inviteError": "We don't have \"{name}\" on our invite list. Check the spelling, or ask the friend who shared this app with you to add you.",
-      "networkError": "Network error. Please try again.",
+      "inviteError": "We can't find \"{name}\" on the list yet — double-check the spelling, or ask the friend who shared this app to add you.",
+      "networkError": "Can't reach the server — check your connection and try again.",
       "offline": "You're offline — reconnect to sign up.",
-      "nameRequired": "Enter your name to sign up",
+      "nameRequired": "Add your name to sign up",
       "pinRequired": "Set a 4-digit PIN to sign up",
-      "pinTooCommon": "Pick a less common PIN",
+      "pinTooCommon": "Try a less common PIN",
       "pinLabel": "PIN",
       "pinHint": "Required. Use this PIN to recover access if you change phones.",
-      "genericFailure": "Failed to sign up",
-      "waitlistFailure": "Failed to join waitlist",
+      "genericFailure": "That didn't go through — give it another try.",
+      "waitlistFailure": "That didn't go through — try the waitlist again.",
       "namePlaceholder": "Enter your name",
       "nameAriaLabel": "Your name",
       "joining": "Joining…",
@@ -37,7 +37,7 @@
       "pinLabel": "PIN",
       "pinCreateLabel": "Create a PIN",
       "pinConfirmLabel": "Confirm PIN",
-      "pinMismatch": "PINs don't match.",
+      "pinMismatch": "Those two don't match — give it another go.",
       "pinIncorrect": "That didn't match. Try again.",
       "pinTooCommon": "Pick a different PIN — try something less common.",
       "forgotPin": "Forgot your PIN?",
@@ -52,7 +52,7 @@
         "skip": "Maybe later",
         "savedToast": "PIN saved",
         "errorInvalid": "PIN must be 4 digits",
-        "errorTooCommon": "Pick a less common PIN"
+        "errorTooCommon": "Try a less common PIN"
       }
     },
     "states": {
@@ -115,9 +115,9 @@
       "pinLabel": "PIN",
       "signInButton": "Sign in",
       "signInChecking": "Checking…",
-      "signInErrorRateLimited": "Too many attempts. Try again in 15 minutes.",
+      "signInErrorRateLimited": "Let's pause a moment — try again in 15 minutes.",
       "signInErrorInvalid": "Incorrect name or PIN.",
-      "signInErrorNetwork": "Network error."
+      "signInErrorNetwork": "Can't reach the server right now."
     }
   },
   "nav": {
@@ -136,7 +136,7 @@
     "anonymousSignInButton": "Sign in",
     "anonymousSignInChecking": "Checking…",
     "anonymousSignInErrorInvalid": "That didn't match. Try again.",
-    "anonymousSignInErrorRateLimited": "Too many tries. Try again later.",
+    "anonymousSignInErrorRateLimited": "Let's pause a moment — try again shortly.",
     "anonymousSignInErrorAdminLogged": "Signed in as admin — sign out first to recover a player account.",
     "anonymousSignInErrorNetwork": "Couldn't reach the server. Check your connection and try again.",
     "anonymousOrDivider": "or",
@@ -151,15 +151,15 @@
       "submit": "Create account",
       "submitting": "Creating…",
       "successWelcome": "Welcome, {name}",
-      "errorMismatch": "PINs don't match",
-      "errorTooCommon": "Pick a less common PIN",
+      "errorMismatch": "Those two don't match — give it another go",
+      "errorTooCommon": "Try a less common PIN",
       "errorInvalid": "PIN must be 4 digits",
-      "errorRateLimited": "Too many tries. Try again in an hour.",
-      "errorNetwork": "Network error. Please try again.",
+      "errorRateLimited": "Let's pause a moment — try again in an hour.",
+      "errorNetwork": "Can't reach the server — check your connection and try again.",
       "errorPinProblem": "Pick a different PIN — try something less common that you'll remember.",
       "errorTryLater": "Couldn't save right now. Try again in a moment.",
       "errorAccountExists": "An account with this name already exists. Sign in instead.",
-      "errorInviteOnly": "This name isn't on the invite list. Ask the admin to add you."
+      "errorInviteOnly": "We can't find that name on the list yet — ask the admin to add you."
     },
     "playerName": "Name",
     "playerSession": "Signed up for",
@@ -170,12 +170,12 @@
     "pinChangeButton": "Change",
     "pinRemoveButton": "Remove",
     "pinSaved": "Saved",
-    "pinTooCommon": "Pick a less common PIN",
+    "pinTooCommon": "Try a less common PIN",
     "pinInvalid": "PIN must be 4 digits",
-    "pinUpdateFailed": "Couldn't update PIN. Please try again.",
+    "pinUpdateFailed": "That didn't save — give your PIN another go.",
     "pinNeedsSignIn": "Sign up for this week first — it re-activates your account on this device so you can set a PIN.",
-    "pinWrongCurrent": "Current PIN doesn't match.",
-    "pinRateLimited": "Too many tries. Try again in an hour.",
+    "pinWrongCurrent": "That current PIN doesn't match — give it another go.",
+    "pinRateLimited": "Let's pause a moment — try again in an hour.",
     "adminToolsTitle": "Admin tools",
     "adminToolsButton": "Admin tools →",
     "settings": {
@@ -207,7 +207,7 @@
     "confirmLabel": "Confirm PIN",
     "save": "Save",
     "cancel": "Cancel",
-    "mismatch": "PINs don't match"
+    "mismatch": "Those two don't match — give it another go"
   },
   "stats": {
     "heading": "Your stats",
@@ -224,7 +224,7 @@
         "high": "Well-calibrated"
       },
       "empty": "Take a skill check-in to see your level.",
-      "error": "Couldn't load — refresh to retry",
+      "error": "Couldn't load that — refresh to try again",
       "needsAuth": "Sign in again to see your level.",
       "onTrack": "On track for {phase} — confirm it at your next check-in.",
       "compare": {
@@ -243,7 +243,7 @@
         "pair": "pair",
         "group": "group"
       },
-      "error": "Couldn't load — refresh to retry",
+      "error": "Couldn't load that — refresh to try again",
       "needsAuth": "Sign in again to see your drills."
     },
     "kudos": {
@@ -251,7 +251,7 @@
       "giveTitle": "Send kudos",
       "giveHint": "Give a shout-out to who you played with tonight.",
       "offline": "You're offline — reconnect to send kudos.",
-      "error": "Couldn't load — refresh to retry",
+      "error": "Couldn't load that — refresh to try again",
       "tag": {
         "great_defense": "Great defense",
         "clutch": "Clutch",
@@ -299,7 +299,7 @@
       "notRated": "Not rated yet",
       "empty": "No check-in yet — take your first to start tracking your game.",
       "baseline": "Baseline saved — check in again after a few sessions to watch it move.",
-      "error": "Couldn't load — refresh to retry",
+      "error": "Couldn't load that — refresh to try again",
       "checkInTitle": "Skill check-in",
       "close": "Close",
       "mirrorTitle": "Recently",
@@ -314,7 +314,7 @@
       "skip": "Skip",
       "save": "Save check-in",
       "saving": "Saving…",
-      "saveError": "Couldn't save — try again.",
+      "saveError": "That didn't save — give it another go.",
       "reviewCount": "{rated} of {total} skills rated",
       "reviewPrompt": "Save to update your trend.",
       "signedOutTitle": "Track your game",
@@ -346,24 +346,9 @@
     "cancelConfirm": "Cancel your spot?",
     "confirmYes": "Yes",
     "confirmNo": "No",
-    "cancelFailure": "Failed to cancel. Please try again.",
-    "loadError": "Couldn't load — refresh to retry.",
+    "cancelFailure": "That didn't go through — give it another try.",
+    "loadError": "Couldn't load that — refresh to try again.",
     "retry": "Retry"
-  },
-  "forcePinModal": {
-    "title": "Set a PIN to keep your spot",
-    "body": "PINs are now required so you can recover your account if you change phones or clear your browser. Pick a 4-digit code you'll remember.",
-    "whatIsThis": "What is this? Why now?",
-    "whatIsThisBody": "Until today, PINs were optional and most accounts didn't have one — so a single browser refresh could lock you out forever. We're making them required for everyone. It takes 5 seconds.",
-    "pinLabel": "Your PIN",
-    "confirmLabel": "Confirm",
-    "save": "Save PIN",
-    "saving": "Saving…",
-    "signOutInstead": "Sign out instead",
-    "errMismatch": "PINs don't match",
-    "errTooCommon": "Pick a less common PIN",
-    "errInvalid": "Couldn't save. Try again.",
-    "errNetwork": "Network error. Try again."
   },
   "admin": {
     "releases": {
@@ -395,7 +380,7 @@
     "forgotPinLink": "Forgot your PIN?",
     "haveCodeLink": "Have a recovery code from admin?",
     "errorInvalid": "That didn't match. Try again.",
-    "errorRateLimited": "Too many tries. Try again later.",
+    "errorRateLimited": "Let's pause a moment — try again shortly.",
     "errorAdminLoggedIn": "Signed in as admin — sign out first to recover a player account.",
     "errorNetwork": "Couldn't reach the server. Try again.",
     "welcomeBack": "Welcome back, {name}",
@@ -419,10 +404,10 @@
     "recTitle": "Players like you often use",
     "recCta": "See gear",
     "recEmpty": "Add your racket to get a pick.",
-    "recError": "Couldn't load — refresh to retry",
+    "recError": "Couldn't load that — refresh to try again",
     "partnersTitle": "Your regular partners",
     "partnersEmpty": "Play a few sessions to see your regulars.",
-    "partnersError": "Couldn't load — refresh to retry",
+    "partnersError": "Couldn't load that — refresh to try again",
     "partnersCount": "{count, plural, one {# session} other {# sessions}}",
     "partnersMostWith": "You play most with",
     "partnersTogether": "{count, plural, one {# session together} other {# sessions together}}",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -12,16 +12,16 @@
       "waitlist": "加入候补",
       "full": "名额已满",
       "confirmed": "已报名：{name}",
-      "inviteError": "邀请名单上没有\"{name}\"。请检查拼写，或联系分享此应用的朋友将您添加。",
-      "networkError": "网络错误，请重试。",
+      "inviteError": "暂时没找到\"{name}\"。请检查拼写，或请分享此应用给你的朋友把你加上。",
+      "networkError": "连不上服务器 — 检查下网络再试一次。",
       "offline": "您已离线 — 重新连接后即可报名。",
-      "nameRequired": "请输入您的姓名以报名",
+      "nameRequired": "填上你的名字就能报名",
       "pinRequired": "请设置 4 位 PIN 后报名",
-      "pinTooCommon": "请使用不太常见的 PIN",
+      "pinTooCommon": "换一个不那么常见的 PIN 吧",
       "pinLabel": "PIN",
       "pinHint": "必填。换设备时用此 PIN 恢复账户。",
-      "genericFailure": "报名失败",
-      "waitlistFailure": "加入候补失败",
+      "genericFailure": "没报上 — 再试一次吧。",
+      "waitlistFailure": "没加上 — 再试一次候补吧。",
       "namePlaceholder": "输入您的姓名",
       "nameAriaLabel": "您的姓名",
       "joining": "正在加入…",
@@ -37,7 +37,7 @@
       "pinLabel": "PIN",
       "pinCreateLabel": "设置 PIN",
       "pinConfirmLabel": "确认 PIN",
-      "pinMismatch": "两次 PIN 不一致。",
+      "pinMismatch": "两次输入不一样，再试一次吧。",
       "pinIncorrect": "信息不匹配，请重试。",
       "pinTooCommon": "请换一个 PIN——选一个不那么常见的。",
       "forgotPin": "忘记 PIN？",
@@ -52,7 +52,7 @@
         "skip": "稍后再说",
         "savedToast": "PIN 已保存",
         "errorInvalid": "PIN 必须是 4 位数字",
-        "errorTooCommon": "请选择不那么常见的 PIN"
+        "errorTooCommon": "换一个不那么常见的 PIN 吧"
       }
     },
     "states": {
@@ -115,9 +115,9 @@
       "pinLabel": "PIN",
       "signInButton": "登录",
       "signInChecking": "验证中…",
-      "signInErrorRateLimited": "尝试次数过多，请 15 分钟后再试。",
+      "signInErrorRateLimited": "先歇一下，15 分钟后再试。",
       "signInErrorInvalid": "名字或 PIN 不正确。",
-      "signInErrorNetwork": "网络错误。"
+      "signInErrorNetwork": "暂时连不上服务器。"
     }
   },
   "nav": {
@@ -136,7 +136,7 @@
     "anonymousSignInButton": "登录",
     "anonymousSignInChecking": "验证中…",
     "anonymousSignInErrorInvalid": "信息不匹配，请重试。",
-    "anonymousSignInErrorRateLimited": "尝试次数过多，请稍后再试。",
+    "anonymousSignInErrorRateLimited": "先歇一下，稍后再试。",
     "anonymousSignInErrorAdminLogged": "已以管理员身份登录 — 请先退出再恢复球员账号。",
     "anonymousSignInErrorNetwork": "无法连接服务器，请检查网络后重试。",
     "anonymousOrDivider": "或",
@@ -151,15 +151,15 @@
       "submit": "创建账号",
       "submitting": "创建中…",
       "successWelcome": "欢迎，{name}",
-      "errorMismatch": "两次输入的 PIN 不一致",
-      "errorTooCommon": "请选择不那么常见的 PIN",
+      "errorMismatch": "两次输入不一样，再试一次吧",
+      "errorTooCommon": "换一个不那么常见的 PIN 吧",
       "errorInvalid": "PIN 必须是 4 位数字",
-      "errorRateLimited": "尝试次数过多，请一小时后再试。",
-      "errorNetwork": "网络错误，请重试。",
+      "errorRateLimited": "先歇一下，一小时后再试。",
+      "errorNetwork": "连不上服务器 — 检查下网络再试一次。",
       "errorPinProblem": "请换一个 PIN——选一个不那么常见、你能记住的。",
       "errorTryLater": "暂时无法保存，请稍后再试。",
       "errorAccountExists": "该名字已存在账号，请登录。",
-      "errorInviteOnly": "该名字不在邀请名单上，请联系管理员添加。"
+      "errorInviteOnly": "暂时没找到这个名字 — 请联系管理员添加。"
     },
     "playerName": "名字",
     "playerSession": "已报名场次",
@@ -170,12 +170,12 @@
     "pinChangeButton": "更改",
     "pinRemoveButton": "移除",
     "pinSaved": "已保存",
-    "pinTooCommon": "请选择不那么常见的 PIN",
+    "pinTooCommon": "换一个不那么常见的 PIN 吧",
     "pinInvalid": "PIN 必须是 4 位数字",
-    "pinUpdateFailed": "更新 PIN 失败，请重试。",
+    "pinUpdateFailed": "没更新成功 — 再试一次吧。",
     "pinNeedsSignIn": "请先报名本周活动——这会在此设备上重新激活你的账户，然后即可设置 PIN。",
-    "pinWrongCurrent": "当前 PIN 不正确。",
-    "pinRateLimited": "尝试次数过多，请一小时后再试。",
+    "pinWrongCurrent": "当前 PIN 不对 — 再试一次吧。",
+    "pinRateLimited": "先歇一下，一小时后再试。",
     "adminToolsTitle": "管理员工具",
     "adminToolsButton": "管理员工具 →",
     "settings": {
@@ -207,7 +207,7 @@
     "confirmLabel": "确认 PIN",
     "save": "保存",
     "cancel": "取消",
-    "mismatch": "PIN 不匹配"
+    "mismatch": "两次输入不一样，再试一次吧"
   },
   "stats": {
     "heading": "你的数据",
@@ -224,7 +224,7 @@
         "high": "已校准"
       },
       "empty": "完成一次技能自评即可看到你的水平。",
-      "error": "加载失败——刷新重试",
+      "error": "暂时加载不出来 — 刷新再试一次",
       "needsAuth": "请重新登录以查看你的水平。",
       "onTrack": "即将达到{phase}——下次自评确认。",
       "compare": {
@@ -243,7 +243,7 @@
         "pair": "双人",
         "group": "多人"
       },
-      "error": "加载失败——刷新重试",
+      "error": "暂时加载不出来 — 刷新再试一次",
       "needsAuth": "请重新登录以查看你的练习。"
     },
     "kudos": {
@@ -251,7 +251,7 @@
       "giveTitle": "送出赞",
       "giveHint": "为今晚和你一起打球的人点个赞。",
       "offline": "你已离线——重新联网后再送赞。",
-      "error": "加载失败——刷新重试",
+      "error": "暂时加载不出来 — 刷新再试一次",
       "tag": {
         "great_defense": "防守出色",
         "clutch": "关键先生",
@@ -299,7 +299,7 @@
       "notRated": "尚未评分",
       "empty": "还没有评估 — 完成第一次评估开始记录你的球技。",
       "baseline": "已记录基线 — 打几场后再来评估，看看变化。",
-      "error": "加载失败 — 刷新重试",
+      "error": "暂时加载不出来 — 刷新再试一次",
       "checkInTitle": "技能评估",
       "close": "关闭",
       "mirrorTitle": "最近",
@@ -314,7 +314,7 @@
       "skip": "跳过",
       "save": "保存评估",
       "saving": "保存中…",
-      "saveError": "保存失败 — 请重试。",
+      "saveError": "没存上 — 再试一次吧。",
       "reviewCount": "已评 {rated} / {total} 项技能",
       "reviewPrompt": "保存以更新你的趋势。",
       "signedOutTitle": "记录你的球技",
@@ -346,24 +346,9 @@
     "cancelConfirm": "取消您的名额？",
     "confirmYes": "是",
     "confirmNo": "否",
-    "cancelFailure": "取消失败，请重试。",
-    "loadError": "加载失败 — 请刷新重试。",
+    "cancelFailure": "没取消成功 — 再试一次吧。",
+    "loadError": "暂时加载不出来 — 刷新再试一次。",
     "retry": "重试"
-  },
-  "forcePinModal": {
-    "title": "设置 PIN 保住您的名额",
-    "body": "现在所有账户都需要 PIN，这样换手机或清除浏览器后还能恢复账户。选一个 4 位数容易记住的就好。",
-    "whatIsThis": "为什么现在要设？",
-    "whatIsThisBody": "之前 PIN 是可选的，大多数账户都没有——只要清一次浏览器就永远找不回。现在所有人都需要设。只要 5 秒。",
-    "pinLabel": "您的 PIN",
-    "confirmLabel": "确认",
-    "save": "保存 PIN",
-    "saving": "保存中…",
-    "signOutInstead": "改为退出登录",
-    "errMismatch": "两次输入的 PIN 不一致",
-    "errTooCommon": "请使用不太常见的 PIN",
-    "errInvalid": "保存失败，请重试。",
-    "errNetwork": "网络错误，请重试。"
   },
   "admin": {
     "releases": {
@@ -395,7 +380,7 @@
     "forgotPinLink": "忘记 PIN？",
     "haveCodeLink": "有管理员发的验证码？",
     "errorInvalid": "信息不匹配，请重试。",
-    "errorRateLimited": "尝试次数过多，请稍后再试。",
+    "errorRateLimited": "先歇一下，稍后再试。",
     "errorAdminLoggedIn": "当前为管理员登录——请先退出后再恢复玩家账户。",
     "errorNetwork": "无法连接到服务器，请重试。",
     "welcomeBack": "欢迎回来，{name}",
@@ -419,10 +404,10 @@
     "recTitle": "和你水平相近的球友常用",
     "recCta": "查看装备",
     "recEmpty": "添加你的球拍以获得推荐。",
-    "recError": "加载失败 — 刷新重试",
+    "recError": "暂时加载不出来 — 刷新再试一次",
     "partnersTitle": "你的常约搭档",
     "partnersEmpty": "多打几场就能看到你的常约搭档。",
-    "partnersError": "加载失败 — 刷新重试",
+    "partnersError": "暂时加载不出来 — 刷新再试一次",
     "partnersCount": "{count} 次",
     "partnersMostWith": "你最常一起打的是",
     "partnersTogether": "一起打了 {count} 次",


### PR DESCRIPTION
## What & why

Gives the whole app **one voice** — *a reliable, insightful friend you go to when you need them, never a scold, a salesman, or a scoreboard.* It's grounded in the skill-acquisition + motivation research (see the investigation doc): feedback should be **informational, not controlling** (Cognitive Evaluation Theory), **mastery-framed, not comparative** (achievement-goal climate), and **never manufactured-anxiety** (the dark-pattern guardrail).

> **Stacked PR:** based on `claude/app-review-upcoming-HtKgE` (PR #158), because the AI-voice change refactors the insight route's `generateCards` from that branch. Retarget to `main` once #158 merges.

## Changes

- **`docs/voice-and-tone.md`** — the charter: persona, a **25–45-year-old peer register**, the **warm & plain** flavor, 7 principles (each tied to a research finding), and a calibrator table of ✓/✗ examples.
- **`lib/aiPersona.ts`** — single source of truth (`VOICE_PERSONA`), now prepended to both prompts in `app/api/stats/insight/route.ts` so the app speaks as one voice and tone edits are one-touch.
- **Copy pass** over `messages/en.json` + `zh-CN.json` (parity kept) — de-blamed/de-pressured the offenders:
  - rate-limit: *"Too many tries"* → *"Let's pause a moment"*
  - failures: *"Failed to…"* → *"That didn't go through"*
  - cold errors: *"Couldn't load — refresh to retry"* → *"Couldn't load that — refresh to try again"*
  - validation: *"PINs don't match"* → *"Those two don't match — give it another go"*
  - invite-exclusion copy softened; retired the **orphaned `forcePinModal`** namespace (modal was already removed, no consumers).
- **`voice-canary` test** — banlist guard against accusatory phrasing + en/zh-CN key-parity assertion. Updated two component tests to the new rate-limit copy.

Honors the **legible-fail** rule (errors stay honest, just kindly) and the no-emoji convention.

## Testing
✅ 798 tests pass · ✅ app-code typecheck clean · ✅ `next build` clean · ✅ lint 0 errors · ✅ flag-sync clean

> Live AI voice needs an `ANTHROPIC_API_KEY` (verify on bpm-next post-merge); the copy changes are visible immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_