### PR TITLE
Add &lt;ErrorState&gt;/&lt;EmptyState&gt; primitives + migrate Stats (Phase 1c)

### DIFF
--- a/__tests__/components/ErrorEmptyState.test.tsx
+++ b/__tests__/components/ErrorEmptyState.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import ErrorState from '../../components/primitives/ErrorState';
+import EmptyState from '../../components/primitives/EmptyState';
+
+describe('ErrorState', () => {
+  afterEach(() => cleanup());
+
+  it('renders the message with role=alert (legible-fail contract)', () => {
+    render(<ErrorState message="Couldn't load" />);
+    const el = screen.getByRole('alert');
+    expect(el.textContent).toBe("Couldn't load");
+    expect(el.className).toContain('text-red-400');
+  });
+});
+
+describe('EmptyState', () => {
+  afterEach(() => cleanup());
+
+  it('renders muted body copy on the --fs-base token, not role=alert', () => {
+    render(<EmptyState>No data yet</EmptyState>);
+    const el = screen.getByText('No data yet');
+    expect(el.className).toContain('fs-base');
+    expect(el.getAttribute('style') ?? '').toContain('var(--text-muted)');
+    // empty != error: must not masquerade as an alert
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/components/primitives/EmptyState.tsx
+++ b/components/primitives/EmptyState.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Empty-state copy — the muted "nothing here yet" line shown when a card
+ * loaded successfully but has no data (distinct from <ErrorState>, which is
+ * a load failure). Standardizes the recurring inline
+ * `{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }` text on the
+ * `--fs-base` token.
+ *
+ * Replaces:  <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{msg}</p>
+ * With:      <EmptyState>{msg}</EmptyState>
+ */
+export interface EmptyStateProps {
+  children: ReactNode;
+}
+
+export default function EmptyState({ children }: EmptyStateProps) {
+  return (
+    <p className="fs-base" style={{ color: 'var(--text-muted)', margin: 0 }}>
+      {children}
+    </p>
+  );
+}

--- a/components/primitives/ErrorState.tsx
+++ b/components/primitives/ErrorState.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Load-error pill — the canonical "couldn't load" message. Centralizes the
+ * `role="alert"` contract and the error styling that was hand-written ~50×
+ * across stats/admin cards (the "legible-fail" rule: a failed fetch must NOT
+ * render as a confident empty state). One place to restyle the error tone.
+ *
+ * Replaces:  <p className="text-red-400 text-xs" role="alert">{msg}</p>
+ * With:      <ErrorState message={msg} />
+ */
+export interface ErrorStateProps {
+  message: ReactNode;
+}
+
+export default function ErrorState({ message }: ErrorStateProps) {
+  return (
+    <p className="text-red-400 text-xs" role="alert" style={{ margin: 0 }}>
+      {message}
+    </p>
+  );
+}

--- a/components/stats/CheckInSheet.tsx
+++ b/components/stats/CheckInSheet.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
+import EmptyState from '@/components/primitives/EmptyState';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 import { SKILLS } from '@/lib/assessment';
 
@@ -164,7 +166,7 @@ export default function CheckInSheet({
                   </p>
                 </div>
               ) : (
-                <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('assess.noGames')}</p>
+                <EmptyState>{t('assess.noGames')}</EmptyState>
               )}
               <p style={{ fontSize: 14, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>{t('assess.ratePrompt')}</p>
               <button type="button" onClick={() => setStep(0)} className="cc-btn cc-btn-primary cc-btn-lg" style={{ width: '100%' }}>
@@ -222,8 +224,8 @@ export default function CheckInSheet({
           {step === total && (
             <div className="space-y-4">
               <p style={{ fontSize: 15, color: 'var(--text-primary)', margin: 0, lineHeight: 1.4 }}>{t('assess.reviewCount', { rated: ratedCount, total })}</p>
-              <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('assess.reviewPrompt')}</p>
-              {error && <p className="text-red-400 text-xs" role="alert">{error}</p>}
+              <EmptyState>{t('assess.reviewPrompt')}</EmptyState>
+              {error && <ErrorState message={error} />}
               <div style={{ display: 'flex', gap: 10 }}>
                 <button type="button" onClick={() => setStep(total - 1)} className="cc-btn cc-btn-ghost" style={{ flex: 1 }}>
                   {t('assess.back')}

--- a/components/stats/DrillsCard.tsx
+++ b/components/stats/DrillsCard.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
+import EmptyState from '@/components/primitives/EmptyState';
 import { getIdentity } from '@/lib/identity';
 import type { DrillPick } from '@/lib/drills';
 import CardHeader from '@/components/primitives/CardHeader';
@@ -80,7 +82,7 @@ export default function DrillsCard() {
   if (state.kind === 'error') {
     return (
       <Frame>
-        <p className="text-red-400 text-xs" role="alert">{t('drills.error')}</p>
+        <ErrorState message={t('drills.error')} />
       </Frame>
     );
   }
@@ -88,7 +90,7 @@ export default function DrillsCard() {
   if (state.kind === 'needsAuth') {
     return (
       <Frame>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('drills.needsAuth')}</p>
+        <EmptyState>{t('drills.needsAuth')}</EmptyState>
       </Frame>
     );
   }

--- a/components/stats/GameLoggerSheet.tsx
+++ b/components/stats/GameLoggerSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '../BottomSheet';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
@@ -105,7 +106,7 @@ export default function GameLoggerSheet({ you, sessionId, open, onClose, onLogge
                 <input inputMode="numeric" aria-label={t('theirScore')} value={scoreB} onChange={(e) => setScoreB(onlyDigits(e.target.value))} />
               </div>
             </div>
-            {error && <p className="text-red-400 text-xs" role="alert">{t('recError')}</p>}
+            {error && <ErrorState message={t('recError')} />}
             <button type="button" disabled={!valid || busy} onClick={submit} className="cc-btn cc-btn-primary cc-btn-lg" style={{ marginTop: 4 }}>
               {t('logGameSubmit')}
             </button>

--- a/components/stats/GearSheet.tsx
+++ b/components/stats/GearSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '../BottomSheet';
 import type { CatalogItem } from '@/lib/types';
 
@@ -97,8 +98,8 @@ export default function GearSheet({ name, open, onClose, onSaved }: Props) {
               maxLength={50}
               autoFocus
             />
-            {loadError && <p className="text-red-400 text-xs" role="alert">{t('recError')}</p>}
-            {saveError && <p className="text-red-400 text-xs" role="alert">{t('recError')}</p>}
+            {loadError && <ErrorState message={t('recError')} />}
+            {saveError && <ErrorState message={t('recError')} />}
             <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
               {matches.map((c) => (
                 <li key={c.id}>

--- a/components/stats/KudosReceivedCard.tsx
+++ b/components/stats/KudosReceivedCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
 import { getIdentity } from '@/lib/identity';
 import { KUDOS_TAGS, type KudosCount, type KudosTag } from '@/lib/kudos';
 import CardHeader from '@/components/primitives/CardHeader';
@@ -80,7 +81,7 @@ export default function KudosReceivedCard() {
   );
 
   if (state.kind === 'error') {
-    return <Frame><p className="text-red-400 text-xs" role="alert">{t('kudos.error')}</p></Frame>;
+    return <Frame><ErrorState message={t('kudos.error')} /></Frame>;
   }
   if (state.kind !== 'ok') return null;
 

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
+import EmptyState from '@/components/primitives/EmptyState';
 import { getIdentity } from '@/lib/identity';
 import type { CanonicalLevel } from '@/lib/level';
 import { isFlagOn } from '@/lib/flags';
@@ -95,7 +97,7 @@ export default function LevelCard() {
   if (state.kind === 'error') {
     return (
       <Frame>
-        <p className="text-red-400 text-xs" role="alert">{t('level.error')}</p>
+        <ErrorState message={t('level.error')} />
       </Frame>
     );
   }
@@ -103,7 +105,7 @@ export default function LevelCard() {
   if (state.kind === 'needsAuth') {
     return (
       <Frame>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('level.needsAuth')}</p>
+        <EmptyState>{t('level.needsAuth')}</EmptyState>
       </Frame>
     );
   }

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -12,6 +12,8 @@ import { useInsight } from '@/lib/useInsight';
 import InsightChip from '@/components/stats/InsightChip';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 import CheckInSheet from './CheckInSheet';
+import ErrorState from '@/components/primitives/ErrorState';
+import EmptyState from '@/components/primitives/EmptyState';
 import CardHeader from '@/components/primitives/CardHeader';
 import StatusBadge from '@/components/primitives/StatusBadge';
 
@@ -190,7 +192,7 @@ export default function SkillTrendCard() {
   if (loadError) {
     return (
       <div className="glass-card p-5">
-        <p className="text-red-400 text-xs" role="alert">{t('assess.error')}</p>
+        <ErrorState message={t('assess.error')} />
       </div>
     );
   }
@@ -219,7 +221,7 @@ export default function SkillTrendCard() {
     return (
       <>
         <Frame>
-          <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('assess.empty')}</p>
+          <EmptyState>{t('assess.empty')}</EmptyState>
           <button type="button" onClick={() => setCheckInOpen(true)} className="cc-btn cc-btn-primary cc-btn-lg" style={{ width: '100%' }}>
             {t('assess.rateSkills')}
           </button>

--- a/components/stats/cards/PartnerFrequencyCard.tsx
+++ b/components/stats/cards/PartnerFrequencyCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
 import { getIdentity } from '@/lib/identity';
 import { avatarColors } from '@/lib/avatar';
 import CardHeader from '@/components/primitives/CardHeader';
@@ -61,7 +62,7 @@ export default function PartnerFrequencyCard() {
     <div className="glass-card p-5 space-y-3">
       <CardHeader icon="groups" title={t('partnersTitle')} badge={<StatusBadge>Beta</StatusBadge>} />
       {loadError ? (
-        <p className="text-red-400 text-xs" role="alert">{t('partnersError')}</p>
+        <ErrorState message={t('partnersError')} />
       ) : partners === null ? null : partners.length === 0 ? (
         <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>{t('partnersEmpty')}</p>
       ) : (

--- a/components/stats/cards/RacketRecCard.tsx
+++ b/components/stats/cards/RacketRecCard.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import ErrorState from '@/components/primitives/ErrorState';
+import EmptyState from '@/components/primitives/EmptyState';
 import type { CatalogItem } from '@/lib/types';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
@@ -32,9 +34,9 @@ export default function RacketRecCard({ name }: { name: string }) {
     <div className="glass-card" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 112 }}>
       <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('weRecommend')}</p>
       {loadError ? (
-        <p className="text-red-400 text-xs" role="alert" style={{ margin: 0 }}>{t('recError')}</p>
+        <ErrorState message={t('recError')} />
       ) : !loaded ? null : !item ? (
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{t('recEmpty')}</p>
+        <EmptyState>{t('recEmpty')}</EmptyState>
       ) : (
         <p style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, margin: 0, lineHeight: 1.25 }}>
           {item.brand} {item.model}


### PR DESCRIPTION
## What

**Phase 1c** of the standardization program. Adds the two "legible-fail" state primitives and migrates the Stats-tab error/empty sites.

### New primitives
- **`ErrorState`** (`components/primitives/ErrorState.tsx`) — the `role="alert"` red load-error pill. Centralizes the alert contract + error tone (was hand-written ~50× across the app).
- **`EmptyState`** (`components/primitives/EmptyState.tsx`) — the muted "no data yet" line, now on the `--fs-base` token (was inline `fontSize: 13`). Kept **distinct** from `ErrorState` so a loaded-empty card never masquerades as a load failure (the CLAUDE.md lying-empty-state rule).

### Migrated (Stats)
Error pills: `KudosReceivedCard`, `LevelCard`, `PartnerFrequencyCard`, `DrillsCard`, `SkillTrendCard`, `RacketRecCard`, `GearSheet`, `CheckInSheet`, `GameLoggerSheet`. Empty texts: `LevelCard`, `DrillsCard`, `SkillTrendCard`, `RacketRecCard`, `CheckInSheet`.

Intentionally left: the **muted-tone** "couldn't load" lines in `AttendanceCardLive`/`StreakSummaryCard` (softer tone, not the red alert) and the `RacketRow` in-`<button>` `<span>` (a `<p>` is invalid inside `<button>`). **Behavior-preserving.**

## Why
The legible-fail rule was culture-driven (each card re-implemented the alert pill, drifting on color: Tailwind vs inline `var()` vs hex). Two primitives make it component-driven and one-place-restylable; admin sweeps follow in a later phase.

## Verification
- `npm test` → **895 passed** (incl. new `__tests__/components/ErrorEmptyState.test.tsx`); `npm run lint` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_