### PR TITLE
Add &lt;StatusBadge&gt; primitive + migrate badge pills (standardization Phase 1b)

### DIFF
--- a/__tests__/components/StatusBadge.test.tsx
+++ b/__tests__/components/StatusBadge.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import StatusBadge from '../../components/primitives/StatusBadge';
+
+describe('StatusBadge', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders its label', () => {
+    render(<StatusBadge>Beta</StatusBadge>);
+    expect(screen.getByText('Beta')).toBeTruthy();
+  });
+
+  it('accent variant (default) uses the accent token, pill radius, no hardcoded hex border', () => {
+    render(<StatusBadge>Live</StatusBadge>);
+    const style = screen.getByText('Live').getAttribute('style') ?? '';
+    expect(style).toContain('var(--accent');
+    expect(style).toContain('var(--radius-pill)');
+  });
+
+  it('muted variant uses the muted tokens', () => {
+    render(<StatusBadge variant="muted">Coming soon</StatusBadge>);
+    const style = screen.getByText('Coming soon').getAttribute('style') ?? '';
+    expect(style).toContain('var(--inner-card-border)');
+    expect(style).toContain('var(--text-muted)');
+  });
+
+  it('phase variant tones: amber for switch, accent otherwise', () => {
+    render(<StatusBadge variant="phase" tone="amber">Switch</StatusBadge>);
+    expect(screen.getByText('Switch').getAttribute('style') ?? '').toContain('var(--accent-amber)');
+    cleanup();
+    render(<StatusBadge variant="phase" tone="accent">Refine</StatusBadge>);
+    expect(screen.getByText('Refine').getAttribute('style') ?? '').toContain('var(--accent)');
+  });
+});

--- a/components/primitives/StatusBadge.tsx
+++ b/components/primitives/StatusBadge.tsx
@@ -1,0 +1,47 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Status badge — the small uppercase pill that appears in card headers and
+ * tiles ("Live" / "Beta" / "Coming soon") and as the skill-phase tag. Replaces
+ * the ~6-8 hand-rolled inline pill blocks across the stats cards, which had
+ * drifted on font size (9/10/11) and padding (2px 7px / 3px 8px / 3px 10px).
+ *
+ * One shared shape; pick a variant:
+ *   - `accent` (default) — the Live/Beta pill (accent border + text, --fs-2xs)
+ *   - `muted`            — the compact "Coming soon" tag (muted border/text, 9px)
+ *   - `phase`            — the larger skill-phase tag; pass `tone="amber"` for
+ *                          the "switch" phase, else accent
+ *
+ * Colors come from tokens (`--accent` / `--accent-amber` / `--inner-card-border`
+ * / `--text-muted`); radius from `--radius-pill`. Text is the children.
+ */
+export type StatusBadgeVariant = 'accent' | 'muted' | 'phase';
+
+export interface StatusBadgeProps {
+  children: ReactNode;
+  variant?: StatusBadgeVariant;
+  /** Only meaningful for `variant="phase"`. */
+  tone?: 'accent' | 'amber';
+}
+
+const BASE: CSSProperties = {
+  display: 'inline-block',
+  borderRadius: 'var(--radius-pill)',
+  whiteSpace: 'nowrap',
+  fontWeight: 600,
+  letterSpacing: '0.04em',
+  textTransform: 'uppercase',
+};
+
+export default function StatusBadge({ children, variant = 'accent', tone = 'accent' }: StatusBadgeProps) {
+  let style: CSSProperties;
+  if (variant === 'muted') {
+    style = { ...BASE, fontSize: 9, padding: '2px 7px', border: '1px solid var(--inner-card-border)', color: 'var(--text-muted)' };
+  } else if (variant === 'phase') {
+    const c = tone === 'amber' ? 'var(--accent-amber)' : 'var(--accent)';
+    style = { ...BASE, fontSize: 'var(--fs-xs)', padding: '3px 10px', border: `1px solid ${c}`, color: c };
+  } else {
+    style = { ...BASE, fontSize: 'var(--fs-2xs)', padding: '3px 8px', border: '1px solid var(--accent, #22c55e)', color: 'var(--accent, #22c55e)' };
+  }
+  return <span style={style}>{children}</span>;
+}

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -8,6 +8,7 @@ import { isFlagOn } from '@/lib/flags';
 import { useInsight } from '@/lib/useInsight';
 import InsightChip from '@/components/stats/InsightChip';
 import CardHeader from '@/components/primitives/CardHeader';
+import StatusBadge from '@/components/primitives/StatusBadge';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const STATS_NAME_KEY = 'badminton_stats_preview_name';
@@ -125,17 +126,9 @@ export default function LevelCard() {
     <Frame>
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
         {level.phase && (
-          <span
-            style={{
-              fontSize: 11, padding: '3px 10px', borderRadius: 100, fontWeight: 600,
-              letterSpacing: '0.04em', textTransform: 'uppercase',
-              border: `1px solid ${level.phase === 'switch' ? 'var(--accent-amber)' : 'var(--accent)'}`,
-              color: level.phase === 'switch' ? 'var(--accent-amber)' : 'var(--accent)',
-              whiteSpace: 'nowrap',
-            }}
-          >
+          <StatusBadge variant="phase" tone={level.phase === 'switch' ? 'amber' : 'accent'}>
             {t(`assess.phase.${level.phase}`)}
-          </span>
+          </StatusBadge>
         )}
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, marginLeft: 'auto' }}>
           <span style={{ fontFamily: 'var(--font-mono)', fontSize: 30, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -13,6 +13,7 @@ import InsightChip from '@/components/stats/InsightChip';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 import CheckInSheet from './CheckInSheet';
 import CardHeader from '@/components/primitives/CardHeader';
+import StatusBadge from '@/components/primitives/StatusBadge';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const STATS_NAME_KEY = 'badminton_stats_preview_name';
@@ -238,17 +239,9 @@ export default function SkillTrendCard() {
       {/* Phase headline + overall */}
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
         {latest.phase && (
-          <span
-            style={{
-              fontSize: 11, padding: '3px 10px', borderRadius: 100, fontWeight: 600,
-              letterSpacing: '0.04em', textTransform: 'uppercase',
-              border: `1px solid ${latest.phase === 'switch' ? 'var(--accent-amber)' : 'var(--accent)'}`,
-              color: latest.phase === 'switch' ? 'var(--accent-amber)' : 'var(--accent)',
-              whiteSpace: 'nowrap',
-            }}
-          >
+          <StatusBadge variant="phase" tone={latest.phase === 'switch' ? 'amber' : 'accent'}>
             {t(`assess.phase.${latest.phase}`)}
-          </span>
+          </StatusBadge>
         )}
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
           <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{t('assess.overall')}</span>

--- a/components/stats/StatsPlaceholder.tsx
+++ b/components/stats/StatsPlaceholder.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import PageHeader from '@/components/primitives/PageHeader';
+import CardHeader from '@/components/primitives/CardHeader';
+import StatusBadge from '@/components/primitives/StatusBadge';
 
 interface CompactCardProps {
   icon: string;
@@ -32,21 +34,7 @@ function CompactComingSoonCard({ icon, title, subtitle, comingSoon }: CompactCar
         >
           {icon}
         </span>
-        <span
-          style={{
-            fontSize: 9,
-            padding: '2px 7px',
-            borderRadius: 100,
-            whiteSpace: 'nowrap',
-            fontWeight: 600,
-            letterSpacing: '0.04em',
-            textTransform: 'uppercase',
-            border: '1px solid var(--inner-card-border)',
-            color: 'var(--text-muted)',
-          }}
-        >
-          {comingSoon}
-        </span>
+        <StatusBadge variant="muted">{comingSoon}</StatusBadge>
       </div>
       <h3
         className="text-xs font-semibold m-0"
@@ -72,36 +60,7 @@ interface LiveCardProps {
 function LiveCard({ icon, title, subtitle, children, badge = 'Live' }: LiveCardProps) {
   return (
     <div className="glass-card p-5 space-y-3">
-      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-          <span
-            className="material-icons"
-            aria-hidden="true"
-            style={{ fontSize: 22, color: 'var(--accent, #22c55e)', marginTop: 1 }}
-          >
-            {icon}
-          </span>
-          <div>
-            <h3 className="bpm-h3 m-0">{title}</h3>
-            <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '2px 0 0', lineHeight: 1.35 }}>{subtitle}</p>
-          </div>
-        </div>
-        <span
-          style={{
-            fontSize: 10,
-            padding: '3px 8px',
-            borderRadius: 100,
-            whiteSpace: 'nowrap',
-            fontWeight: 600,
-            letterSpacing: '0.04em',
-            textTransform: 'uppercase',
-            border: '1px solid var(--accent, #22c55e)',
-            color: 'var(--accent, #22c55e)',
-          }}
-        >
-          {badge}
-        </span>
-      </div>
+      <CardHeader icon={icon} title={title} subtitle={subtitle} badge={<StatusBadge>{badge}</StatusBadge>} />
       {children}
     </div>
   );

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { getIdentity, IDENTITY_EVENT } from '@/lib/identity';
+import CardHeader from '@/components/primitives/CardHeader';
+import StatusBadge from '@/components/primitives/StatusBadge';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const STATS_NAME_KEY = 'badminton_stats_preview_name';
@@ -166,15 +168,7 @@ export default function StreakSummaryCard() {
       {/* ── Body: passive AI insight (recap + focus) ── */}
       {showBody && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12, ...(hasStreak ? { borderTop: '1px solid var(--inner-card-border)', paddingTop: 14 } : {}) }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: ACCENT }}>auto_fix_high</span>
-              <h3 className="bpm-h3 m-0">Your read</h3>
-            </div>
-            <span style={{ fontSize: 10, padding: '3px 8px', borderRadius: 100, whiteSpace: 'nowrap', fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', border: `1px solid ${ACCENT}`, color: ACCENT }}>
-              Beta
-            </span>
-          </div>
+          <CardHeader icon="auto_fix_high" title="Your read" badge={<StatusBadge>Beta</StatusBadge>} />
 
           {insightLoading && !hasInsight ? (
             <div aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>

--- a/components/stats/cards/PartnerFrequencyCard.tsx
+++ b/components/stats/cards/PartnerFrequencyCard.tsx
@@ -3,10 +3,11 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { getIdentity } from '@/lib/identity';
 import { avatarColors } from '@/lib/avatar';
+import CardHeader from '@/components/primitives/CardHeader';
+import StatusBadge from '@/components/primitives/StatusBadge';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const STATS_NAME_KEY = 'badminton_stats_preview_name';
-const ACCENT = 'var(--accent, #22c55e)';
 
 // Mirrors AttendanceCardLive: identity → stats preview-name → null. The preview
 // key lets admins/incognito browse someone else's stats without faking identity.
@@ -58,21 +59,7 @@ export default function PartnerFrequencyCard() {
 
   return (
     <div className="glass-card p-5 space-y-3">
-      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: ACCENT }}>groups</span>
-          <h3 className="bpm-h3 m-0">{t('partnersTitle')}</h3>
-        </div>
-        <span
-          style={{
-            fontSize: 10, padding: '3px 8px', borderRadius: 100, whiteSpace: 'nowrap',
-            fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase',
-            border: `1px solid ${ACCENT}`, color: ACCENT,
-          }}
-        >
-          Beta
-        </span>
-      </div>
+      <CardHeader icon="groups" title={t('partnersTitle')} badge={<StatusBadge>Beta</StatusBadge>} />
       {loadError ? (
         <p className="text-red-400 text-xs" role="alert">{t('partnersError')}</p>
       ) : partners === null ? null : partners.length === 0 ? (


### PR DESCRIPTION
## What

**Phase 1b** of the standardization program. Adds the `StatusBadge` primitive and migrates every Stats-tab badge/pill to it, finishing the header/badge consolidation started in #164.

### New primitive — `components/primitives/StatusBadge.tsx`
One shared uppercase pill, three variants:
- `accent` (default) — the **Live/Beta** pill (accent border+text, `--fs-2xs`, `3px 8px`)
- `muted` — the compact **"Coming soon"** tag (`--inner-card-border` / `--text-muted`, 9px)
- `phase` — the **skill-phase** tag; `tone="amber"` for the "switch" phase, else accent (`--fs-xs`, `3px 10px`)

Colors come from tokens (`--accent` / `--accent-amber` / `--inner-card-border` / `--text-muted`), radius from `--radius-pill`.

### Migrated (retires ~6 hand-rolled inline pills)
- `StatsPlaceholder` **LiveCard** → `CardHeader` + `StatusBadge`; compact coming-soon tile → `StatusBadge variant="muted"`
- `PartnerFrequencyCard` header → `CardHeader` + `StatusBadge` (drops now-unused `ACCENT`)
- `StreakSummaryCard` "Your read" header → `CardHeader` + `StatusBadge`
- `LevelCard` + `SkillTrendCard` phase tags → `StatusBadge variant="phase"`

All Stats-tab card headers and badges now flow through the two primitives. **Behavior-preserving.**

## Why
The status pill was hand-coded ~6–8× with drifting font size (9/10/11) and padding. A single variant-driven primitive removes the duplication and the drift.

## Verification
- `npm test` → **893 passed** (incl. new `__tests__/components/StatusBadge.test.tsx`); `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_