### PR TITLE
Add &lt;ListRow&gt; primitive + migrate skill rows (standardization Phase 1d)

### DIFF
--- a/__tests__/components/ListRow.test.tsx
+++ b/__tests__/components/ListRow.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import ListRow from '../../components/primitives/ListRow';
+
+describe('ListRow', () => {
+  afterEach(() => cleanup());
+
+  it('renders title, subtitle, leading and trailing slots', () => {
+    render(
+      <ListRow
+        leading={<span>L</span>}
+        title="Row title"
+        subtitle="Row subtitle"
+        trailing={<span>T</span>}
+      />,
+    );
+    expect(screen.getByText('Row title')).toBeTruthy();
+    expect(screen.getByText('Row subtitle')).toBeTruthy();
+    expect(screen.getByText('L')).toBeTruthy();
+    expect(screen.getByText('T')).toBeTruthy();
+  });
+
+  it('is a plain div (no button) when no onClick', () => {
+    render(<ListRow title="static" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders as a tappable cc-mini-card button when onClick is given', () => {
+    const onClick = vi.fn();
+    render(<ListRow title="tap me" onClick={onClick} ariaLabel="tap me" />);
+    const btn = screen.getByRole('button', { name: 'tap me' });
+    expect(btn.className).toContain('cc-mini-card');
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/components/primitives/ListRow.tsx
+++ b/components/primitives/ListRow.tsx
@@ -1,0 +1,80 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * List row — the shared structural layout for the many list-item rows across
+ * the app (skill rows, kudos rows, partner rows, etc.): an optional leading
+ * slot + title (+ subtitle) on the left, optional trailing slot on the right,
+ * justified. Renders as a `cc-mini-card` <button> when `onClick` is given,
+ * else a plain <div>.
+ *
+ * Deliberately STRUCTURAL, not opinionated about typography: the rows it
+ * replaces have legitimately different text styling (a score readout vs a
+ * partner name vs a kudos tag), so `title`/`subtitle`/`trailing` take nodes
+ * and the caller styles the text. This consolidates the repeated flex +
+ * cc-mini-card + gap boilerplate without flattening intentional differences
+ * (the reason a single fully-styled row primitive was the wrong call). Spacing
+ * uses the --space-* scale.
+ *
+ *   <ListRow
+ *     onClick={() => onPick(key)}
+ *     title={<span style={{ fontSize: 'var(--fs-sm)' }}>{label}</span>}
+ *     trailing={<Score value={v} />}
+ *   />
+ */
+export interface ListRowProps {
+  leading?: ReactNode;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  trailing?: ReactNode;
+  /** When set, the row renders as a tappable cc-mini-card button. */
+  onClick?: () => void;
+  ariaLabel?: string;
+}
+
+const LAYOUT: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 'var(--space-3)',
+  width: '100%',
+  textAlign: 'left',
+};
+
+export default function ListRow({ leading, title, subtitle, trailing, onClick, ariaLabel }: ListRowProps) {
+  const lead = (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', minWidth: 0, flex: 1 }}>
+      {leading}
+      {subtitle != null ? (
+        <div style={{ minWidth: 0 }}>
+          <div>{title}</div>
+          <div className="fs-sm" style={{ color: 'var(--text-muted)' }}>{subtitle}</div>
+        </div>
+      ) : (
+        title
+      )}
+    </div>
+  );
+
+  const body = (
+    <>
+      {lead}
+      {trailing}
+    </>
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={ariaLabel}
+        className="cc-mini-card"
+        style={{ ...LAYOUT, padding: 10, cursor: 'pointer' }}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return <div style={LAYOUT}>{body}</div>;
+}

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -15,6 +15,7 @@ import CheckInSheet from './CheckInSheet';
 import ErrorState from '@/components/primitives/ErrorState';
 import EmptyState from '@/components/primitives/EmptyState';
 import CardHeader from '@/components/primitives/CardHeader';
+import ListRow from '@/components/primitives/ListRow';
 import StatusBadge from '@/components/primitives/StatusBadge';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
@@ -366,19 +367,18 @@ function SkillList({
         const thenV = thenMap.get(r.skillKey);
         const nowV = nowMap.get(r.skillKey) ?? r.value;
         return (
-          <button
+          <ListRow
             key={r.skillKey}
-            type="button"
             onClick={() => onPick(r.skillKey)}
-            className="cc-mini-card"
-            style={{ width: '100%', padding: 10, textAlign: 'left', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, cursor: 'pointer' }}
-          >
-            <span style={{ fontSize: 12, color: 'var(--text-secondary)', lineHeight: 1.2 }}>{skill.label}</span>
-            <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 4, whiteSpace: 'nowrap' }}>
-              <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 700, color: 'var(--text-primary)' }}>{nowV}</span>
-              {thenV !== undefined && <Delta value={nowV - thenV} />}
-            </span>
-          </button>
+            ariaLabel={skill.label}
+            title={<span style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-secondary)', lineHeight: 1.2 }}>{skill.label}</span>}
+            trailing={
+              <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 4, whiteSpace: 'nowrap' }}>
+                <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-md)', fontWeight: 700, color: 'var(--text-primary)' }}>{nowV}</span>
+                {thenV !== undefined && <Delta value={nowV - thenV} />}
+              </span>
+            }
+          />
         );
       })}
     </div>


### PR DESCRIPTION
## What

**Phase 1d** — the final Phase-1 primitive, `components/primitives/ListRow.tsx`. Completes the primitive set (CardHeader, StatusBadge, ErrorState/EmptyState, ListRow).

`ListRow` is the shared **structural** row layout: optional `leading` + `title` (+ `subtitle`) on the left, optional `trailing` on the right, justified. Renders a `cc-mini-card` `<button>` when `onClick` is set, else a plain `<div>`. Spacing uses `--space-*`.

It's deliberately **not opinionated about typography** — the rows it replaces (score readout vs partner name vs kudos tag) have legitimately different text styling, so the slots take nodes and the caller styles the text. This consolidates the repeated flex + `cc-mini-card` boilerplate without flattening intentional differences (which is why a single fully-styled row primitive was the wrong shape — revised from the earlier "skip 1d" call to match the plan's flexible-base intent).

### Migrated
`SkillTrendCard`'s `SkillList` rows → `ListRow` (also tokenizes their inline font sizes to `--fs-sm` / `--fs-md`). Behavior-preserving. Other list rows (partner, kudos) can adopt it incrementally; the Drills row's multi-line column layout is genuinely different and stays as-is.

## Verification
- `npm test` → **941 passed** (incl. new `__tests__/components/ListRow.test.tsx`); `npm run lint` → **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_