### PR TITLE
Fix Report-a-problem icon rendering as text; disable zoom on the web app

### DIFF
--- a/__tests__/icon-subset.test.ts
+++ b/__tests__/icon-subset.test.ts
@@ -54,4 +54,34 @@ describe('Material Symbols icon subset', () => {
           '\nAdd the glyph names to the URL or they will render as raw text.';
     expect(missing, message).toEqual([]);
   });
+
+  // Data-driven icons (`icon: 'flag'` in a SettingsList/rows array) don't match
+  // the literal-span regex above, so a missing glyph there renders as raw text
+  // with no test failure — exactly how the "Report a problem" flag icon shipped
+  // broken. Catch those `icon: '<glyph>'` string literals too.
+  it('every data-driven icon: \'<glyph>\' prop is in the subset URL', () => {
+    const subset = extractSubset();
+    const files = SCAN_DIRS.flatMap(walk);
+    const missing: { file: string; glyph: string }[] = [];
+
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      const re = /\bicon:\s*'([a-z0-9_]+)'/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(src))) {
+        const glyph = m[1];
+        if (!subset.has(glyph)) {
+          missing.push({ file: file.replace(ROOT + '/', ''), glyph });
+        }
+      }
+    }
+
+    const message =
+      missing.length === 0
+        ? ''
+        : 'Missing data-driven icon glyphs in app/layout.tsx icon_names URL:\n' +
+          missing.map((x) => '  - "' + x.glyph + '" used in ' + x.file).join('\n') +
+          '\nAdd the glyph names to the URL or they will render as raw text.';
+    expect(missing, message).toEqual([]);
+  });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -361,6 +361,10 @@ html,
 body {
   height: 100%;
   overflow-x: hidden;
+  /* Disable double-tap-to-zoom (and the legacy 300ms tap delay) — pairs with
+     the viewport scale cap in layout.tsx to make the iOS web app feel native.
+     `manipulation` still permits scroll + panning, just not the zoom gestures. */
+  touch-action: manipulation;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -78,9 +78,13 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  // Allow user pinch-zoom — disabling it is a WCAG 1.4.4 violation and was
-  // flagged by Lighthouse a11y. Low-vision users rely on zoom; the tradeoff
-  // (occasional accidental zoom on form inputs) is worth the access.
+  // Pinch / double-tap / input-focus zoom disabled by product decision — the
+  // accidental-zoom jank on the saved-to-homescreen iOS web app outweighed the
+  // benefit here. NOTE: this is a deliberate WCAG 1.4.4 tradeoff (Lighthouse
+  // a11y will flag it). `touch-action: manipulation` in globals.css removes the
+  // double-tap zoom + 300ms tap delay; the scale cap stops pinch + input zoom.
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -98,7 +102,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
             the dynamic icon_names subset, so opt this one out of the rule. */}
         {/* eslint-disable-next-line @next/next/no-page-custom-font */}
         <link
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=add,add_shopping_cart,admin_panel_settings,arrow_back,arrow_forward,article_person,auto_fix_high,bar_chart,bolt,calendar_today,campaign,celebration,check_circle,chevron_left,chevron_right,close,dark_mode,delete,delete_forever,delete_outline,delete_sweep,download,edit,emoji_events,error,error_outline,event,expand_less,expand_more,fact_check,fitness_center,format_list_bulleted,format_list_numbered,group,group_add,groups,help_outline,home,hourglass_empty,hourglass_top,how_to_reg,image,inventory_2,key,light_mode,local_fire_department,lock,lock_clock,logout,more_vert,paid,payments,person,person_add,person_remove,radio_button_unchecked,receipt_long,remove,request_quote,restore,schedule,school,science,search,send,share,shield,sports_tennis,star,subdirectory_arrow_left,translate,trending_up,verified,visibility,volunteer_activism,warning,watch_later&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=add,add_shopping_cart,admin_panel_settings,arrow_back,arrow_forward,article_person,auto_fix_high,bar_chart,bolt,calendar_today,campaign,celebration,check_circle,chevron_left,chevron_right,close,dark_mode,delete,delete_forever,delete_outline,delete_sweep,download,edit,emoji_events,error,error_outline,event,expand_less,expand_more,fact_check,fitness_center,flag,format_list_bulleted,format_list_numbered,group,group_add,groups,help_outline,home,hourglass_empty,hourglass_top,how_to_reg,image,inventory_2,key,light_mode,local_fire_department,lock,lock_clock,logout,more_vert,paid,payments,person,person_add,person_remove,radio_button_unchecked,receipt_long,remove,request_quote,restore,schedule,school,science,search,send,share,shield,sports_tennis,star,subdirectory_arrow_left,translate,trending_up,verified,visibility,volunteer_activism,warning,watch_later&display=swap"
           rel="stylesheet"
         />
       </head>


### PR DESCRIPTION
Two small fixes.

## 1 · "Report a problem" icon rendered as the text `flag`
The Profile settings row passed `icon: 'flag'` as a **data prop** to `SettingsList`, but `flag` wasn't in the Material Symbols subset URL in `app/layout.tsx` — so it rendered as the raw string "flag" instead of the icon.

- Added `flag` to the subset.
- **Extended the icon-subset test** to also scan data-driven `icon: '<glyph>'` props. The existing test only matched literal `<span className="material-icons">…</span>` usages, so this entire class of icon (settings rows, menus) was unchecked — which is how it shipped broken. Audited all such props; `flag` was the only missing one.

## 2 · Disable zoom on the iOS web app
Per request — accidental pinch / double-tap / input-focus zoom on the saved-to-homescreen app was janky.

- Viewport: `maximumScale: 1` + `userScalable: false`.
- `touch-action: manipulation` on `body` to drop double-tap zoom and the legacy 300ms tap delay (still allows scroll/pan).
- ⚠️ This is a **deliberate WCAG 1.4.4 tradeoff** — the prior viewport comment intentionally kept zoom on for low-vision accessibility and noted Lighthouse would flag disabling it. Overriding that per your call; updated the comment to record the decision. (On iOS, "disable pinch only" isn't cleanly separable from input-zoom, so this behaves as a full zoom-disable, as discussed.)

## Verification
- `npm test` — **964 passing** (icon-subset test now has 2 cases: literal spans + data-driven props).
- `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeGwYYBp9aHRzNULEHRRtV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeGwYYBp9aHRzNULEHRRtV)_