### PR TITLE
feat(payments): per-session summary header (date · players · % paid · $/ea + Share)

### DIFF
--- a/__tests__/components/PaymentsCard.test.tsx
+++ b/__tests__/components/PaymentsCard.test.tsx
@@ -187,6 +187,103 @@ describe('<PaymentsCard />', () => {
       }
     });
 
+    it('summary header: shows players · % paid · $ each for the viewed session', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        fetchSettledPlayers([
+          { id: 'p1', name: 'Daisy', paid: true, owedAmount: 15 },
+          { id: 'p2', name: 'Mei', paid: false, owedAmount: 15 },
+        ]);
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        expect(screen.getByText(/2 players.*50% paid/)).toBeTruthy();
+        // The amount is a single "$15 each" node — it must NOT inflate the
+        // per-row exact-'$15' count (still 2 rows).
+        expect(screen.getByText('$15 each')).toBeTruthy();
+        expect(screen.getAllByText('$15').length).toBe(2);
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('summary header: hides the $ each line + Share button when settle flag is off', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'false';
+      try {
+        fetchSettledPlayers([{ id: 'p1', name: 'Daisy', paid: true, owedAmount: 15 }]);
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        expect(screen.queryByText(/each/i)).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Share receipt' })).toBeNull();
+        // Line 1 (cost-independent) still renders.
+        expect(screen.getByText(/1 player/)).toBeTruthy();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('summary header: Share disabled + "—" when the session has no cost', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // ACTIVE_SESSION is unsettled with no court/bird cost → no per-person amount.
+        fetchPlayers([{ id: 'p1', name: 'Daisy', paid: false }]);
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        const share = screen.getByRole('button', { name: 'Share receipt' });
+        expect((share as HTMLButtonElement).disabled).toBe(true);
+        expect(screen.getByText('—')).toBeTruthy();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('summary header: Share enabled but shows the recipient reason when none is set', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // fetchSettledPlayers 404s /api/admin/settings → no recipient.
+        fetchSettledPlayers([{ id: 'p1', name: 'Daisy', paid: true, owedAmount: 15 }]);
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        const share = screen.getByRole('button', { name: 'Share receipt' });
+        expect((share as HTMLButtonElement).disabled).toBe(false);
+        fireEvent.click(share);
+        await waitFor(() => expect(screen.getByText(/e-transfer recipient/i)).toBeTruthy());
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('summary header: Share opens the receipt sheet when a recipient is set', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        urlFetch(async (url) => {
+          if (url.includes('/api/admin/settings')) {
+            return new Response(JSON.stringify({ eTransferRecipient: { name: 'Grant', email: 'g@x.com' } }), { status: 200 });
+          }
+          if (url.includes('/api/sessions')) {
+            return new Response(JSON.stringify([SETTLED_SESSION]), { status: 200 });
+          }
+          if (url.includes('/api/session')) {
+            return new Response(JSON.stringify(SETTLED_SESSION), { status: 200 });
+          }
+          if (url.includes('/api/players')) {
+            return new Response(JSON.stringify([{ id: 'p1', name: 'Daisy', paid: true, owedAmount: 15 }]), { status: 200 });
+          }
+          return new Response('not found', { status: 404 });
+        });
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        fireEvent.click(screen.getByRole('button', { name: 'Share receipt' }));
+        await waitFor(() => expect(screen.getByText('Share session cost')).toBeTruthy());
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
     it('v1.5/C: removing a settled debtor opens Cover & remove, not a plain confirm', async () => {
       const prevSettle = process.env.NEXT_PUBLIC_FLAG_SETTLE;
       const prevLedger = process.env.NEXT_PUBLIC_FLAG_LEDGER;

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -8,7 +8,9 @@ import CardSkeleton from '@/components/primitives/CardSkeleton';
 import { fmtSessionLabel } from '@/lib/fmt';
 import { isFlagOn } from '@/lib/flags';
 import { useReportFetchFailure } from '@/lib/useOnline';
-import type { SettledSnapshot } from '@/lib/types';
+import { buildReceiptInput } from '@/lib/buildReceiptInput';
+import ReceiptSheet from './ReceiptSheet';
+import type { Session, ETransferRecipient } from '@/lib/types';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -47,14 +49,6 @@ export function canCover(
   );
 }
 
-interface SessionLite {
-  id: string;
-  datetime?: string;
-  maxPlayers?: number;
-  /** Present when the session was settled. PaymentsCard reads costPerPerson off this. */
-  settled?: SettledSnapshot;
-}
-
 interface PaymentsCardProps {
   refreshKey?: number;
   onOpenPlayer?: (memberId: string, name: string) => void;
@@ -65,7 +59,7 @@ interface PaymentsCardProps {
 }
 
 export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndividualReceipt, initialSessionId }: PaymentsCardProps) {
-  const [sessions, setSessions] = useState<SessionLite[]>([]);
+  const [sessions, setSessions] = useState<Session[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [viewedSessionId, setViewedSessionId] = useState<string | null>(null);
   const [allPlayers, setAllPlayers] = useState<Player[]>([]);
@@ -102,6 +96,12 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
     open: false, playerName: '', code: '', expiresAt: 0,
   });
 
+  // Group-receipt sheet for the VIEWED session (owned here — CommandCenter's
+  // receipt path is active-session-only, so it can't render a past session's
+  // receipt). Mirrors PastSessionsPage.
+  const [receiptOpen, setReceiptOpen] = useState(false);
+  const [globalRecipient, setGlobalRecipient] = useState<ETransferRecipient | null>(null);
+
   const isCurrentSession = activeSessionId === viewedSessionId;
   const viewedSession = sessions.find((s) => s.id === viewedSessionId);
   const settleFlagOn = isFlagOn('NEXT_PUBLIC_FLAG_SETTLE');
@@ -122,8 +122,8 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
         setActiveSessionId(null);
         return;
       }
-      const current = await sessionRes.json() as SessionLite;
-      const archived = await sessionsRes.json() as SessionLite[];
+      const current = await sessionRes.json() as Session;
+      const archived = await sessionsRes.json() as Session[];
 
       const all = current ? [current, ...archived.filter((s) => s.id !== current.id)] : archived;
       const sorted = all
@@ -172,6 +172,23 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
 
   useEffect(() => { void load(); }, [load, refreshKey]);
 
+  // The admin's own e-transfer recipient — the fallback used to address a
+  // receipt when the viewed session has no per-session override. A missing or
+  // failed recipient is NOT a load error: it just yields the receipt's
+  // "set a recipient first" reason, so it must not touch loadError.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${BASE}/api/admin/settings`, { cache: 'no-store' });
+        if (!res.ok) return;
+        const s = await res.json() as { eTransferRecipient?: ETransferRecipient | null };
+        if (!cancelled) setGlobalRecipient(s.eTransferRecipient ?? null);
+      } catch { /* recipient stays null → NO_RECIPIENT path, not a load error */ }
+    })();
+    return () => { cancelled = true; };
+  }, [refreshKey]);
+
   // Auto-dismiss the paid-toggle error after 4.5s. Without this, the banner
   // sticks around until the next toggle attempt, which can read as
   // "still failing" after a successful retry. Closes #62.
@@ -198,6 +215,18 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
   }, [allPlayers]);
 
   const total = lists.active.length;
+  const paidCount = lists.active.filter((p) => p.paid === true).length;
+  const paidPercent = total > 0 ? Math.round((paidCount / total) * 100) : 0;
+
+  // Single resolver — the SAME one behind /api/sessions/history and
+  // PastSessionsPage — so the header's "$Y each" and the receipt agree with
+  // the Past-sessions list by construction. Returns costPerPerson even when
+  // the recipient is null (the number needs no recipient; the receipt does).
+  const receiptRecipient = viewedSession?.eTransferRecipient ?? globalRecipient;
+  const receiptBuild = useMemo(
+    () => (viewedSession ? buildReceiptInput(viewedSession, allPlayers, receiptRecipient) : null),
+    [viewedSession, allPlayers, receiptRecipient],
+  );
 
   /* ── Actions ── */
 
@@ -479,6 +508,44 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
         >
           {toggleError}
         </p>
+      )}
+
+      {/* Per-session summary header — mirrors the Past sessions row for the
+          viewed chip. Line 1 is cost-independent; line 2 (amount + Share)
+          is gated on settleFlagOn like the other dollar surfaces below. */}
+      {!loadError && !playersError && viewedSession && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <p className="text-xs" style={{ color: 'var(--text-muted)', margin: 0 }}>
+            {[
+              fmtSessionLabel(viewedSession.datetime),
+              `${total} player${total === 1 ? '' : 's'}`,
+              total > 0 ? `${paidPercent}% paid` : '',
+            ].filter(Boolean).join(' · ')}
+          </p>
+          {settleFlagOn && (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+              <span
+                className="fs-md"
+                style={{
+                  color: 'var(--text-primary)',
+                  fontFamily: 'var(--font-mono), ui-monospace, monospace',
+                  fontWeight: 600,
+                }}
+              >
+                {receiptBuild?.costPerPerson != null ? `$${receiptBuild.costPerPerson} each` : '—'}
+              </span>
+              <button
+                type="button"
+                onClick={() => setReceiptOpen(true)}
+                disabled={receiptBuild?.costPerPerson == null}
+                className="cc-btn cc-btn-secondary"
+                style={{ fontSize: 12, padding: '4px 12px' }}
+              >
+                Share receipt
+              </button>
+            </div>
+          )}
+        </div>
       )}
 
       {/* What the admin absorbed by covering players this session. */}
@@ -775,6 +842,15 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
           expiresAt={resetSheet.expiresAt}
         />
       )}
+
+      {/* Group receipt for the VIEWED session (past or current). */}
+      <ReceiptSheet
+        open={receiptOpen}
+        onClose={() => setReceiptOpen(false)}
+        input={receiptBuild?.input ?? null}
+        error={receiptBuild?.error}
+        initialMode="group"
+      />
     </section>
   );
 }


### PR DESCRIPTION
## What & why

Folds the **Past sessions** summary into the admin **Payments** section (follow-up to #196). When the admin selects a session chip, Payments now shows a summary header above the per-player rows:

- **Line 1:** `<date> · N players · X% paid`
- **Line 2:** `$Y each` + a **Share receipt** button

The two surfaces overlapped — Payments' chip strip and the Past sessions list enumerate the same sessions. This puts the at-a-glance summary right where the admin actually chases payments, without a new screen.

## How it works

- **`$Y each` reuses `lib/buildReceiptInput.ts`** — the same resolver behind `/api/sessions/history` and `PastSessionsPage` — so the header amount, the Past sessions list, and the receipt agree by construction.
- **Line 1** (players / % paid) is computed from the roster PaymentsCard already loads — no new data.
- **PaymentsCard now owns its own `ReceiptSheet`** (mirroring `PastSessionsPage`). This also **fixes a latent bug**: the group Share now builds the receipt for the *viewed* session, so it works for **past** sessions — the previous CommandCenter receipt path only ever fetched the *active* session. The Ledger→Payments drill-in gains a working receipt it never had.
- **Recipient** for the Share receipt resolves `viewedSession.eTransferRecipient ?? admin global` via a new `/api/admin/settings` fetch (a missing recipient is not a load error — the sheet shows the actionable "set a recipient first" reason).

## Design decisions

- **Line 2 gated on `NEXT_PUBLIC_FLAG_SETTLE`**, matching the other three dollar surfaces in the card (per-player amount, covered note, "Sent" chip). Line 1 is ungated.
- **Type widening:** PaymentsCard's fetched sessions were typed as a narrow `SessionLite`; widened to the real `Session` (the endpoints already return full docs) so the resolver gets honest input.

## Test plan

- [x] `__tests__/components/PaymentsCard.test.tsx` — 5 new cases: settled+flag-on shows `players · % paid · $ each`; flag-off hides line 2 + Share; no-cost disables Share and shows `—`; no-recipient keeps Share enabled with the reason; recipient-set opens the sheet. The `$Y each` renders as a single node so it doesn't inflate the existing per-row `getAllByText('$15')` count.
- [x] Full suite **1033/1033**, `tsc --noEmit` clean, `eslint` no new warnings
- [x] Real runtime: dev server compiles under Turbopack, serves 200, admin/settings + sessions endpoints OK

## Out of scope (follow-up)

- The per-row **individual** receipt icon still routes through the active-session-only `CommandCenter.openReceipt` — a pre-existing quirk for past sessions, left unchanged to keep this the smallest change. A clean follow-up routes it through the same local sheet (`initialMode='individual'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
