### PR TITLE
fix(unpaid): match owed sessions by identity, add admin owed-audit

### DIFF
--- a/__tests__/admin-owed-audit.test.ts
+++ b/__tests__/admin-owed-audit.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GET } from '@/app/api/admin/owed-audit/route';
+import {
+  resetMockStore,
+  setupAdminPin,
+  seedPointer,
+  seedSession,
+  seedPlayer,
+  seedMember,
+  seedAlias,
+  seedTestAdminMember,
+  makeAdminRequest,
+  makeRequest,
+} from './helpers';
+
+setupAdminPin();
+
+const ACTIVE = 'session-2026-06-08';
+const OLDER = 'session-2026-06-01';
+const URL = 'http://localhost:3000/api/admin/owed-audit';
+
+function settled() {
+  return { at: '', costPerPerson: 10, totalCost: 40, courtTotal: 40, birdTotal: 0, playerCount: 4, playerNames: [] };
+}
+
+function adminGet(query: string) {
+  return GET(makeAdminRequest('GET', `${URL}?${query}`));
+}
+
+describe('GET /api/admin/owed-audit', () => {
+  beforeEach(async () => {
+    resetMockStore();
+    await seedTestAdminMember();
+    seedPointer(ACTIVE);
+    seedSession(OLDER, { settled: settled(), datetime: '2026-06-01T19:00:00-04:00' });
+    seedSession(ACTIVE, { settled: settled(), datetime: '2026-06-08T19:00:00-04:00' });
+  });
+
+  it('rejects a non-admin with 401', async () => {
+    const res = await GET(makeRequest('GET', `${URL}?name=Lin`));
+    expect(res.status).toBe(401);
+  });
+
+  it('requires a name or memberId', async () => {
+    const res = await adminGet('');
+    expect(res.status).toBe(400);
+  });
+
+  it('classifies each session with a reason and totals only the counted ones', async () => {
+    seedMember('Lin', { id: 'm-lin' });
+    seedPlayer(OLDER, 'Lin', { memberId: 'm-lin', owedAmount: 10, paid: true }); // paid → excluded
+    seedPlayer(ACTIVE, 'Lin', { memberId: 'm-lin', owedAmount: 12.5, paid: false }); // counts
+
+    const res = await adminGet('name=Lin');
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    expect(data.totalOwed).toBe(12.5);
+    expect(data.countedCount).toBe(1);
+    expect(data.sessionCount).toBe(2);
+
+    const byId = Object.fromEntries(data.sessions.map((s: { sessionId: string }) => [s.sessionId, s]));
+    expect(byId[ACTIVE].counted).toBe(true);
+    expect(byId[ACTIVE].reason).toBe('counted');
+    expect(byId[OLDER].counted).toBe(false);
+    expect(byId[OLDER].reason).toBe('paid');
+  });
+
+  it('surfaces all linked names so an admin can spot an unlinked variant', async () => {
+    seedMember('Lin', { id: 'm-lin' });
+    seedAlias('Lin', 'Lin Dan');
+    seedPlayer(OLDER, 'Lin Dan', { owedAmount: 9, paid: false });
+    seedPlayer(ACTIVE, 'Lin', { owedAmount: 11, paid: false });
+
+    const res = await adminGet('name=Lin');
+    const data = await res.json();
+    expect(new Set(data.names)).toEqual(new Set(['Lin', 'Lin Dan']));
+    expect(data.totalOwed).toBe(20);
+  });
+
+  it('flags an unsettled past session with no recorded cost', async () => {
+    const PAST = 'session-2026-05-20';
+    seedSession(PAST, { costPerCourt: 0, courts: 0, datetime: '2026-05-20T19:00:00-04:00' });
+    seedPlayer(PAST, 'Lin', { paid: false });
+
+    const res = await adminGet('name=Lin');
+    const data = await res.json();
+    const row = data.sessions.find((s: { sessionId: string }) => s.sessionId === PAST);
+    expect(row.counted).toBe(false);
+    expect(row.reason).toBe('unsettled_no_cost');
+  });
+});

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -88,6 +88,18 @@ export function seedMember(name: string, overrides: Record<string, unknown> = {}
   return member;
 }
 
+export function seedAlias(appName: string, etransferName: string) {
+  const store = getStore();
+  if (!store['aliases']) store['aliases'] = [];
+  const alias = {
+    id: `alias-${Math.random().toString(36).slice(2, 8)}`,
+    appName,
+    etransferName,
+  };
+  store['aliases'].push(alias);
+  return alias;
+}
+
 export function seedAnnouncement(sessionId: string, text: string, overrides: Record<string, unknown> = {}) {
   const store = getStore();
   if (!store['announcements']) store['announcements'] = [];

--- a/__tests__/playerIdentity.test.ts
+++ b/__tests__/playerIdentity.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  expandAliasNames,
+  finiteSessionDate,
+  matchesIdentity,
+  resolveIdentity,
+  classifyOwed,
+} from '@/lib/playerIdentity';
+import type { Alias, Session } from '@/lib/types';
+import { resetMockStore, seedMember, seedAlias } from './helpers';
+
+describe('expandAliasNames', () => {
+  const aliases: Alias[] = [
+    { id: 'a1', appName: 'Mike', etransferName: 'Michael Chen' },
+    { id: 'a2', appName: 'Bea', etransferName: 'Beatrice' },
+  ];
+
+  it('always includes the lowercased input name', () => {
+    expect(expandAliasNames('Lin', [])).toEqual(new Set(['lin']));
+  });
+
+  it('adds the e-transfer name when the app name matches', () => {
+    expect(expandAliasNames('Mike', aliases)).toEqual(new Set(['mike', 'michael chen']));
+  });
+
+  it('is bidirectional — matching the e-transfer name adds the app name', () => {
+    expect(expandAliasNames('Michael Chen', aliases)).toEqual(new Set(['michael chen', 'mike']));
+  });
+
+  it('does not merge unrelated names', () => {
+    expect(expandAliasNames('Lin', aliases)).toEqual(new Set(['lin']));
+  });
+});
+
+describe('finiteSessionDate', () => {
+  it('accepts a valid ISO datetime', () => {
+    expect(finiteSessionDate({ datetime: '2026-06-01T19:00:00-04:00' })).toBe(true);
+  });
+  it('rejects a malformed datetime', () => {
+    expect(finiteSessionDate({ datetime: 'not-a-date' })).toBe(false);
+  });
+  it('rejects a missing datetime', () => {
+    expect(finiteSessionDate({ datetime: undefined as unknown as string })).toBe(false);
+  });
+});
+
+describe('matchesIdentity', () => {
+  const idy = { memberId: 'm-1', names: new Set(['lin', 'lynn']) };
+
+  it('matches by memberId regardless of name', () => {
+    expect(matchesIdentity({ name: 'Whoever', memberId: 'm-1' }, idy)).toBe(true);
+  });
+  it('matches by name when memberId differs', () => {
+    expect(matchesIdentity({ name: 'Lynn', memberId: 'm-2' }, idy)).toBe(true);
+  });
+  it('does not match an unrelated row', () => {
+    expect(matchesIdentity({ name: 'Viktor', memberId: 'm-2' }, idy)).toBe(false);
+  });
+});
+
+describe('resolveIdentity', () => {
+  beforeEach(() => resetMockStore());
+
+  it('resolves a member by name and widens via aliases', async () => {
+    seedMember('Mike', { id: 'm-mike' });
+    seedAlias('Mike', 'Michael Chen');
+
+    const idy = await resolveIdentity({ name: 'mike' });
+    expect(idy.memberId).toBe('m-mike');
+    expect(idy.names.has('mike')).toBe(true);
+    expect(idy.names.has('michael chen')).toBe(true);
+  });
+
+  it('resolves an unknown name to no member but keeps the name itself', async () => {
+    const idy = await resolveIdentity({ name: 'Ghost' });
+    expect(idy.member).toBeNull();
+    expect(idy.memberId).toBeNull();
+    expect(idy.names).toEqual(new Set(['ghost']));
+  });
+});
+
+describe('classifyOwed', () => {
+  const ctx = { activeSessionId: 'session-active', now: new Date('2026-06-10T00:00:00Z').getTime(), activeCount: 4 };
+  const settled = (over: Partial<Session> = {}): Session =>
+    ({ id: 's', datetime: '2026-06-01T19:00:00-04:00', settled: { at: '', costPerPerson: 10, totalCost: 40, courtTotal: 40, birdTotal: 0, playerCount: 4, playerNames: [] }, ...over } as Session);
+  const unsettledPast = (over: Partial<Session> = {}): Session =>
+    ({ id: 's', datetime: '2026-06-01T19:00:00-04:00', costPerCourt: 20, courts: 2, ...over } as Session);
+
+  it('counts a settled session with a frozen owedAmount', () => {
+    expect(classifyOwed({ owedAmount: 12.5 }, settled(), ctx)).toEqual({ counted: true, reason: 'counted', owedAmount: 12.5 });
+  });
+  it('drops a settled session whose owedAmount is 0', () => {
+    expect(classifyOwed({ owedAmount: 0 }, settled(), ctx).reason).toBe('settled_zero_owed');
+  });
+  it('drops paid / written-off regardless of settle state', () => {
+    expect(classifyOwed({ paid: true, owedAmount: 10 }, settled(), ctx).reason).toBe('paid');
+    expect(classifyOwed({ writtenOff: true, owedAmount: 10 }, settled(), ctx).reason).toBe('written_off');
+  });
+  it('computes the live per-person share for an unsettled past priced session', () => {
+    expect(classifyOwed({}, unsettledPast(), ctx)).toEqual({ counted: true, reason: 'counted', owedAmount: 10 });
+  });
+  it('drops an unsettled past session with no recorded cost', () => {
+    expect(classifyOwed({}, unsettledPast({ costPerCourt: 0, courts: 0 }), ctx).reason).toBe('unsettled_no_cost');
+  });
+  it('drops the active session via the live path', () => {
+    expect(classifyOwed({}, unsettledPast({ id: 'session-active' }), ctx).reason).toBe('future_or_active');
+  });
+  it('drops a future unsettled session', () => {
+    expect(classifyOwed({}, unsettledPast({ datetime: '2026-12-01T19:00:00-04:00' }), ctx).reason).toBe('future_or_active');
+  });
+  it('drops a session with a malformed datetime instead of throwing', () => {
+    expect(classifyOwed({ owedAmount: 10 }, settled({ datetime: 'bad' }), ctx).reason).toBe('bad_datetime');
+  });
+});

--- a/__tests__/players-unpaid.test.ts
+++ b/__tests__/players-unpaid.test.ts
@@ -5,6 +5,8 @@ import {
   seedPointer,
   seedSession,
   seedPlayer,
+  seedMember,
+  seedAlias,
   makeRequest,
 } from './helpers';
 
@@ -136,5 +138,42 @@ describe('GET /api/players/unpaid', () => {
     const data = await res.json();
     expect(data.totalOwed).toBe(0);
     expect(data.mostRecent).toBeNull();
+  });
+
+  it('counts a week signed up under an alias-linked name', async () => {
+    // Lin (app name) e-transfers as "Lin Dan". An older week was recorded
+    // under "Lin Dan"; querying "Lin" must now include it via the alias.
+    seedMember('Lin', { id: 'm-lin' });
+    seedAlias('Lin', 'Lin Dan');
+    seedPlayer(OLDER, 'Lin Dan', { owedAmount: 9, paid: false });
+    seedPlayer(ACTIVE, 'Lin', { owedAmount: 11, paid: false });
+
+    const res = await get('Lin');
+    const data = await res.json();
+    expect(data.totalOwed).toBe(20);
+    expect(data.sessionCount).toBe(2);
+  });
+
+  it('counts a renamed-member week matched by memberId even when the name differs', async () => {
+    // The member is now "Carolina" but an old player row kept "Caro" — linked
+    // by memberId, so it still counts without an alias.
+    seedMember('Carolina', { id: 'm-caro' });
+    seedPlayer(OLDER, 'Caro', { memberId: 'm-caro', owedAmount: 6, paid: false });
+
+    const res = await get('Carolina');
+    const data = await res.json();
+    expect(data.totalOwed).toBe(6);
+    expect(data.sessions[0].sessionId).toBe(OLDER);
+  });
+
+  it('excludes a settled session with a malformed datetime without throwing', async () => {
+    const BAD = 'session-bad';
+    seedSession(BAD, { settled: settled(), datetime: 'not-a-real-date' });
+    seedPlayer(BAD, 'Lin', { owedAmount: 50, paid: false });
+
+    const res = await get('Lin');
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.sessions.find((x: { sessionId: string }) => x.sessionId === BAD)).toBeUndefined();
   });
 });

--- a/app/api/admin/owed-audit/route.ts
+++ b/app/api/admin/owed-audit/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContainer, POINTER_ID, getActiveSessionId } from '@/lib/cosmos';
+import { isAdminAuthed, unauthorized } from '@/lib/auth';
+import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
+import { resolveIdentity, matchesIdentity, classifyOwed, type OwedReason } from '@/lib/playerIdentity';
+import type { Player, Session } from '@/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/owed-audit?name=<name>  (or ?memberId=<id>)
+ *
+ * Admin diagnostic: explains, per session, why a player's "what you owe" total
+ * is what it is. Resolves identity the SAME way `/api/players/unpaid` does
+ * (memberId + name + aliases) and classifies every session that identity
+ * attended via the SAME `classifyOwed` — so this audit always matches the
+ * card the player sees, and surfaces exactly which weeks are excluded and why
+ * (paid, written off, unsettled with no recorded cost, settled-but-zero, etc.).
+ *
+ * The `names` array exposes the distinct linked names found, so an admin can
+ * spot a week signed up under an UNLINKED variant (→ add an alias to merge it).
+ */
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+interface AuditRow {
+  sessionId: string;
+  date: string;
+  rowName: string;
+  settled: boolean;
+  attended: boolean;
+  paid: boolean;
+  writtenOff: boolean;
+  owedAmount: number;
+  counted: boolean;
+  reason: OwedReason;
+}
+
+export async function GET(req: NextRequest) {
+  // Rate limit before auth so it can't be bypassed (CLAUDE.md security #4).
+  const ip = getClientIp(req);
+  if (!checkRateLimit(`owed-audit:${ip}`, 30, 60_000)) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+  }
+  if (!isAdminAuthed(req)) return unauthorized();
+
+  const name = req.nextUrl.searchParams.get('name')?.trim() || undefined;
+  const memberId = req.nextUrl.searchParams.get('memberId')?.trim() || undefined;
+  if (!name && !memberId) {
+    return NextResponse.json({ error: 'name or memberId required' }, { status: 400 });
+  }
+
+  try {
+    const sessionsContainer = getContainer('sessions');
+    const playersContainer = getContainer('players');
+    const activeSessionId = await getActiveSessionId();
+    const now = Date.now();
+
+    const identity = await resolveIdentity({ name, memberId });
+
+    const { resources: allSessions } = await sessionsContainer.items
+      .query({
+        query: 'SELECT * FROM c WHERE c.id != @pointerId AND c.id != @legacyId',
+        parameters: [
+          { name: '@pointerId', value: POINTER_ID },
+          { name: '@legacyId', value: 'current-session' },
+        ],
+      })
+      .fetchAll();
+    const sessionById = new Map<string, Session>();
+    for (const s of allSessions as Session[]) sessionById.set(s.id, s);
+
+    // All players (small dataset for a friend group); we need the full roster
+    // per session for the live-share denominator, then filter to this identity.
+    const { resources: allPlayers } = await playersContainer.items
+      .query({ query: 'SELECT * FROM c' })
+      .fetchAll();
+    const players = allPlayers as Player[];
+
+    const activeCountBySession = new Map<string, number>();
+    for (const p of players) {
+      if (!sessionById.has(p.sessionId)) continue;
+      if (p.removed === true || p.waitlisted === true) continue;
+      activeCountBySession.set(p.sessionId, (activeCountBySession.get(p.sessionId) ?? 0) + 1);
+    }
+
+    const linkedNames = new Set<string>();
+    const rows: AuditRow[] = [];
+    for (const p of players) {
+      if (!matchesIdentity(p, identity)) continue;
+      const session = sessionById.get(p.sessionId);
+      if (!session) continue;
+      if (typeof p.name === 'string') linkedNames.add(p.name);
+
+      const result = classifyOwed(p, session, {
+        activeSessionId,
+        now,
+        activeCount: activeCountBySession.get(p.sessionId) ?? 0,
+      });
+
+      rows.push({
+        sessionId: p.sessionId,
+        date: session.datetime ?? '',
+        rowName: p.name ?? '',
+        settled: !!session.settled,
+        attended: p.removed !== true && p.waitlisted !== true,
+        paid: p.paid === true,
+        writtenOff: p.writtenOff === true,
+        owedAmount: result.owedAmount,
+        counted: result.counted,
+        reason: result.reason,
+      });
+    }
+
+    rows.sort((a, b) => (a.date < b.date ? 1 : -1));
+    const totalOwed = round2(rows.reduce((sum, r) => sum + (r.counted ? r.owedAmount : 0), 0));
+    const countedCount = rows.filter((r) => r.counted).length;
+
+    return NextResponse.json({
+      names: Array.from(linkedNames),
+      totalOwed,
+      countedCount,
+      sessionCount: rows.length,
+      sessions: rows,
+    });
+  } catch (error) {
+    console.error('GET /api/admin/owed-audit error:', error);
+    return NextResponse.json({ error: 'Failed to compute owed audit' }, { status: 500 });
+  }
+}

--- a/app/api/members/[id]/history/route.ts
+++ b/app/api/members/[id]/history/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
 import { isAdminAuthed, unauthorized } from '@/lib/auth';
 import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
-import type { Member, Player, Session } from '@/lib/types';
+import { expandAliasNames } from '@/lib/playerIdentity';
+import type { Alias, Member, Player, Session } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
@@ -50,11 +51,7 @@ export async function GET(req: NextRequest, context: { params: Promise<{ id: str
       const { resources: aliasRows } = await aliasesContainer.items
         .query({ query: 'SELECT * FROM c' })
         .fetchAll();
-      const aliasNames = (aliasRows as Array<{ appName?: string; etransferName?: string }>)
-        .filter((a) => typeof a.appName === 'string' && a.appName.toLowerCase() === member.name.toLowerCase())
-        .map((a) => a.etransferName)
-        .filter((n): n is string => typeof n === 'string');
-      const candidateNames = new Set([member.name.toLowerCase(), ...aliasNames.map((n) => n.toLowerCase())]);
+      const candidateNames = expandAliasNames(member.name, aliasRows as Alias[]);
 
       const { resources: allPlayers } = await playersContainer.items
         .query({ query: 'SELECT * FROM c' })

--- a/app/api/players/unpaid/route.ts
+++ b/app/api/players/unpaid/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, POINTER_ID, getActiveSessionId } from '@/lib/cosmos';
-import { sessionCostTotals } from '@/lib/sessionCost';
 import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
+import { resolveIdentity, matchesIdentity, classifyOwed, finiteSessionDate } from '@/lib/playerIdentity';
 import type { Player, Session } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -14,18 +14,15 @@ export const dynamic = 'force-dynamic';
  * posture as `/api/stats/attendance`) — no auth, rate-limited by IP so it can't
  * be scraped wholesale.
  *
- * A player owes for a PAST session they attended and that isn't paid/written
- * off (`paid !== true && writtenOff !== true`). Two ways the amount is known:
- *   1. SETTLED sessions — use the frozen `owedAmount` stamped at settle time
- *      (only counts when `> 0`).
- *   2. UNSETTLED past sessions — the admin never ran settle, so there's no
- *      frozen amount; compute the live per-person share `totalCost / active
- *      roster`. This matches the friend-group mental model ("owed = whoever
- *      didn't get marked paid") rather than requiring the settle step, which
- *      most past sessions never had. Unpriced sessions contribute 0.
+ * Identity is resolved via `resolveIdentity` (memberId + name + aliases), NOT a
+ * raw name match — so weeks signed up under a renamed member or an alias-linked
+ * name are no longer dropped. The per-session owed decision is delegated to the
+ * shared `classifyOwed`, so this card and the admin owed-audit always agree.
  *
- * The active session is never counted via the live path (its bill isn't due
- * yet — it may not have happened), but a settled debt on it is real and counts.
+ * There is NO lookback window: every archived session is considered. A session
+ * owes when it's SETTLED with a frozen `owedAmount > 0`, or UNSETTLED+past with a
+ * recorded cost (live per-person share). The active session never counts via the
+ * live path (its bill isn't due yet); a settled debt on it does.
  */
 
 function round2(n: number): number {
@@ -63,6 +60,8 @@ export async function GET(req: NextRequest) {
     const activeSessionId = await getActiveSessionId();
     const now = Date.now();
 
+    const identity = await resolveIdentity({ name });
+
     const { resources: allSessions } = await sessionsContainer.items
       .query({
         query: 'SELECT * FROM c WHERE c.id != @pointerId AND c.id != @legacyId',
@@ -73,37 +72,21 @@ export async function GET(req: NextRequest) {
       })
       .fetchAll();
 
-    // Two buckets, mutually exclusive on `session.settled`:
-    //  - settled: amount is frozen on each player.
-    //  - unsettled & past & not the active session: compute the live share.
-    // Excluding the active session uses its id, NOT datetime — this week's game
-    // may already be underway (datetime < now) but not yet advanced/billed.
-    const settledSessions = (allSessions as Session[]).filter(
-      (s) => s.settled && typeof s.datetime === 'string',
-    );
-    const unsettledPast = (allSessions as Session[]).filter(
-      (s) =>
-        !s.settled &&
-        typeof s.datetime === 'string' &&
-        s.id !== activeSessionId &&
-        new Date(s.datetime!).getTime() < now,
-    );
-
-    const relevant = [...settledSessions, ...unsettledPast];
+    // Sessions a debt can come from: settled (frozen amount) OR unsettled & past
+    // & not the active session (live share). Both require a finite datetime.
+    const relevant = (allSessions as Session[]).filter((s) => {
+      if (!finiteSessionDate(s)) return false;
+      if (s.settled) return true;
+      return s.id !== activeSessionId && new Date(s.datetime).getTime() < now;
+    });
     if (relevant.length === 0) {
       return NextResponse.json(EMPTY);
     }
 
-    const dateBySession = new Map<string, string>();
-    for (const s of relevant) dateBySession.set(s.id, s.datetime!);
-    const settledIdSet = new Set(settledSessions.map((s) => s.id));
-    const unsettledIdSet = new Set(unsettledPast.map((s) => s.id));
+    const sessionById = new Map<string, Session>();
+    for (const s of relevant) sessionById.set(s.id, s);
     const sessionIds = relevant.map((s) => s.id);
     const sessionIdSet = new Set(sessionIds);
-
-    // Frozen group total for each unsettled session (for the live per-person share).
-    const totalCostBySession = new Map<string, number>();
-    for (const s of unsettledPast) totalCostBySession.set(s.id, sessionCostTotals(s).totalCost);
 
     // Batch fetch. Real Cosmos honors IN(); the mock store ignores it and
     // returns every row — so we post-filter by the session set for parity
@@ -117,40 +100,27 @@ export async function GET(req: NextRequest) {
       .fetchAll();
     const players = (rawPlayers as Player[]).filter((p) => sessionIdSet.has(p.sessionId));
 
-    // Active-roster size per unsettled session = the live per-person denominator.
-    // Count the FULL active roster (everyone non-removed, non-waitlisted),
-    // independent of who's asking — so the share is right regardless of how many
-    // have paid.
+    // Full active-roster size per session = the live per-person denominator.
+    // Counted independent of who's asking, so the share is right regardless of
+    // how many have paid.
     const activeCountBySession = new Map<string, number>();
     for (const p of players) {
-      if (!unsettledIdSet.has(p.sessionId)) continue;
       if (p.removed === true || p.waitlisted === true) continue;
       activeCountBySession.set(p.sessionId, (activeCountBySession.get(p.sessionId) ?? 0) + 1);
     }
 
-    const lowerName = name.toLowerCase();
     const unpaid: UnpaidSession[] = [];
     for (const p of players) {
-      if (typeof p.name !== 'string' || p.name.toLowerCase() !== lowerName) continue;
-      // "Still owes" base predicate — mirrors the admin ledger.
-      if (p.paid === true || p.writtenOff === true) continue;
-      const date = dateBySession.get(p.sessionId);
-      if (!date) continue;
-
-      if (settledIdSet.has(p.sessionId)) {
-        // Settled: use the frozen amount (never the live compute — that would
-        // double-count and could disagree with what the player was billed).
-        const owed = p.owedAmount ?? 0;
-        if (owed > 0) unpaid.push({ sessionId: p.sessionId, date, owedAmount: round2(owed) });
-      } else {
-        // Unsettled past: live per-person share. Skip removed/waitlisted (not on
-        // the hook) and unpriced sessions (no amount to owe).
-        if (p.removed === true || p.waitlisted === true) continue;
-        const totalCost = totalCostBySession.get(p.sessionId) ?? 0;
-        const activeCount = activeCountBySession.get(p.sessionId) ?? 0;
-        if (totalCost > 0 && activeCount > 0) {
-          unpaid.push({ sessionId: p.sessionId, date, owedAmount: round2(totalCost / activeCount) });
-        }
+      if (!matchesIdentity(p, identity)) continue;
+      const session = sessionById.get(p.sessionId);
+      if (!session) continue;
+      const result = classifyOwed(p, session, {
+        activeSessionId,
+        now,
+        activeCount: activeCountBySession.get(p.sessionId) ?? 0,
+      });
+      if (result.counted) {
+        unpaid.push({ sessionId: p.sessionId, date: session.datetime, owedAmount: result.owedAmount });
       }
     }
 

--- a/components/admin/CommandCenter/PlayerProfileSheet.tsx
+++ b/components/admin/CommandCenter/PlayerProfileSheet.tsx
@@ -20,6 +20,51 @@ interface History {
   lifetime: { attended: number; totalPaid: number };
 }
 
+type OwedReason =
+  | 'counted'
+  | 'paid'
+  | 'written_off'
+  | 'removed'
+  | 'waitlisted'
+  | 'unsettled_no_cost'
+  | 'settled_zero_owed'
+  | 'bad_datetime'
+  | 'future_or_active';
+
+interface AuditRow {
+  sessionId: string;
+  date: string;
+  rowName: string;
+  owedAmount: number;
+  counted: boolean;
+  reason: OwedReason;
+}
+
+interface OwedAudit {
+  names: string[];
+  totalOwed: number;
+  countedCount: number;
+  sessionCount: number;
+  sessions: AuditRow[];
+}
+
+/** Short, admin-legible label for why a session is excluded from the owed total. */
+const REASON_LABEL: Record<OwedReason, string> = {
+  counted: 'Counted',
+  paid: 'Paid',
+  written_off: 'Covered',
+  removed: 'Removed',
+  waitlisted: 'Waitlisted',
+  unsettled_no_cost: 'No cost recorded',
+  settled_zero_owed: 'Settled · $0',
+  bad_datetime: 'Bad date',
+  future_or_active: 'Not due yet',
+};
+
+function fmtMoney(n: number): string {
+  return Number.isInteger(n) ? `$${n}` : `$${n.toFixed(2)}`;
+}
+
 interface PlayerProfileSheetProps {
   open: boolean;
   onClose: () => void;
@@ -50,6 +95,8 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [updatingSession, setUpdatingSession] = useState<string | null>(null);
+  const [audit, setAudit] = useState<OwedAudit | null>(null);
+  const [auditError, setAuditError] = useState(false);
 
   useEffect(() => {
     if (!open || !memberId) {
@@ -72,6 +119,36 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
         if (!cancelled) setError('Network error.');
       } finally {
         if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [open, memberId]);
+
+  // Owed breakdown — explains exactly what the player's "what you owe" card shows
+  // and why each excluded session is excluded. Same classifier as the card.
+  useEffect(() => {
+    if (!open || !memberId) {
+      setAudit(null);
+      setAuditError(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${BASE}/api/admin/owed-audit?memberId=${encodeURIComponent(memberId)}`, { cache: 'no-store' });
+        if (cancelled) return;
+        if (!res.ok) { setAuditError(true); return; }
+        const data = (await res.json()) as OwedAudit;
+        // Defensive: a malformed payload must surface as a load error, never a
+        // crash mid-render (CLAUDE.md legible-fail).
+        if (!data || typeof data.totalOwed !== 'number' || !Array.isArray(data.sessions)) {
+          setAuditError(true);
+          return;
+        }
+        setAudit(data);
+        setAuditError(false);
+      } catch {
+        if (!cancelled) setAuditError(true);
       }
     })();
     return () => { cancelled = true; };
@@ -208,6 +285,73 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                   <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '4px 0 0 0' }}>
                     +{history.sessions.length - 12} more older sessions
                   </p>
+                )}
+              </section>
+
+              <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
+                  <p style={{
+                    fontSize: 11,
+                    letterSpacing: '0.06em',
+                    textTransform: 'uppercase',
+                    color: 'var(--text-muted)',
+                    margin: 0,
+                    fontWeight: 600,
+                  }}>
+                    Owed breakdown
+                  </p>
+                  {audit && (
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 700, color: 'var(--text-primary)' }}>
+                      {fmtMoney(audit.totalOwed)}
+                    </span>
+                  )}
+                </div>
+
+                {auditError ? (
+                  <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+                    Couldn’t load owed breakdown.
+                  </p>
+                ) : !audit ? (
+                  <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>Loading…</p>
+                ) : audit.sessions.length === 0 ? (
+                  <p style={{ fontSize: 14, color: 'var(--text-muted)', margin: 0 }}>No billable sessions on record.</p>
+                ) : (
+                  <>
+                    {audit.names.length > 1 && (
+                      <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>
+                        Linked names: {audit.names.join(', ')}
+                      </p>
+                    )}
+                    <ul role="list" style={{ display: 'flex', flexDirection: 'column', gap: 0, listStyle: 'none', margin: 0, padding: 0 }}>
+                      {audit.sessions.map((s, i, arr) => (
+                        <li
+                          key={s.sessionId}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'space-between',
+                            gap: 12,
+                            padding: '10px 0',
+                            borderBottom: i < arr.length - 1 ? '1px solid var(--border-subtle, rgba(255,255,255,0.06))' : 'none',
+                            fontSize: 14,
+                          }}
+                        >
+                          <span style={{ color: s.counted ? 'var(--text-primary)' : 'var(--text-muted)' }}>
+                            {s.date ? fmtDate(s.date) : s.sessionId}
+                          </span>
+                          {s.counted ? (
+                            <span style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)', whiteSpace: 'nowrap' }}>
+                              {fmtMoney(s.owedAmount)}
+                            </span>
+                          ) : (
+                            <span style={{ fontSize: 12, color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>
+                              {REASON_LABEL[s.reason]}
+                            </span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  </>
                 )}
               </section>
             </>

--- a/lib/playerIdentity.ts
+++ b/lib/playerIdentity.ts
@@ -1,0 +1,167 @@
+import { getContainer } from './cosmos';
+import type { Alias, Member, Player, Session } from './types';
+import { sessionCostTotals } from './sessionCost';
+
+/**
+ * Shared player-identity resolution + owed classification.
+ *
+ * The friend-group app keys a lot of cross-session math on a player's *name*,
+ * but the same human can appear under more than one row identity across weeks:
+ *   - a persistent `memberId` link (the durable identity), and/or
+ *   - a renamed member (old player rows keep the old name but the memberId), and/or
+ *   - admin-curated `aliases` mapping an app signup name ↔ an e-transfer name.
+ *
+ * Matching by raw name only (as `/api/players/unpaid` used to) silently drops
+ * any week signed up under a variant. This module is the ONE place that resolves
+ * "who is this" (`resolveIdentity` + `matchesIdentity`) and "does this session
+ * count toward what they owe, and if not why" (`classifyOwed`) so the player
+ * card, the admin ledger drill-in, and the admin owed-audit can never disagree.
+ */
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/** True when `s.datetime` parses to a finite timestamp. Mirrors the admin
+ *  ledger's guard so a malformed/absent datetime drops the session instead of
+ *  poisoning the math with NaN. */
+export function finiteSessionDate(s: Pick<Session, 'datetime'>): boolean {
+  return typeof s.datetime === 'string' && Number.isFinite(new Date(s.datetime).getTime());
+}
+
+/**
+ * Given a name and the full alias list, return the set of lowercased candidate
+ * names that refer to the same person. Bidirectional: a match on either side of
+ * an `appName ↔ etransferName` pair contributes the other side. Always includes
+ * the input name itself. Pure — the caller supplies the alias rows.
+ */
+export function expandAliasNames(name: string, aliasRows: Alias[]): Set<string> {
+  const lower = name.trim().toLowerCase();
+  const names = new Set<string>([lower]);
+  for (const a of aliasRows) {
+    const app = typeof a.appName === 'string' ? a.appName.toLowerCase() : '';
+    const et = typeof a.etransferName === 'string' ? a.etransferName.toLowerCase() : '';
+    if (!app || !et) continue;
+    if (app === lower) names.add(et);
+    if (et === lower) names.add(app);
+  }
+  return names;
+}
+
+export interface ResolvedIdentity {
+  member: Member | null;
+  memberId: string | null;
+  /** Lowercased candidate names (queried/member name + alias-linked names). */
+  names: Set<string>;
+}
+
+/**
+ * Resolve a player's identity from a name (or memberId). Reads the `members`
+ * and `aliases` containers. Used by `/api/players/unpaid` and
+ * `/api/admin/owed-audit`. Never throws on an empty result — an unknown name
+ * resolves to `{ member: null, memberId: null, names: { <name> } }`.
+ */
+export async function resolveIdentity(arg: { name?: string; memberId?: string }): Promise<ResolvedIdentity> {
+  const membersContainer = getContainer('members');
+  const aliasesContainer = getContainer('aliases');
+
+  let member: Member | null = null;
+  if (arg.memberId) {
+    const { resource } = await membersContainer.item(arg.memberId, arg.memberId).read<Member>();
+    member = resource ?? null;
+  } else if (arg.name) {
+    // STRINGEQUALS(..., true) = case-insensitive on real Cosmos; the mock store
+    // filters on the `@name` param (also case-insensitive).
+    const { resources } = await membersContainer.items
+      .query({
+        query: 'SELECT * FROM c WHERE STRINGEQUALS(c.name, @name, true)',
+        parameters: [{ name: '@name', value: arg.name }],
+      })
+      .fetchAll();
+    member = (resources[0] as Member | undefined) ?? null;
+  }
+
+  const baseName = (member?.name ?? arg.name ?? '').trim();
+  const { resources: aliasRows } = await aliasesContainer.items
+    .query({ query: 'SELECT * FROM c' })
+    .fetchAll();
+  const names = baseName ? expandAliasNames(baseName, aliasRows as Alias[]) : new Set<string>();
+
+  return { member, memberId: member?.id ?? null, names };
+}
+
+/** Does this player row belong to the resolved identity? memberId is the strong
+ *  signal; name membership covers legacy/alias rows. */
+export function matchesIdentity(
+  p: Pick<Player, 'name' | 'memberId'>,
+  idy: Pick<ResolvedIdentity, 'memberId' | 'names'>,
+): boolean {
+  if (idy.memberId && p.memberId === idy.memberId) return true;
+  return typeof p.name === 'string' && idy.names.has(p.name.toLowerCase());
+}
+
+export type OwedReason =
+  | 'counted'
+  | 'paid'
+  | 'written_off'
+  | 'removed'
+  | 'waitlisted'
+  | 'unsettled_no_cost'
+  | 'settled_zero_owed'
+  | 'bad_datetime'
+  | 'future_or_active';
+
+export interface OwedContext {
+  activeSessionId: string;
+  now: number;
+  /** Full active-roster size of the session (the live per-person denominator).
+   *  Only consulted for unsettled past sessions. */
+  activeCount: number;
+}
+
+export interface OwedResult {
+  counted: boolean;
+  reason: OwedReason;
+  owedAmount: number;
+}
+
+/**
+ * Decide whether one (player, session) pair counts toward what the player owes,
+ * and the amount. This is the single source of truth shared by the unpaid card
+ * and the admin owed-audit — identical predicates, so the audit always explains
+ * exactly what the card shows.
+ *
+ *  - Settled session → the frozen `owedAmount` (counts only when > 0). A settled
+ *    debt counts even on the active session (the bill was already frozen).
+ *  - Unsettled past session → the live per-person share `totalCost / activeCount`
+ *    (the active session itself and any future session never count this way).
+ */
+export function classifyOwed(
+  player: Pick<Player, 'paid' | 'writtenOff' | 'removed' | 'waitlisted' | 'owedAmount'>,
+  session: Pick<Session, 'id' | 'datetime' | 'settled' | 'costPerCourt' | 'courts' | 'birdUsage' | 'birdUsages'>,
+  ctx: OwedContext,
+): OwedResult {
+  const miss = (reason: OwedReason): OwedResult => ({ counted: false, reason, owedAmount: 0 });
+
+  if (!finiteSessionDate(session)) return miss('bad_datetime');
+  if (player.paid === true) return miss('paid');
+  if (player.writtenOff === true) return miss('written_off');
+
+  if (session.settled) {
+    const owed = player.owedAmount ?? 0;
+    if (owed > 0) return { counted: true, reason: 'counted', owedAmount: round2(owed) };
+    return miss('settled_zero_owed');
+  }
+
+  // Unsettled: only PAST, non-active sessions are billable as a live share.
+  if (player.removed === true) return miss('removed');
+  if (player.waitlisted === true) return miss('waitlisted');
+  if (session.id === ctx.activeSessionId) return miss('future_or_active');
+  if (new Date(session.datetime).getTime() >= ctx.now) return miss('future_or_active');
+
+  const { totalCost } = sessionCostTotals(session);
+  if (totalCost > 0 && ctx.activeCount > 0) {
+    return { counted: true, reason: 'counted', owedAmount: round2(totalCost / ctx.activeCount) };
+  }
+  return miss('unsettled_no_cost');
+}


### PR DESCRIPTION
## Problem

Players reported seeing **some but not all** of what they owe in the Profile/Home balance card.

Investigation showed there is **no lookback window** — `GET /api/players/unpaid` already scans every archived session and the card renders every returned line. The gaps came from per-session **matching/filters**:

1. **Name-only matching** — the route matched the raw signed-in name, so weeks signed up under a renamed member or an alias-linked name were silently dropped. (The admin member-history route already resolved identity by `memberId + name + aliases`; the unpaid route didn't.)
2. **No finite-datetime guard** — a malformed/absent `datetime` poisoned the date math (the admin ledger guards this; unpaid didn't).

The user wasn't sure which sessions were missing, so they also wanted a way to **diagnose on real data**.

## Changes

- **`lib/playerIdentity.ts` (new)** — one shared source of truth for:
  - `resolveIdentity({ name?, memberId? })` → memberId + alias-expanded name set (bidirectional `appName ↔ etransferName`).
  - `matchesIdentity(player, identity)` — memberId is the strong signal; name membership covers legacy/alias rows.
  - `classifyOwed(player, session, ctx)` → `{ counted, reason, owedAmount }`, the single predicate for "does this week count, and if not why."
  - `finiteSessionDate(session)` — the ledger's NaN guard.
- **`GET /api/players/unpaid`** — resolves identity instead of exact-name match, delegates the per-session decision to `classifyOwed`, and drops malformed-datetime sessions cleanly. **Response shape unchanged.**
- **`app/api/members/[id]/history`** — now shares the alias helper (`expandAliasNames`); behavior preserved.
- **`GET /api/admin/owed-audit` (new, admin-only)** — per-session breakdown using the **same** classifier, with a `reason` for every excluded week and the list of linked `names`, so an admin can spot a week signed up under an *unlinked* variant and add an alias.
- **`PlayerProfileSheet`** — adds an **"Owed breakdown"** section to the member drill-in (fetches the audit by `memberId`), with legible-fail on a malformed/failed response.

## Why this is safe

- Identity matching is a strict superset of the old raw-name match (memberId/aliases only *add* matches).
- `classifyOwed` reproduces the previous unpaid predicates exactly — existing `players-unpaid` assertions still pass.

## Verification

- `npm test` — **1019 passed** (new `playerIdentity` + `admin-owed-audit` suites; extended `players-unpaid` with alias / memberId-rename / bad-datetime cases; member-history stays green).
- `npm run build` — clean; both `/api/players/unpaid` and `/api/admin/owed-audit` register.
- ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeGwYYBp9aHRzNULEHRRtV)_