### PR TITLE
Fade content in on the skeleton→content swap (reveal motion)

### DIFF
--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -405,6 +405,10 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         />
       </div>
 
+      {/* Reveal the data cards together on load. Wrapping below the sticky
+          PageHeader keeps the header out of the transform (containing-block
+          trap) while the card stack fades in once when data lands. */}
+      <div className="space-y-5 animate-fadeIn">
       {/* Tile row: Location | Date & Time */}
       <div className="grid grid-cols-2 gap-3">
         {/* Location tile */}
@@ -710,6 +714,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
         hasIdentity={hasIdentity}
         etransferEmail={etransferEmail}
       />
+      </div>
       <ReleaseNotesSheet
         open={releaseSheetOpen}
         releases={releases}

--- a/components/admin/CommandCenter/AdminConsoleHero.tsx
+++ b/components/admin/CommandCenter/AdminConsoleHero.tsx
@@ -143,7 +143,7 @@ export default function AdminConsoleHero({ onOpenAdmin }: AdminConsoleHeroProps)
   ].filter(Boolean).length;
 
   return (
-    <div className="admin-hero">
+    <div className="admin-hero animate-fadeIn">
       <span className="badge">Admin console</span>
       <p className="ah-title">
         {needsYou === 0

--- a/components/admin/CommandCenter/AdminDashTiles.tsx
+++ b/components/admin/CommandCenter/AdminDashTiles.tsx
@@ -86,7 +86,7 @@ export default function AdminDashTiles({ onOpenBirds, onOpenRoster }: AdminDashT
 
   if (!data) {
     return (
-      <div className="cc-dgrid" role="status" aria-label="Loading">
+      <div key="tiles-loading" className="cc-dgrid" role="status" aria-label="Loading">
         <CardSkeleton height={92} />
         <CardSkeleton height={92} />
       </div>
@@ -96,7 +96,7 @@ export default function AdminDashTiles({ onOpenBirds, onOpenRoster }: AdminDashT
   const birdsAlertClass = data.birdStock < 5 ? 'cc-dcard alert' : data.birdStock < 10 ? 'cc-dcard warn' : 'cc-dcard';
 
   return (
-    <div className="cc-dgrid">
+    <div key="tiles-loaded" className="cc-dgrid animate-fadeIn">
       <button
         type="button"
         className={birdsAlertClass}

--- a/components/admin/CommandCenter/BirdInventoryCard.tsx
+++ b/components/admin/CommandCenter/BirdInventoryCard.tsx
@@ -86,7 +86,7 @@ export default function BirdInventoryCard({ onOpen }: BirdInventoryCardProps = {
   const lowStock = stock < 5;
 
   return (
-    <section className="glass-card p-4 space-y-2" aria-label="Bird inventory">
+    <section className="glass-card p-4 space-y-2 animate-fadeIn" aria-label="Bird inventory">
       <h3 className="bpm-h3">Bird inventory</h3>
       <div className="flex items-baseline gap-2">
         <span

--- a/components/admin/CommandCenter/ETransferRecipientEditor.tsx
+++ b/components/admin/CommandCenter/ETransferRecipientEditor.tsx
@@ -96,7 +96,7 @@ export default function ETransferRecipientEditor() {
   if (loading) return <CardSkeleton height={120} />;
 
   return (
-    <section className="glass-card p-4 space-y-3" aria-label="E-transfer recipient">
+    <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="E-transfer recipient">
       <header>
         <h3 className="bpm-h3">E-transfer recipient</h3>
         <p className="text-xs text-gray-400 mt-0.5">

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -172,7 +172,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
   const isSettled = settleFlagOn && !!session.settled;
 
   return (
-    <section className="glass-card p-4 space-y-3" aria-label="Next session">
+    <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Next session">
       <header className="flex items-center justify-between gap-3">
         <div>
           <h3 className="bpm-h3">{fmtDate(session.datetime)}</h3>

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -408,7 +408,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
   if (loading) return <CardSkeleton height={240} />;
 
   return (
-    <section className="glass-card p-4 space-y-3" aria-label="Payments">
+    <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Payments">
       {/* Session selector — horizontal chips replace the old prev/next
           chevrons AND the standalone RecentSessionsStrip card (merged here).
           Built from the already-loaded `sessions` list (newest-first by id),

--- a/components/admin/CommandCenter/RosterHealthCard.tsx
+++ b/components/admin/CommandCenter/RosterHealthCard.tsx
@@ -74,7 +74,7 @@ export default function RosterHealthCard({ onOpen }: RosterHealthCardProps = {})
   }
 
   return (
-    <section className="glass-card p-4 space-y-3" aria-label="Roster health">
+    <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Roster health">
       <h3 className="bpm-h3">Roster health</h3>
       <div className="grid grid-cols-3 gap-3">
         <RosterStat label="Invite list" value={health.inviteListSize} />

--- a/components/admin/CommandCenter/SkipDatesEditor.tsx
+++ b/components/admin/CommandCenter/SkipDatesEditor.tsx
@@ -79,7 +79,7 @@ export default function SkipDatesEditor() {
   if (loading) return <CardSkeleton height={140} />;
 
   return (
-    <section className="glass-card p-4 space-y-3" aria-label="Skip dates">
+    <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Skip dates">
       <header>
         <h3 className="bpm-h3">Skip dates</h3>
         <p className="text-xs text-gray-400 mt-0.5">

--- a/components/stats/GameLoggerCard.tsx
+++ b/components/stats/GameLoggerCard.tsx
@@ -82,7 +82,7 @@ export default function GameLoggerCard() {
   }
 
   return (
-    <div className="glass-card p-5 space-y-3">
+    <div className="glass-card p-5 space-y-3 animate-fadeIn">
       <CardHeader icon="sports_tennis" title={t('logGameTitle')} subtitle={t('logGameHint')} />
       <button type="button" onClick={() => setOpen(true)} className="cc-btn cc-btn-primary">
         {t('logGameSubmit')}

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -129,6 +129,9 @@ export default function LevelCard() {
   }
 
   return (
+    // Stable wrapper carries the reveal so the fade plays once on load; the
+    // inline Frame remounting on insight updates stays invisible inside it.
+    <div className="animate-fadeIn">
     <Frame>
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
         {level.phase && (
@@ -214,5 +217,6 @@ export default function LevelCard() {
         </div>
       )}
     </Frame>
+    </div>
   );
 }

--- a/components/stats/SkillTrendCard.tsx
+++ b/components/stats/SkillTrendCard.tsx
@@ -205,7 +205,11 @@ export default function SkillTrendCard() {
   }
 
   // Loading: reserve the radar card's footprint with a skeleton rather than a
-  // blank gap below the Summary segment control.
+  // blank gap below the Summary segment control. Height is a deliberate middle:
+  // the card is short (~240) for a first-time user (empty "rate skills" CTA) and
+  // tall (~835) once there's assessment data, so no fixed height matches both.
+  // We favor the empty case (a new user's first impression) and let the reveal
+  // fade smooth the gentle downward settle for data-rich users.
   if (!loaded) return <CardSkeleton height={320} />;
 
   // Card chrome wraps every state so the section reads consistently.
@@ -246,6 +250,9 @@ export default function SkillTrendCard() {
   const workOn = workOnNext(latest.ratings);
 
   return (
+    // Stable wrapper carries the reveal so the fade plays once on load; the
+    // inline Frame remounting on insight updates stays invisible inside it.
+    <div className="animate-fadeIn">
     <Frame>
       {/* Phase headline + overall */}
       <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 12 }}>
@@ -354,6 +361,7 @@ export default function SkillTrendCard() {
 
       <CheckInSheet name={activeName} open={checkInOpen} onClose={() => setCheckInOpen(false)} onSaved={load} previous={nowMap} />
     </Frame>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Why

The skeletons (#184/#185) reserve layout so it no longer jumps — but the **skeleton→content swap itself was an instant hard pop** on every surface except PlayersTab rows. This adds a gentle reveal so content **fades in** when data lands, smoothing the jarring switch.

Decision: reuse the existing `.animate-fadeIn` (250ms, `--ease-glass`, fade + small settle). No new CSS; `prefers-reduced-motion` auto-collapses it to instant via the globals.css blanket rule.

## How it works

A CSS mount-animation only plays if React **creates a fresh DOM node**. The loading branch returns a `<CardSkeleton>` *component* and the loaded branch a *host element*, so React remounts the content → the fade fires. Specifics:

| Case | Treatment |
|------|-----------|
| Stable-root cards (NextSession, Payments, RosterHealth, BirdInventory, ETransfer, SkipDates, AdminConsoleHero, GameLogger) | add `animate-fadeIn` to the loaded `<section>`/`<div>` |
| `AdminDashTiles` (same `cc-dgrid` div in both branches) | distinct `key`s so it remounts + fades |
| `LevelCard` / `SkillTrendCard` (inline `Frame` remounts on every render, e.g. when `useInsight` lands) | wrap the loaded return in a **stable** `<div className="animate-fadeIn">` so the fade plays **once**, not on each re-render |
| `HomeTab` | wrap the data-card stack **below** the sticky `PageHeader` (header stays out of the transform → no containing-block trap) |

## Left as-is (deliberate)

- **PlayersTab** — rows already stagger-fade (`animate-fadeIn` + `animationDelay`); it's the precedent.
- **Inner body/value swaps** (PartnerFrequency body, Racket value) — already shimmer in place with no layout jump; a fade there needs `key` gymnastics for ~zero gain.
- **SkillTrendCard skeleton height** — kept at 320 (not bumped). The card is ~240px empty (first-time "rate skills" CTA) vs ~835px with data, so no fixed height matches both; 320 favors the new-user first impression and the fade smooths the data-rich settle.

## Verification

- ✅ Caught the fade **at mount** via MutationObserver on Home and Stats: `animationName: fadeIn`, opacity ramps `0 → 1` over 0.25s.
- ✅ `prefers-reduced-motion: reduce` → duration collapses to `1e-05s` (instant, no stuck-invisible content).
- ✅ Loaded layout intact (Home header sticky + cards; Stats Level + radar) — screenshots.
- ✅ `npm test` 968 pass · `tsc --noEmit` clean · ESLint 0 errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeGwYYBp9aHRzNULEHRRtV)_