### PR TITLE
Normalize Stats card header inner items (two-tier)

### DIFF
--- a/components/stats/GameLoggerCard.tsx
+++ b/components/stats/GameLoggerCard.tsx
@@ -69,11 +69,11 @@ export default function GameLoggerCard() {
 
   return (
     <div className="glass-card p-5 space-y-3">
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: ACCENT }}>sports_tennis</span>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: ACCENT, marginTop: 1 }}>sports_tennis</span>
         <div>
           <h3 className="bpm-h3 m-0">{t('logGameTitle')}</h3>
-          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, marginTop: 2 }}>{t('logGameHint')}</p>
+          <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '2px 0 0', lineHeight: 1.35 }}>{t('logGameHint')}</p>
         </div>
       </div>
       <button type="button" onClick={() => setOpen(true)} className="cc-btn cc-btn-primary">

--- a/components/stats/GiveKudosCard.tsx
+++ b/components/stats/GiveKudosCard.tsx
@@ -102,11 +102,11 @@ export default function GiveKudosCard() {
 
   return (
     <div className="glass-card p-5 space-y-3">
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: 'var(--accent, #22c55e)' }}>volunteer_activism</span>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: 'var(--accent, #22c55e)', marginTop: 1 }}>volunteer_activism</span>
         <div>
           <h3 className="bpm-h3 m-0">{t('kudos.giveTitle')}</h3>
-          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, marginTop: 2 }}>{t('kudos.giveHint')}</p>
+          <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '2px 0 0', lineHeight: 1.35 }}>{t('kudos.giveHint')}</p>
         </div>
       </div>
       {!online && (

--- a/components/stats/StatsPlaceholder.tsx
+++ b/components/stats/StatsPlaceholder.tsx
@@ -73,17 +73,17 @@ function LiveCard({ icon, title, subtitle, children, badge = 'Live' }: LiveCardP
   return (
     <div className="glass-card p-5 space-y-3">
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
           <span
             className="material-icons"
             aria-hidden="true"
-            style={{ fontSize: 22, color: 'var(--accent, #22c55e)' }}
+            style={{ fontSize: 22, color: 'var(--accent, #22c55e)', marginTop: 1 }}
           >
             {icon}
           </span>
           <div>
             <h3 className="bpm-h3 m-0">{title}</h3>
-            <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, marginTop: 2 }}>{subtitle}</p>
+            <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '2px 0 0', lineHeight: 1.35 }}>{subtitle}</p>
           </div>
         </div>
         <span

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -168,7 +168,7 @@ export default function StreakSummaryCard() {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12, ...(hasStreak ? { borderTop: '1px solid var(--inner-card-border)', paddingTop: 14 } : {}) }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span className="material-icons" aria-hidden="true" style={{ fontSize: 20, color: ACCENT }}>auto_fix_high</span>
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: ACCENT }}>auto_fix_high</span>
               <h3 className="bpm-h3 m-0">Your read</h3>
             </div>
             <span style={{ fontSize: 10, padding: '3px 8px', borderRadius: 100, whiteSpace: 'nowrap', fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', border: `1px solid ${ACCENT}`, color: ACCENT }}>


### PR DESCRIPTION
## What

Follow-up to #159. That PR normalized the Stats cards' **outer** padding/spacing; this normalizes the **inner** header items, inline (no new components, no `globals.css`), using a **two-tier** canon.

Aligns the full-width "live" card headers to the canonical pattern already used by `LevelCard` / `SkillTrendCard` / `DrillsCard`:
- **subtitle** `13px → 12px`, `margin: '2px 0 0'`, `lineHeight: 1.35`
- header group **`alignItems: center → flex-start`**
- header **icon** gains `marginTop: 1`

Applied to the three drifted cards: **`GameLoggerCard`**, **`GiveKudosCard`**, and the shared **`LiveCard`** (in `StatsPlaceholder`). Plus **`StreakSummaryCard`**'s "Your read" icon `20px → 22px` to match the Tier-A icon size.

### Deliberately left alone
- The skill **phase pill** (amber/accent, in `LevelCard` + `SkillTrendCard`) — a distinct badge role, already identical across both uses.
- **Body copy** at 13px (empty states / hints) — a consistent role of its own, not a header subtitle.
- Compact coming-soon tiles (Tier B: icon 20px, badge 9px/muted) — already consistent.

## Why
After the wrapper normalization, the card *headers* still varied — subtitle sizes (11/12/13px), header alignment, and icon offset differed across cards, so titles and descriptions didn't sit on a consistent baseline.

## Verification
- `npm test` → **861 passed**; lint clean (0 errors).
- Value-only inline edits; no JSX structure, content, text, icons, or images changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_