### PR TITLE
Wire shared primitives into the /design styleguide (standardization Phase 2)

### DIFF
--- a/app/design/components/page.tsx
+++ b/app/design/components/page.tsx
@@ -4,6 +4,11 @@
  * and color so consumers call them bare (no Tailwind companions needed).
  */
 
+import CardHeader from '@/components/primitives/CardHeader';
+import StatusBadge from '@/components/primitives/StatusBadge';
+import ErrorState from '@/components/primitives/ErrorState';
+import EmptyState from '@/components/primitives/EmptyState';
+
 function Row({ title, caption, children }: { title: string; caption?: string; children: React.ReactNode }) {
   return (
     <section style={{ display: 'grid', gap: '0.5rem' }}>
@@ -233,6 +238,24 @@ export default function ComponentsPage() {
             </div>
           ))}
         </div>
+      </Row>
+
+      {/* ── Standardization primitives (live components, not specimens) ──── */}
+      <Row title="STANDARDIZATION PRIMITIVES" caption="The shared composition primitives from components/primitives/. These render the real components, so this is the canonical visual reference — CardHeader (two-tier header spec), StatusBadge (accent/muted/phase), ErrorState + EmptyState (legible-fail).">
+        <CardHeader
+          icon="trending_up"
+          title="Card header"
+          subtitle="icon + bpm-h3 title + --fs-sm subtitle"
+          badge={<StatusBadge>Beta</StatusBadge>}
+        />
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+          <StatusBadge>Live</StatusBadge>
+          <StatusBadge variant="muted">Coming soon</StatusBadge>
+          <StatusBadge variant="phase" tone="accent">Refine</StatusBadge>
+          <StatusBadge variant="phase" tone="amber">Switch</StatusBadge>
+        </div>
+        <ErrorState message="Couldn't load — refresh to try again" />
+        <EmptyState>No data yet</EmptyState>
       </Row>
     </main>
   );


### PR DESCRIPTION
## What

**Phase 2** guardrail #3 of 3 — the **living styleguide**. Adds a "Standardization primitives" section to `app/design/components` that renders the **real** shared primitives (not static specimens):
- `CardHeader` (two-tier header spec)
- `StatusBadge` — all variants (`accent` / `muted` / `phase` accent+amber)
- `ErrorState` + `EmptyState` (legible-fail)

`/bpm/design` is flag-gated behind `NEXT_PUBLIC_FLAG_DESIGN_PREVIEW` and not linked from the bottom nav, so this is an internal reference surface only.

## Why
Gives the primitives one canonical place to view every variant together — for review, design QA, and future visual-regression. Pairs with the canary test (contract) and the ESLint rule (gate) to complete the chosen guardrail set.

## Verification
- `npm run lint` → **0 errors** (249 warnings, none new — the showcase uses only tokens).
- `npm test` → **938 passed** (`design-preview-route` test unaffected — no route/registry change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_