### PR TITLE
Skeleton the remaining silent-null Stats cards while loading

### DIFF
--- a/components/stats/GameLoggerCard.tsx
+++ b/components/stats/GameLoggerCard.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { getIdentity } from '@/lib/identity';
 import GameLoggerSheet from './GameLoggerSheet';
 import CardHeader from '@/components/primitives/CardHeader';
+import CardSkeleton from '@/components/primitives/CardSkeleton';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 const STATS_NAME_KEY = 'badminton_stats_preview_name';
@@ -66,7 +67,9 @@ export default function GameLoggerCard() {
     return () => { live = false; };
   }, [identResolved, activeName]);
 
-  if (status === 'loading' || status === 'no-identity') return null;
+  if (status === 'no-identity') return null;
+  // Loading: reserve the card's footprint instead of rendering blank.
+  if (status === 'loading') return <CardSkeleton height={120} />;
 
   if (status === 'error') {
     return (

--- a/components/stats/RacketRow.tsx
+++ b/components/stats/RacketRow.tsx
@@ -70,7 +70,9 @@ export default function RacketRow() {
           <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('yourRacket')}</p>
           {loadError ? (
             <span className="text-red-400 text-xs" role="alert">{t('recError')}</span>
-          ) : !loaded ? null : racketLabel ? (
+          ) : !loaded ? (
+            <span className="shimmer-line rounded-lg" style={{ height: 15, width: '70%' }} aria-hidden="true" />
+          ) : racketLabel ? (
             <span style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, lineHeight: 1.25 }}>{racketLabel}</span>
           ) : (
             <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>{t('noRacketYet')}</span>

--- a/components/stats/cards/PartnerFrequencyCard.tsx
+++ b/components/stats/cards/PartnerFrequencyCard.tsx
@@ -63,7 +63,16 @@ export default function PartnerFrequencyCard() {
       <CardHeader icon="groups" title={t('partnersTitle')} badge={<StatusBadge>Beta</StatusBadge>} />
       {loadError ? (
         <ErrorState message={t('partnersError')} />
-      ) : partners === null ? null : partners.length === 0 ? (
+      ) : partners === null ? (
+        // Loading: shimmer the avatar-row body so the card reserves its shape.
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }} aria-hidden="true">
+          <div className="shimmer-line" style={{ width: 46, height: 46, borderRadius: '50%' }} />
+          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <div className="shimmer-line rounded-lg" style={{ height: 11, width: '40%' }} />
+            <div className="shimmer-line rounded-lg" style={{ height: 16, width: '65%' }} />
+          </div>
+        </div>
+      ) : partners.length === 0 ? (
         <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>{t('partnersEmpty')}</p>
       ) : (
         // Hero the #1 partner — in doubles your most-frequent partner is the

--- a/components/stats/cards/RacketRecCard.tsx
+++ b/components/stats/cards/RacketRecCard.tsx
@@ -35,7 +35,9 @@ export default function RacketRecCard({ name }: { name: string }) {
       <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('weRecommend')}</p>
       {loadError ? (
         <ErrorState message={t('recError')} />
-      ) : !loaded ? null : !item ? (
+      ) : !loaded ? (
+        <span className="shimmer-line rounded-lg" style={{ height: 15, width: '70%' }} aria-hidden="true" />
+      ) : !item ? (
         <EmptyState>{t('recEmpty')}</EmptyState>
       ) : (
         <p style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, margin: 0, lineHeight: 1.25 }}>


### PR DESCRIPTION
## Why

Follow-up audit of the whole app against the loading rule established in #184: **while data is loading, a card must render a skeleton that reserves its real location/size — never a blank `return null`, never a lying empty state** (exception: cards that are conditionally absent when there's genuinely no data).

**Audit result:**
- Home / Sign-Ups / Admin / the headline Stats cards (LevelCard, SkillTrendCard) / all Command Center cards — **clean** (fixed in #184).
- **Lying empty state** — none; every fetching card already tracks a distinct `loadError` + error pill. Compliant with the CLAUDE.md rule.
- **Remaining offenders — the Stats tab's Game-stats / Gear slots** still went blank or popped their body in while loading.

## What changed (loading branch only — error/empty branches untouched)

| Card | Before | After |
|------|--------|-------|
| `GameLoggerCard` | **fully blank** while `status === 'loading'` | `'no-identity'` stays null (anon absent); loading → `CardSkeleton` |
| `PartnerFrequencyCard` | header rendered, **body null** while loading | shimmers the avatar-row body so the card reserves its shape |
| `RacketRow` / `RacketRecCard` | value line popped in under the label | `.shimmer-line` holds the value slot while loading |

Reuses the existing skeleton family — `CardSkeleton` and the `.shimmer-line` class — so no new patterns.

## Intentionally left as-is (documented in the audit)

- **Conditionally-absent cards** (null when empty *and* while loading): `DrillsCard`, `KudosReceivedCard`, `GiveKudosCard`, `AnomalyFeed`, `SkillDiscoveryCard` — correct per the exception.
- **ProfileTab cost rows** — only appear when owe/prev data exists (conditionally present); a skeleton would reserve space that often stays empty.
- **`reportFetchFailure()` gaps** in some stats-card catches — an *offline-detection* nicety, not a loading-skeleton issue; noted for a possible separate hardening pass.

## Verification

- ✅ `npm test` — 968 tests / 125 files pass.
- ✅ `tsc --noEmit` — changed files clean.
- ✅ ESLint (components/stats is `error`-tier for design tokens) — 0 errors.
- ✅ Booted offline with next flags + an injected identity; **Stats → Game stats** while holding the API now shows GameLogger + Partner skeletons (verified by screenshot), not blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeGwYYBp9aHRzNULEHRRtV)_