### PR TITLE
Sweep borderRadius:100 → var(--radius-pill) (standardization Phase 3)

### DIFF
--- a/app/design/stats/page.tsx
+++ b/app/design/stats/page.tsx
@@ -28,7 +28,7 @@ function Chip({ color, children }: { color: string; children: React.ReactNode })
       style={{
         fontSize: 10,
         padding: '3px 8px',
-        borderRadius: 100,
+        borderRadius: 'var(--radius-pill)',
         whiteSpace: 'nowrap',
         fontWeight: 600,
         letterSpacing: '0.04em',
@@ -143,8 +143,8 @@ function PartnerBars({ data }: { data: { name: string; count: number }[] }) {
       {data.map((d) => (
         <div key={d.name} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ width: 64, fontSize: 12, color: PRIMARY }}>{d.name}</span>
-          <div style={{ flex: 1, height: 10, borderRadius: 100, background: 'var(--inner-card-bg)', overflow: 'hidden' }}>
-            <div style={{ width: `${(d.count / max) * 100}%`, height: '100%', background: ACCENT, borderRadius: 100 }} />
+          <div style={{ flex: 1, height: 10, borderRadius: 'var(--radius-pill)', background: 'var(--inner-card-bg)', overflow: 'hidden' }}>
+            <div style={{ width: `${(d.count / max) * 100}%`, height: '100%', background: ACCENT, borderRadius: 'var(--radius-pill)' }} />
           </div>
           <span style={{ fontFamily: 'var(--font-mono)', fontSize: 11, color: MUTED, minWidth: 24, textAlign: 'right' }}>
             {d.count}
@@ -505,7 +505,7 @@ function SessionRoster() {
           style={{
             fontSize: 11,
             padding: '4px 10px',
-            borderRadius: 100,
+            borderRadius: 'var(--radius-pill)',
             background: 'var(--inner-card-bg)',
             border: '1px solid var(--inner-card-border)',
             color: PRIMARY,
@@ -521,7 +521,7 @@ function SessionRoster() {
 function PaymentLoopClose() {
   return (
     <div style={{ display: 'grid', gap: 6 }}>
-      <div style={{ display: 'flex', gap: 2, height: 8, borderRadius: 100, overflow: 'hidden' }}>
+      <div style={{ display: 'flex', gap: 2, height: 8, borderRadius: 'var(--radius-pill)', overflow: 'hidden' }}>
         <div style={{ flex: 10, background: ACCENT }} />
         <div style={{ flex: 2, background: 'var(--inner-card-border)' }} />
       </div>

--- a/components/SkillsTab.tsx
+++ b/components/SkillsTab.tsx
@@ -246,7 +246,7 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
             style={{
               fontSize: 10,
               padding: '2px 8px',
-              borderRadius: 100,
+              borderRadius: 'var(--radius-pill)',
               fontWeight: 600,
               letterSpacing: '0.04em',
               textTransform: 'uppercase',

--- a/components/stats/CheckInSheet.tsx
+++ b/components/stats/CheckInSheet.tsx
@@ -145,7 +145,7 @@ export default function CheckInSheet({
           {/* Progress track — only during the quiz steps. */}
           {skill && (
             <div style={{ marginTop: 12 }}>
-              <div className="cc-progress-track" style={{ height: 4, borderRadius: 100, overflow: 'hidden' }}>
+              <div className="cc-progress-track" style={{ height: 4, borderRadius: 'var(--radius-pill)', overflow: 'hidden' }}>
                 <div style={{ width: `${((step + 1) / total) * 100}%`, height: '100%', background: 'var(--accent)', transition: 'width 180ms var(--ease-out-quart, ease-out)' }} />
               </div>
               <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '6px 0 0' }}>{t('assess.step', { n: step + 1, total })}</p>

--- a/components/stats/InsightChip.tsx
+++ b/components/stats/InsightChip.tsx
@@ -50,7 +50,7 @@ export default function InsightChip({ headline, support, kind }: CardSlice) {
         style={{
           fontSize: 9,
           padding: '2px 6px',
-          borderRadius: 100,
+          borderRadius: 'var(--radius-pill)',
           whiteSpace: 'nowrap',
           fontWeight: 600,
           letterSpacing: '0.04em',

--- a/components/stats/KudosReceivedCard.tsx
+++ b/components/stats/KudosReceivedCard.tsx
@@ -92,7 +92,7 @@ export default function KudosReceivedCard() {
           const count = state.kudos.find((k) => k.tag === tag)?.count ?? 0;
           return (
             <li key={tag} style={{
-              display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 100,
+              display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 'var(--radius-pill)',
               border: '1px solid var(--border, rgba(255,255,255,0.12))', fontSize: 13, color: 'var(--text-secondary)',
             }}>
               <span aria-hidden="true">{TAG_EMOJI[tag]}</span>

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -143,7 +143,7 @@ export default function LevelCard() {
       <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         <span
           aria-hidden="true"
-          style={{ width: 8, height: 8, borderRadius: 100, background: CONF_COLOR[level.confidence], flexShrink: 0 }}
+          style={{ width: 8, height: 8, borderRadius: 'var(--radius-pill)', background: CONF_COLOR[level.confidence], flexShrink: 0 }}
         />
         <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
           {t(`level.confidence.${level.confidence}`)}

--- a/components/stats/SummaryGreeting.tsx
+++ b/components/stats/SummaryGreeting.tsx
@@ -31,7 +31,7 @@ export default function SummaryGreeting() {
         style={{
           fontSize: 10,
           padding: '3px 8px',
-          borderRadius: 100,
+          borderRadius: 'var(--radius-pill)',
           whiteSpace: 'nowrap',
           fontWeight: 600,
           letterSpacing: '0.04em',

--- a/components/stats/skeletons/PartnerChips.tsx
+++ b/components/stats/skeletons/PartnerChips.tsx
@@ -32,7 +32,7 @@ export default function PartnerChips() {
           marginLeft: 8,
           height: 6,
           flex: 1,
-          borderRadius: 100,
+          borderRadius: 'var(--radius-pill)',
           background: 'linear-gradient(90deg, color-mix(in oklab, var(--accent, #22c55e) 55%, transparent), transparent)',
         }}
       />


### PR DESCRIPTION
## What

First **Phase 3** token sweep — the unambiguous pill case. Replaces every inline `borderRadius: 100` with `var(--radius-pill)` across 8 files (stats cards/sheets, `SkillsTab`, the `design/stats` specimen).

`100px` **is** the pill token, so this is a mechanical, behavior-identical swap — no per-value judgment, no recharts/SVG colors involved.

## Why
Advances the Phase-3 goal of adopting the `globals.css` tokens so the ESLint guardrail can eventually tighten to `error`. Clears **12** of the radius warnings (249 → 237).

## Scope / what's next
- Remaining raw-radius warnings are **non-pill** values (`8/10/12/16` → `--radius-xs..xl`) — those map per-value and come in follow-up sweeps.
- **Hex-color** sweeps need tokenize-vs-`eslint-disable` judgment (some hex are legit recharts/SVG colors that can't take `var()`) — also separate follow-ups.

Note on **Phase 1d (`ListRow`)**: deliberately **not** extracted — investigation showed list rows are genuinely bespoke (avatars / score buttons / chips / multi-line drill items), so a shared primitive would be a low-value abstraction. The high-value primitives (CardHeader, StatusBadge, ErrorState, EmptyState) are done.

## Verification
- `npm run lint` → **0 errors** (237 warnings, down from 249); `npm test` → **938 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_