### PR TITLE
fix(payments): individual receipt uses the viewed session, not the active one

### DIFF
--- a/__tests__/components/PaymentsCard.test.tsx
+++ b/__tests__/components/PaymentsCard.test.tsx
@@ -284,6 +284,42 @@ describe('<PaymentsCard />', () => {
       }
     });
 
+    it('per-row receipt icon opens the individual receipt for the VIEWED session', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        urlFetch(async (url) => {
+          if (url.includes('/api/admin/settings')) {
+            return new Response(JSON.stringify({ eTransferRecipient: { name: 'Grant', email: 'g@x.com' } }), { status: 200 });
+          }
+          if (url.includes('/api/sessions')) {
+            return new Response(JSON.stringify([SETTLED_SESSION]), { status: 200 });
+          }
+          if (url.includes('/api/session')) {
+            return new Response(JSON.stringify(SETTLED_SESSION), { status: 200 });
+          }
+          if (url.includes('/api/players')) {
+            return new Response(JSON.stringify([
+              { id: 'p1', name: 'Daisy', paid: true, owedAmount: 15 },
+              { id: 'p2', name: 'Mei', paid: false, owedAmount: 15 },
+            ]), { status: 200 });
+          }
+          return new Response('not found', { status: 404 });
+        });
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        // Icon renders locally now (no onSendIndividualReceipt prop needed).
+        fireEvent.click(screen.getByLabelText('Send receipt to Mei'));
+        await waitFor(() => expect(screen.getByText('Share session cost')).toBeTruthy());
+        // Individual mode, preset to the tapped player — proves it's THIS
+        // session's receipt, not the active-session delegation.
+        const select = screen.getByRole('combobox') as HTMLSelectElement;
+        expect(select.value).toBe('Mei');
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
     it('v1.5/C: removing a settled debtor opens Cover & remove, not a plain confirm', async () => {
       const prevSettle = process.env.NEXT_PUBLIC_FLAG_SETTLE;
       const prevLedger = process.env.NEXT_PUBLIC_FLAG_LEDGER;

--- a/components/admin/CommandCenter/CommandCenter.tsx
+++ b/components/admin/CommandCenter/CommandCenter.tsx
@@ -139,7 +139,6 @@ export default function CommandCenter({ refreshKey, setView, onExit }: CommandCe
       <PaymentsCard
         refreshKey={composedRefresh}
         onOpenPlayer={openPlayer}
-        onSendIndividualReceipt={(name) => openReceipt({ mode: 'individual', playerName: name })}
       />
 
       {/* Profile-style settings list (mirrors ProfileTab's SettingsList).

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -52,13 +52,12 @@ export function canCover(
 interface PaymentsCardProps {
   refreshKey?: number;
   onOpenPlayer?: (memberId: string, name: string) => void;
-  onSendIndividualReceipt?: (playerName: string) => void;
   /** When rendered standalone (e.g. drilled in from the Ledger), preselect
    *  this session's chip instead of defaulting to the active session. */
   initialSessionId?: string | null;
 }
 
-export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndividualReceipt, initialSessionId }: PaymentsCardProps) {
+export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSessionId }: PaymentsCardProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [viewedSessionId, setViewedSessionId] = useState<string | null>(null);
@@ -96,10 +95,12 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
     open: false, playerName: '', code: '', expiresAt: 0,
   });
 
-  // Group-receipt sheet for the VIEWED session (owned here — CommandCenter's
-  // receipt path is active-session-only, so it can't render a past session's
-  // receipt). Mirrors PastSessionsPage.
+  // Receipt sheet for the VIEWED session — group OR per-player individual —
+  // owned here because CommandCenter's receipt path is active-session-only and
+  // can't render a past session's receipt. Mirrors PastSessionsPage.
   const [receiptOpen, setReceiptOpen] = useState(false);
+  const [receiptMode, setReceiptMode] = useState<'group' | 'individual'>('group');
+  const [receiptPlayer, setReceiptPlayer] = useState<string | null>(null);
   const [globalRecipient, setGlobalRecipient] = useState<ETransferRecipient | null>(null);
 
   const isCurrentSession = activeSessionId === viewedSessionId;
@@ -227,6 +228,12 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
     () => (viewedSession ? buildReceiptInput(viewedSession, allPlayers, receiptRecipient) : null),
     [viewedSession, allPlayers, receiptRecipient],
   );
+
+  const openReceiptSheet = useCallback((mode: 'group' | 'individual', playerName?: string) => {
+    setReceiptMode(mode);
+    setReceiptPlayer(playerName ?? null);
+    setReceiptOpen(true);
+  }, []);
 
   /* ── Actions ── */
 
@@ -536,7 +543,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
               </span>
               <button
                 type="button"
-                onClick={() => setReceiptOpen(true)}
+                onClick={() => openReceiptSheet('group')}
                 disabled={receiptBuild?.costPerPerson == null}
                 className="cc-btn cc-btn-secondary"
                 style={{ fontSize: 12, padding: '4px 12px' }}
@@ -628,10 +635,10 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
                     )}
                   </button>
                 )}
-                {onSendIndividualReceipt && (
+                {settleFlagOn && receiptBuild?.costPerPerson != null && (
                   <button
                     type="button"
-                    onClick={() => onSendIndividualReceipt(player.name)}
+                    onClick={() => openReceiptSheet('individual', player.name)}
                     className="text-xs text-gray-400 hover:text-gray-200 px-2 py-1"
                     aria-label={`Send receipt to ${player.name}`}
                     title="Send individual receipt"
@@ -843,13 +850,14 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
         />
       )}
 
-      {/* Group receipt for the VIEWED session (past or current). */}
+      {/* Group or individual receipt for the VIEWED session (past or current). */}
       <ReceiptSheet
         open={receiptOpen}
         onClose={() => setReceiptOpen(false)}
         input={receiptBuild?.input ?? null}
         error={receiptBuild?.error}
-        initialMode="group"
+        initialMode={receiptMode}
+        initialPlayerName={receiptPlayer ?? undefined}
       />
     </section>
   );


### PR DESCRIPTION
## What & why

Fixes the follow-up noted in #197: the per-player **receipt icon** in the Payments card sent the **wrong** receipt for a past session.

The icon delegated to `CommandCenter.openReceipt`, which always re-fetched the **active** session. So while viewing a *past* session's payments, tapping a player's receipt icon generated a receipt for the **current** session instead of the one being viewed.

## Fix

Route the per-row individual receipt through **PaymentsCard's own `ReceiptSheet`** (added in #197) in `individual` mode, built from `buildReceiptInput` for the **viewed** session — so it's correct for past sessions and consistent with the group Share button right above it.

- Drops the now-obsolete `onSendIndividualReceipt` prop and its `CommandCenter` wiring (the delegation existed only to reach CommandCenter's active-session sheet, which is exactly the bug).
- The icon is now gated like the other dollar surfaces (`FLAG_SETTLE` + a known per-person cost) instead of on a prop — so it also appears in the **Ledger → Payments** drill-in mount, which previously had no receipt affordance at all.

## Test plan

- [x] `__tests__/components/PaymentsCard.test.tsx` — new case: tapping a player's receipt icon on a settled session opens the sheet in **individual** mode preset to that player (asserts the recipient `<select>` value), proving it's the viewed session's receipt, not the active-session delegation.
- [x] Full suite **1034/1034**, `tsc --noEmit` clean, `eslint` no new warnings
- [x] Real runtime: dev server compiles under Turbopack, serves 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
