### PR TITLE
fix(nav): highlight Profile (not Home) while in Admin

### DIFF
--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -42,12 +42,17 @@ export default function BottomNav({ activeTab, onTabChange }: Props) {
     { id: 'profile', label: t('profile'), icon: 'person' },
   ];
 
+  // Admin is a sub-screen of Profile (opened from "Admin tools →", exits back
+  // to it), not its own nav slot — so the nav highlights Profile while inside
+  // Admin instead of falling back to Home (findIndex -1 → Math.max → index 0).
+  const navTab: Tab = activeTab === 'admin' ? 'profile' : activeTab;
+
   if (isFlagOn('NEXT_PUBLIC_FLAG_NAV_RAIL')) {
     // Active index drives the shared sliding indicator (--ri). findIndex
-    // is always 0–3 for a valid Tab; Math.max guards the -1 edge.
+    // is always 0–3 for a valid navTab; Math.max guards the -1 edge.
     const activeIndex = Math.max(
       0,
-      visibleTabs.findIndex((tb) => tb.id === activeTab),
+      visibleTabs.findIndex((tb) => tb.id === navTab),
     );
     return (
       <nav
@@ -59,7 +64,7 @@ export default function BottomNav({ activeTab, onTabChange }: Props) {
           <span className="rail-indicator-pill" />
         </span>
         {visibleTabs.map((tab) => {
-          const active = activeTab === tab.id;
+          const active = navTab === tab.id;
           return (
             <button
               key={tab.id}
@@ -88,7 +93,7 @@ export default function BottomNav({ activeTab, onTabChange }: Props) {
       <div className="max-w-lg mx-auto px-4 flex justify-center">
         <div className="nav-glass">
           {visibleTabs.map((tab) => {
-            const active = activeTab === tab.id;
+            const active = navTab === tab.id;
             return (
               <button
                 key={tab.id}


### PR DESCRIPTION
## Problem

When an admin opens the Admin screens, the bottom nav highlights **Home** — confusing, since they're clearly not on Home.

## Root cause

The bottom nav has 4 fixed slots (`home · players · skills · profile`); Admin is intentionally not one of them — it's a sub-screen reached from Profile ("Admin tools →") that exits back to Profile. With `activeTab === 'admin'`, the rail's `visibleTabs.findIndex(...)` returns `-1`, and `Math.max(0, -1)` snaps the sliding indicator pill to index `0` (Home). The per-tab `active` string comparison was also false for every tab, so no tab got the active class — but the pill still sat on Home.

## Fix

`components/BottomNav.tsx` only. Derive a single highlight target that folds `'admin'` into `'profile'`:

```ts
const navTab: Tab = activeTab === 'admin' ? 'profile' : activeTab;
```

Used by both the rail branch (`--ri` index + per-tab `active`) and the legacy glass-pill branch. Admin now lights up **Profile** as its parent tab — the standard mobile pattern where a sub-screen highlights the root tab it lives under, and it matches the entry/exit flow (`AdminTab onExit={() => setActiveTab('profile')}`).

No CSS changes, no new nav slot, no change to `HomeShell` or the `Tab` type. Reuses the existing `.rail-tab-active` / `.nav-tab-active` styling and `aria-current`.

## Verification

- `npm test` — **981 passed**.
- `npm run build` — clean.
- `eslint components/BottomNav.tsx` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeGwYYBp9aHRzNULEHRRtV)_