### PR TITLE
Add ESLint design-token guardrail (warn) (standardization Phase 2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,31 @@ const config = [
       ],
     },
   },
+  {
+    // Design-token guardrail (standardization Phase 2). Steers inline styles
+    // toward the globals.css tokens instead of hand-typed values. Scoped to
+    // app/components/lib source only (not tests). Shipped as `warn` first —
+    // there's an existing backlog of ~230 hardcoded colors / ~74 raw radii;
+    // the Phase-3 sweeps clear them area-by-area, after which this tightens
+    // to `error`. Note: the `var(--accent, #22c55e)` fallback form is NOT
+    // flagged — the hex there is inside the var() string, not a bare literal.
+    files: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}', 'lib/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-syntax': [
+        'warn',
+        {
+          selector: 'Literal[value=/^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/]',
+          message:
+            'Hardcoded hex color — use a design token from globals.css (var(--accent), --text-*, --sev-*, etc.) instead of a bare hex literal.',
+        },
+        {
+          selector: "Property[key.name='borderRadius'] > Literal[raw=/^[0-9]/]",
+          message:
+            'Raw border-radius — use the radii ladder token: var(--radius-xs|sm|md|lg|xl|pill).',
+        },
+      ],
+    },
+  },
 ];
 
 export default config;


### PR DESCRIPTION
## What

**Phase 2** guardrail #2 of 3. Adds an ESLint rule that steers inline styles toward the `globals.css` design tokens.

`eslint.config.mjs` gains a `no-restricted-syntax` block (scoped to `app/`, `components/`, `lib/` — not tests):
- **hardcoded hex color literals** (`'#ef4444'`) → "use a design token"
- **raw inline `borderRadius` numbers** (`borderRadius: 12`) → "use `var(--radius-*)`"

The `var(--accent, #22c55e)` **fallback form is not flagged** — the hex there lives inside the `var()` string, not as a bare literal, so token-correct code stays clean.

## Why / rollout
Nothing enforced token use, so drift re-accumulated after cleanups. Shipped as **`warn`** because there's an existing backlog (**~211 hits surfaced**, on top of the 38 pre-existing react-compiler warnings). `eslint .` exits 0 on warnings, so **CI stays green** (0 errors). The Phase-3 token sweeps clear the backlog area-by-area; once an area is clean, this rule tightens to `error` for that path (Phase 4 flips it globally).

## Verification
- `npm run lint` → **249 problems, 0 errors, 249 warnings**; `eslint .` exit code **0**.
- `npm test` → **938 passed** (rule change doesn't affect runtime/tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_