### PR TITLE
Codify inner-content styling reference; conform Home + Stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ Canonical bundle mirrored at `docs/design-system/` (43 files — tokens, 28 spec
   - `<ErrorState message />` / `<EmptyState>` — the legible-fail surfaces: ErrorState is the `role="alert"` red load-error pill; EmptyState is muted "no data yet" body copy. Keep them distinct (a loaded-empty card must not look like a failure).
   - `<ListRow leading? title subtitle? trailing? onClick? />` — structural row layout (renders a `cc-mini-card` button when `onClick` is set). Not opinionated about text styling; slots take nodes.
   - The `<BottomSheet>` primitive (below) predates these and is the same idea for sheets.
+- **Inner-content reference** (the single "one true reference" for in-card content styling, derived from Home/Sign-Up and codified 2026-06-18): use these roles instead of hand-rolling raw Tailwind (`text-xl`/`text-sm`) or raw px. Stats/admin cards already conform via the primitives.
+  - **Card container**: `.glass-card` (16px radius). Content cards pad **20px** (`p-5`); compact tiles (date/location) pad **16px** (`p-4`).
+  - **Card title**: standard card-header title = `.bpm-h3` (18px) via `<CardHeader>`. The bare hero heading (Sign-Up's "I'm in this week") = `.bpm-h2` (20px) — use the same class in every state (don't fork into `text-xl font-bold text-green-400`).
+  - **Card subtitle**: `--fs-sm` (12px) via `<CardHeader subtitle>`.
+  - **Primary body copy** (announcement, AI insight, the card's main reading payload) = `--fs-md` (14px), `--text-primary`. **Muted/secondary** helper lines = 12px, `--text-muted`. (13px `--fs-base` is the generic body token but Home renders primary body at 14 — match it.)
+  - **Section label** (uppercase eyebrow) = `--fs-2xs` (10px) / `.section-label` (11px), 700 display.
+  - **Inner rows + stat tiles** (`ListRow`/`cc-mini-card`/`cc-tile` inside a card): **12px radius (`--radius-lg`) + 12px padding**. Override `cc-tile`'s 14px per-use, don't edit the shared admin class.
+  - **Inline stat/value numbers** = `--fs-md` (14px). The Stats tab's headline data numbers (Level, Overall, streak count) are a deliberate larger mono scale (20–22px) — Stats-specific, no Home equivalent.
 - **Token guardrail (ESLint)**: `eslint.config.mjs` flags bare hex color literals and raw inline `borderRadius` numbers (steer to `var(--accent)`/`--text-*`/`--sev-*` and `var(--radius-*)`). The `var(--accent, #22c55e)` fallback form is fine (hex is inside the `var()` string). App-wide it's `warn`; **per cleared area it tightens to `error`** (the `DESIGN_TOKEN_SELECTORS` override pattern — `components/stats` is already `error`). Genuinely-untokenizable values (recharts/SVG stroke-fill that can't read `var()`) carry an `// eslint-disable-next-line no-restricted-syntax` with a reason. The `design-canary` test (`__tests__/design-canary.test.ts`) pins the token/class contract.
 
 ## Coding Conventions

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -464,13 +464,13 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         ) : isSignupClosed && !effectiveIsSignedUp && !isWaitlisted ? (
           /* ── State: Sign-ups opening soon ── */
           <div className="space-y-4">
-            <p className="text-xl font-bold text-green-400">{t('signup.heading')}</p>
+            <p className="bpm-h2">{t('signup.heading')}</p>
             <StatusBanner tone="warn" icon="watch_later" title={tStates('openingSoonTitle')} body={tStates('openingSoonBody')} />
           </div>
         ) : isDeadlinePast && !effectiveIsSignedUp && !isWaitlisted ? (
           /* ── State: Deadline passed ── */
           <div className="space-y-4">
-            <p className="text-xl font-bold text-green-400">{t('signup.heading')}</p>
+            <p className="bpm-h2">{t('signup.heading')}</p>
             <StatusBanner
               tone="warn"
               icon="lock_clock"

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -198,7 +198,7 @@ function InsightSection({ label, body, accent }: { label: string; body: string; 
       <p style={{ margin: 0, fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: accent ? ACCENT : MUTED }}>
         {label}
       </p>
-      <p style={{ margin: 0, fontSize: 'var(--fs-base)', lineHeight: 1.5, color: PRIMARY }}>{body}</p>
+      <p style={{ margin: 0, fontSize: 'var(--fs-md)', lineHeight: 1.5, color: PRIMARY }}>{body}</p>
     </div>
   );
 }


### PR DESCRIPTION
Replaces #176 (which was cut from a pre-squash branch tip and hit a merge conflict after #175 landed). This branch is cut from current `main`, so the net diff is exactly the three intended files.

## Why

After the Stats↔Home alignment (#175), the ask was: a quick consistency pass on **Home/Sign-Up themselves** so there's *one true reference*, then conform Stats to it.

## Changes

1. **HomeTab sign-up heading** — `signup.heading` rendered via `.bpm-h2` in 5 states but hand-rolled `text-xl font-bold text-green-400` in 2 (opening-soon, deadline-passed). Same heading, off-token color → unified to `.bpm-h2`.
2. **StreakSummaryCard insight body** — the card's primary reading payload → `--fs-md` (14px), matching Home's announcement body. (Supersedes the interim 13px.)
3. **CLAUDE.md** — documents the inner-content reference table (container padding, title/subtitle/body roles, 12px rows+tiles, stat scales) so the contract is durable.

The row/tile 12px work is already on `main` from #175; Stats conforms to the rest via the shared primitives.

## Verification
`npm run lint` → 0 errors · `npm test` → 941 passed · `npm run build` → green (all run locally on this tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_