### PR TITLE
Add design-system canary test (standardization Phase 2)

### DIFF
--- a/__tests__/design-canary.test.ts
+++ b/__tests__/design-canary.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Design-system canary — mirrors __tests__/i18n/canary-strings.test.tsx but for
+ * the CSS token/class contract. globals.css is the single source of truth for
+ * design tokens, and stable + next share it, so a renamed/deleted token is a
+ * silent, app-wide regression (and a schema-rule violation). This test pins the
+ * canonical tokens + utility classes the shared primitives and the --fs-/--space-
+ * scales depend on. If you intentionally rename one, update this list in the
+ * same commit.
+ */
+const css = readFileSync(join(process.cwd(), 'app', 'globals.css'), 'utf8');
+
+// Tokens that must be defined (as `--name:`), grouped by role.
+const REQUIRED_TOKENS = [
+  // color
+  '--accent', '--accent-amber', '--text-primary', '--text-secondary', '--text-muted',
+  // glass surfaces
+  '--glass-bg', '--glass-border', '--glass-blur', '--inner-card-border',
+  // radii ladder
+  '--radius-xs', '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl', '--radius-pill',
+  // type-size scale (standardization Phase 0)
+  '--fs-2xs', '--fs-xs', '--fs-sm', '--fs-base', '--fs-md', '--fs-lg',
+  '--lh-tight', '--lh-snug', '--lh-normal',
+  // inline spacing scale (Phase 0)
+  '--space-1', '--space-2', '--space-3', '--space-4', '--space-5', '--space-6',
+];
+
+// Utility/surface classes the primitives + cards rely on.
+const REQUIRED_CLASSES = [
+  '.glass-card', '.glass-card-soft', '.bpm-h1', '.bpm-h2', '.bpm-h3',
+  '.section-label', '.fs-2xs', '.fs-sm', '.fs-base', '.cc-btn', '.segment-control',
+];
+
+describe('design-system canary: globals.css token/class contract', () => {
+  it.each(REQUIRED_TOKENS)('defines token %s', (token) => {
+    expect(css).toContain(`${token}:`);
+  });
+
+  it.each(REQUIRED_CLASSES)('defines class %s', (cls) => {
+    expect(css).toContain(cls);
+  });
+
+  it('pins the canonical --fs scale values (a re-scale must update this test)', () => {
+    expect(css).toContain('--fs-2xs: 10px');
+    expect(css).toContain('--fs-sm: 12px');
+    expect(css).toContain('--fs-base: 13px');
+    expect(css).toContain('--fs-lg: 16px');
+  });
+
+  it('caps the rectangular radius ladder at 16px (corner-radii ladder rule)', () => {
+    expect(css).toContain('--radius-xl: 16px');
+    expect(css).toContain('--radius-pill: 100px');
+  });
+});


### PR DESCRIPTION
## What

**Phase 2** of the standardization program (guardrail #1 of the chosen three). Adds a **design-system canary test** mirroring `__tests__/i18n/canary-strings.test.tsx`, but for the CSS token/class contract.

`__tests__/design-canary.test.ts` asserts:
- the canonical **tokens** are defined in `globals.css` — color (`--accent`, `--text-*`), glass (`--glass-bg/border/blur`, `--inner-card-border`), the radii ladder, and the Phase-0 `--fs-*` / `--lh-*` / `--space-*` scales;
- the **utility/surface classes** the primitives rely on exist (`.glass-card`, `.bpm-h3`, `.section-label`, `.fs-*`, `.cc-btn`, `.segment-control`);
- the `--fs-*` scale **values** are pinned (a re-scale must update the test);
- the rectangular radius ladder is capped at **16px**.

## Why
`globals.css` is the single source of truth and is shared by **both** `bpm-stable` and `bpm-next`, so a renamed or deleted token is a silent, app-wide regression (and a schema-rule violation). This pins the contract in CI — if a token is intentionally renamed, the list must be updated in the same commit.

## Verification
- `npm test` → **938 passed** (the canary adds 43 assertions); `npm run lint` → 0 errors.
- Pure test addition — no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_