### PR TITLE
Align Stats level/overall number size + insight body text

### DIFF
--- a/components/primitives/ListRow.tsx
+++ b/components/primitives/ListRow.tsx
@@ -69,7 +69,7 @@ export default function ListRow({ leading, title, subtitle, trailing, onClick, a
         onClick={onClick}
         aria-label={ariaLabel}
         className="cc-mini-card"
-        style={{ ...LAYOUT, padding: '10px 12px', borderRadius: 'var(--radius-lg)', cursor: 'pointer' }}
+        style={{ ...LAYOUT, padding: 12, borderRadius: 'var(--radius-lg)', cursor: 'pointer' }}
       >
         {body}
       </button>

--- a/components/primitives/ListRow.tsx
+++ b/components/primitives/ListRow.tsx
@@ -69,7 +69,7 @@ export default function ListRow({ leading, title, subtitle, trailing, onClick, a
         onClick={onClick}
         aria-label={ariaLabel}
         className="cc-mini-card"
-        style={{ ...LAYOUT, padding: 10, cursor: 'pointer' }}
+        style={{ ...LAYOUT, padding: '10px 12px', borderRadius: 'var(--radius-lg)', cursor: 'pointer' }}
       >
         {body}
       </button>

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -133,7 +133,7 @@ export default function LevelCard() {
           </StatusBadge>
         )}
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, marginLeft: 'auto' }}>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 30, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 20, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>
             {level.level.toFixed(1)}
           </span>
           <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>{t('level.ofFive')}</span>

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -298,7 +298,7 @@ export default function SkillTrendCard() {
           const nowV = latest.dimensionScores?.[dim] ?? null;
           const thenV = prev?.dimensionScores?.[dim] ?? null;
           return (
-            <div key={dim} className="cc-tile cc-tile-static" style={{ padding: 10, textAlign: 'center' }}>
+            <div key={dim} className="cc-tile cc-tile-static" style={{ padding: 12, borderRadius: 'var(--radius-lg)', textAlign: 'center' }}>
               <span style={{ fontSize: 10, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
                 {t(`assess.dim.${dim}`)}
               </span>

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -198,7 +198,7 @@ function InsightSection({ label, body, accent }: { label: string; body: string; 
       <p style={{ margin: 0, fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: accent ? ACCENT : MUTED }}>
         {label}
       </p>
-      <p style={{ margin: 0, fontSize: 14.5, lineHeight: 1.5, color: PRIMARY }}>{body}</p>
+      <p style={{ margin: 0, fontSize: 'var(--fs-base)', lineHeight: 1.5, color: PRIMARY }}>{body}</p>
     </div>
   );
 }


### PR DESCRIPTION
## What

Stats inner-content alignment to the Home/Sign-Up majority pattern (all values confirmed with you):

1. **`LevelCard`** level number **30px → 20px** — matches `SkillTrendCard`'s "Overall" number (both 20px mono/700).
2. **`StreakSummaryCard`** insight body **`14.5` → `var(--fs-base)` (13px)** — kills a non-token size; matches Home/Sign-Up body copy.
3. **Skill-list rows** (`ListRow`) — `cc-mini-card` had **no border-radius** (square corners). Now **12px (`var(--radius-lg)`)** + **12px padding**.
4. **`SkillTrendCard` dimension tiles** — overrode `cc-tile`'s 14px to **12px (`var(--radius-lg)`)** + **12px padding** (per-use; the admin-shared `cc-tile` class is untouched).

Rows + tiles now share the **12px / 12px** inner-surface spec (matching the design-system inner tier + Sign-Up player rows).

## Verification
- `npm run lint` → **0 errors** (`components/stats` enforced at `error`); `npm test` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb