### PR TITLE
feat(admin): Command Center UI polish (7 enhancements)

### DIFF
--- a/__tests__/components/NextSessionCard.test.tsx
+++ b/__tests__/components/NextSessionCard.test.tsx
@@ -49,6 +49,7 @@ describe('<NextSessionCard />', () => {
       expect(screen.getByText(/3 \/ 12 signed up/)).toBeTruthy();
       expect(screen.getByText(/\+1 waitlist/)).toBeTruthy();
       expect(screen.getByText(/Signup open/)).toBeTruthy();
+      expect(screen.getByText(/Sign up deadline/)).toBeTruthy();
       expect(screen.getByText(/left/)).toBeTruthy();
     });
   });
@@ -65,6 +66,36 @@ describe('<NextSessionCard />', () => {
     await waitFor(() => {
       expect(screen.getByText(/Signup closed/)).toBeTruthy();
     });
+  });
+
+  it('the signup pill toggles sign-ups: optimistic flip + PUT { signupOpen }', async () => {
+    const future = new Date(Date.now() + 3 * 86_400_000).toISOString();
+    let putBody: { signupOpen?: boolean } | null = null;
+    global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      const method = init?.method ?? 'GET';
+      if (method === 'PUT' && url.includes('/api/session')) {
+        putBody = JSON.parse(init?.body as string);
+        return new Response('{}', { status: 200 });
+      }
+      if (url.includes('/api/players')) return new Response(JSON.stringify([]), { status: 200 });
+      if (url.includes('/api/session')) {
+        return new Response(JSON.stringify(
+          { id: 's', title: 'X', datetime: future, deadline: future, courts: 2, maxPlayers: 12, signupOpen: true },
+        ), { status: 200 });
+      }
+      return new Response('not found', { status: 404 });
+    }) as typeof fetch;
+
+    render(<NextSessionCard />);
+    const pill = await screen.findByRole('switch', { name: 'Signup open' });
+    fireEvent.click(pill);
+
+    // Optimistic flip in the UI…
+    await waitFor(() => expect(screen.getByText('Signup closed')).toBeTruthy());
+    // …and the persisted PUT.
+    await waitFor(() => expect(putBody).not.toBeNull());
+    expect((putBody as unknown as { signupOpen: boolean }).signupOpen).toBe(false);
   });
 
   it('marks deadline as Passed when in the past', async () => {
@@ -90,32 +121,36 @@ describe('<NextSessionCard />', () => {
       courts: 2, maxPlayers: 12, signupOpen: true,
     };
 
-    it('a single tap on "Advance to next week" does NOT advance — it warns + asks to confirm', async () => {
+    it('a single tap on "Advance to next week" opens a confirm sheet instead of advancing', async () => {
       let advanced = 0;
       mockFetch(makeFetcher(session, []));
       render(<NextSessionCard onAdvance={() => { advanced += 1; }} />);
-      await waitFor(() => expect(screen.getByText('Advance to next week')).toBeTruthy());
+      const trigger = await screen.findByRole('button', { name: 'Advance to next week' });
 
-      fireEvent.click(screen.getByText('Advance to next week'));
+      fireEvent.click(trigger);
 
       expect(advanced).toBe(0);
-      expect(screen.getByText(/Can.t go back to the previous week once you advance/)).toBeTruthy();
-      expect(screen.getByText('Confirm advance →')).toBeTruthy();
+      await waitFor(() => {
+        expect(screen.getByText(/Can.t go back to the previous week once you advance/)).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Confirm advance →' })).toBeTruthy();
+      });
     });
 
-    it('Cancel reverts without advancing; Confirm calls onAdvance once', async () => {
+    it('Cancel in the sheet does not advance', async () => {
       let advanced = 0;
       mockFetch(makeFetcher(session, []));
       render(<NextSessionCard onAdvance={() => { advanced += 1; }} />);
-      await waitFor(() => expect(screen.getByText('Advance to next week')).toBeTruthy());
-
-      fireEvent.click(screen.getByText('Advance to next week'));
-      fireEvent.click(screen.getByText('Cancel'));
+      fireEvent.click(await screen.findByRole('button', { name: 'Advance to next week' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
       expect(advanced).toBe(0);
-      expect(screen.getByText('Advance to next week')).toBeTruthy();
+    });
 
-      fireEvent.click(screen.getByText('Advance to next week'));
-      fireEvent.click(screen.getByText('Confirm advance →'));
+    it('Confirm advance → calls onAdvance once', async () => {
+      let advanced = 0;
+      mockFetch(makeFetcher(session, []));
+      render(<NextSessionCard onAdvance={() => { advanced += 1; }} />);
+      fireEvent.click(await screen.findByRole('button', { name: 'Advance to next week' }));
+      fireEvent.click(await screen.findByRole('button', { name: 'Confirm advance →' }));
       expect(advanced).toBe(1);
     });
   });
@@ -155,13 +190,13 @@ describe('<NextSessionCard />', () => {
       }
     });
 
-    it('shows "Send the bill" when flag on and session not yet settled', async () => {
+    it('shows "Finalize cost" when flag on and session not yet settled', async () => {
       const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
       process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
       try {
         mockFetch(makeFetcher(session, []));
         render(<NextSessionCard onShareCost={() => {}} />);
-        await waitFor(() => expect(screen.getByText(/Send the bill/)).toBeTruthy());
+        await waitFor(() => expect(screen.getByText(/Finalize cost/)).toBeTruthy());
         expect(screen.queryByText(/Sent ·/)).toBeNull();
         expect(screen.queryByText(/Share cost/)).toBeNull();
       } finally {

--- a/__tests__/components/PaymentsCard.test.tsx
+++ b/__tests__/components/PaymentsCard.test.tsx
@@ -76,10 +76,10 @@ describe('<PaymentsCard />', () => {
     await waitFor(() => {
       expect(screen.getByText('Daisy')).toBeTruthy();
     });
-    // The summary header is intentionally gone — the strip + per-row
-    // pills carry payment state now.
+    // The old "X of Y paid" summary line is gone — the strip + per-row
+    // pills carry payment state now. The card keeps a plain "Payments" title.
     expect(screen.queryByText(/of 3 paid/i)).toBeNull();
-    expect(screen.queryByText('Payments')).toBeNull();
+    expect(screen.getByText('Payments')).toBeTruthy();
   });
 
   it('toggles paid optimistically and PATCHes the API', async () => {

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect, useState, useCallback } from 'react';
-import { fmtSessionLabel as fmtDate } from '@/lib/fmt';
+import { fmtSessionLabel as fmtDate, fmtDeadline } from '@/lib/fmt';
 import { isFlagOn } from '@/lib/flags';
 import type { SettledSnapshot } from '@/lib/types';
 import CardSkeleton from '@/components/primitives/CardSkeleton';
+import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -60,6 +61,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
   // (it used to sit next to "Edit details") shouldn't trigger it.
   const [confirmingAdvance, setConfirmingAdvance] = useState(false);
   const [shareCopied, setShareCopied] = useState(false);
+  const [togglingSignup, setTogglingSignup] = useState(false);
   const settleFlagOn = isFlagOn('NEXT_PUBLIC_FLAG_SETTLE');
 
   // Build a ready-to-paste sign-up invite and share it (native share sheet on
@@ -153,6 +155,31 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
     }
   }, [load]);
 
+  // Open/close sign-ups in place — optimistic flip + rollback on failure.
+  // `PUT /api/session` is a read-merge and only targets the active session,
+  // which is exactly what this card always shows. Mirrors PaymentsCard's
+  // togglePaid pattern.
+  const toggleSignup = useCallback(async () => {
+    if (!session || togglingSignup) return;
+    const next = !(session.signupOpen === true);
+    setSettleError(null);
+    setTogglingSignup(true);
+    setSession((s) => (s ? { ...s, signupOpen: next } : s));
+    try {
+      const res = await fetch(`${BASE}/api/session`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ signupOpen: next }),
+      });
+      if (!res.ok) throw new Error(String(res.status));
+    } catch {
+      setSession((s) => (s ? { ...s, signupOpen: !next } : s));
+      setSettleError("Couldn't update sign-ups. Try again.");
+    } finally {
+      setTogglingSignup(false);
+    }
+  }, [session, togglingSignup]);
+
   useEffect(() => { void load(); }, [load, refreshKey]);
 
   if (loading) return <CardSkeleton height={180} />;
@@ -187,9 +214,18 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
               Sent · ${session.settled?.costPerPerson}
             </span>
           )}
-          <span className={open ? 'cc-pill cc-pill-success' : 'cc-pill cc-pill-muted'}>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={open}
+            onClick={toggleSignup}
+            disabled={togglingSignup}
+            className={open ? 'cc-pill cc-pill-success' : 'cc-pill cc-pill-muted'}
+            style={{ cursor: 'pointer', font: 'inherit' }}
+            title={open ? 'Sign-ups are open — tap to close' : 'Sign-ups are closed — tap to open'}
+          >
             {open ? 'Signup open' : 'Signup closed'}
-          </span>
+          </button>
         </div>
       </header>
 
@@ -213,37 +249,26 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
 
       {countdown && (
         <p className="text-xs text-gray-400">
-          Deadline: <span className="text-gray-200">{countdown === 'closed' ? 'Passed' : countdown + ' left'}</span>
+          Sign up deadline: <span className="text-gray-200">
+            {fmtDeadline(session.deadline)}{countdown === 'closed' ? ' (Passed)' : ` (${countdown} left)`}
+          </span>
         </p>
       )}
 
       <div className="flex flex-wrap gap-2 pt-1">
         {settleFlagOn ? (
-          // Unified "Send the bill" flow. One primary action — pre-send it
-          // settles + opens share; post-send it just opens share again.
-          !isSettled ? (
+          // Post-settle: re-share the frozen bill. Settling itself moved to
+          // the footer "Finalize cost" action, beside Advance.
+          isSettled && onShareCost ? (
             <button
               type="button"
-              onClick={sendBill}
-              disabled={settling}
+              onClick={onShareCost}
               className="cc-btn cc-btn-primary"
-              title="Locks tonight's cost and opens the share sheet for the group chat."
             >
-              <span className="material-icons text-base align-middle">send</span>
-              {settling ? 'Sending…' : 'Send the bill'}
+              <span className="material-icons text-base align-middle">share</span>
+              Share again — ${session.settled?.costPerPerson} each
             </button>
-          ) : (
-            onShareCost && (
-              <button
-                type="button"
-                onClick={onShareCost}
-                className="cc-btn cc-btn-primary"
-              >
-                <span className="material-icons text-base align-middle">share</span>
-                Share again — ${session.settled?.costPerPerson} each
-              </button>
-            )
-          )
+          ) : null
         ) : (
           // Pre-flag stable users keep the simple "Share cost" affordance.
           onShareCost && (
@@ -280,38 +305,27 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         )}
       </div>
 
-      {/* Advance lives apart from the action row: a stray tap meant for
-          "Edit details" must not start a new week. Ghost-weight + a
-          two-step inline confirm (heavy, hard-to-reverse action). */}
-      {onAdvance && (
+      {/* End-of-night actions live apart from the action row: finalize the
+          cost, then start next week. Advance is ghost-weight + a confirm sheet
+          since it's hard to reverse (a stray tap must not archive the week). */}
+      {((settleFlagOn && !isSettled) || onAdvance) && (
         <div
           className="flex justify-end items-center gap-2 pt-3 mt-1"
           style={{ borderTop: '1px solid var(--divider)' }}
         >
-          {confirmingAdvance ? (
-            <>
-              <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
-                Can&apos;t go back to the previous week once you advance.
-              </span>
-              <button
-                type="button"
-                onClick={() => setConfirmingAdvance(false)}
-                className="cc-btn cc-btn-ghost text-xs"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setConfirmingAdvance(false);
-                  onAdvance();
-                }}
-                className="cc-btn cc-btn-danger text-xs"
-              >
-                Confirm advance →
-              </button>
-            </>
-          ) : (
+          {settleFlagOn && !isSettled && (
+            <button
+              type="button"
+              onClick={sendBill}
+              disabled={settling}
+              className="cc-btn cc-btn-primary"
+              title="Locks tonight's cost and opens the share sheet for the group chat."
+            >
+              <span className="material-icons text-base align-middle">send</span>
+              {settling ? 'Finalizing…' : 'Finalize cost'}
+            </button>
+          )}
+          {onAdvance && (
             <button
               type="button"
               onClick={() => setConfirmingAdvance(true)}
@@ -327,6 +341,48 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         <p role="alert" className="text-xs" style={{ color: 'var(--color-red, #ef4444)' }}>
           {settleError}
         </p>
+      )}
+
+      {/* Advance confirm — a bottom sheet (was an inline two-step confirm). */}
+      {onAdvance && (
+        <BottomSheet
+          open={confirmingAdvance}
+          onClose={() => setConfirmingAdvance(false)}
+          ariaLabel="Advance to next week"
+          maxHeight="50vh"
+          className="max-w-sm mx-auto"
+        >
+          <BottomSheetHeader className="flex items-center justify-between p-4">
+            <span style={{ fontSize: 16, fontWeight: 600 }}>Advance to next week</span>
+            <button
+              type="button"
+              onClick={() => setConfirmingAdvance(false)}
+              aria-label="Close"
+              style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+            >
+              <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+            </button>
+          </BottomSheetHeader>
+          <BottomSheetBody className="p-5 pb-8">
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
+                Can&apos;t go back to the previous week once you advance.
+              </p>
+              <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+                <button type="button" onClick={() => setConfirmingAdvance(false)} className="cc-btn cc-btn-ghost">
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setConfirmingAdvance(false); onAdvance(); }}
+                  className="cc-btn cc-btn-danger"
+                >
+                  Confirm advance →
+                </button>
+              </div>
+            </div>
+          </BottomSheetBody>
+        </BottomSheet>
       )}
     </section>
   );

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -5,6 +5,7 @@ import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/Bo
 import ResetAccessSheet from '../ResetAccessSheet';
 import CoverSheet, { type CoverSheetMode } from '../CoverSheet';
 import CardSkeleton from '@/components/primitives/CardSkeleton';
+import CardHeader from '@/components/primitives/CardHeader';
 import { fmtSessionLabel } from '@/lib/fmt';
 import { isFlagOn } from '@/lib/flags';
 import { useReportFetchFailure } from '@/lib/useOnline';
@@ -438,6 +439,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, onSendIndiv
 
   return (
     <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Payments">
+      <CardHeader icon="payments" title="Payments" />
       {/* Session selector — horizontal chips replace the old prev/next
           chevrons AND the standalone RecentSessionsStrip card (merged here).
           Built from the already-loaded `sessions` list (newest-first by id),

--- a/components/admin/CommandCenter/ReceiptSheet.tsx
+++ b/components/admin/CommandCenter/ReceiptSheet.tsx
@@ -110,7 +110,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel="Receipt" maxHeight="80vh" className="max-w-sm mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>Share session cost</span>
+        <span className="fs-lg" style={{ fontWeight: 600 }}>Share session cost</span>
         <button
           type="button"
           onClick={onClose}
@@ -137,7 +137,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
               role="alert"
               style={{
                 color: 'var(--color-red, #ef4444)',
-                fontSize: 13,
+                fontSize: 'var(--fs-base)',
                 lineHeight: 1.5,
                 margin: 0,
               }}
@@ -148,18 +148,24 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
 
           {input && (
             <>
-              {/* Mode toggle — uses canonical .segment-control */}
-              <div className="segment-control">
+              {/* Mode toggle — canonical .segment-control needs `flex` on the
+                  wrapper and `flex-1` centered children, else the active pill
+                  overlaps its neighbor (the class sets no display of its own). */}
+              <div className="segment-control flex" role="tablist" aria-label="Receipt mode">
                 <button
                   type="button"
-                  className={mode === 'group' ? 'segment-tab-active' : 'segment-tab-inactive'}
+                  role="tab"
+                  aria-selected={mode === 'group'}
+                  className={`flex-1 flex items-center justify-center text-xs ${mode === 'group' ? 'segment-tab-active' : 'segment-tab-inactive'}`}
                   onClick={() => setMode('group')}
                 >
                   Group
                 </button>
                 <button
                   type="button"
-                  className={mode === 'individual' ? 'segment-tab-active' : 'segment-tab-inactive'}
+                  role="tab"
+                  aria-selected={mode === 'individual'}
+                  className={`flex-1 flex items-center justify-center text-xs ${mode === 'individual' ? 'segment-tab-active' : 'segment-tab-inactive'}`}
                   onClick={() => setMode('individual')}
                   disabled={input.playerNames.length === 0}
                 >
@@ -169,7 +175,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
 
               {mode === 'individual' && (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                  <label style={{ fontSize: 12, color: 'var(--text-muted)' }}>Recipient</label>
+                  <label className="section-label" style={{ color: 'var(--text-muted)' }}>Recipient</label>
                   <select
                     value={selectedPlayer ?? ''}
                     onChange={(e) => setSelectedPlayer(e.target.value || null)}
@@ -226,7 +232,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
               )}
 
               <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-                <label style={{ fontSize: 12, color: 'var(--text-muted)' }}>Text version</label>
+                <label className="section-label" style={{ color: 'var(--text-muted)' }}>Text version</label>
                 <pre
                   style={{
                     fontFamily: 'var(--font-mono), ui-monospace, monospace',

--- a/lib/fmt.ts
+++ b/lib/fmt.ts
@@ -50,3 +50,13 @@ export function fmtFullDate(iso: string | undefined): string {
     return iso.slice(0, 10);
   }
 }
+
+/** Day-of-week + time — 'Thu, 8:00 PM'. Used for the sign-up deadline display. */
+export function fmtDeadline(iso: string | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+  } catch {
+    return iso.slice(0, 10);
+  }
+}


### PR DESCRIPTION
## What & why

Seven admin Command Center polish items from screenshot feedback, all reusing existing design-system primitives (`BottomSheet`, `CardHeader`, `.segment-control`, `cc-btn`/`cc-pill`, `--fs-*`). No API or data-model changes.

## Changes

**NextSessionCard**
1. **Advance confirm → bottom sheet.** The inline "Confirm advance" row is now a proper `BottomSheet` action sheet (harder to mis-tap; matches the app's sheet idiom).
2. **"Send the bill" → "Finalize cost"**, relocated beside "Advance to next week" as the two end-of-night actions. Behavior unchanged (finalize + open share).
3. **"Deadline: X" → "Sign up deadline: `<time>` (`<countdown>`)"** — e.g. "Sign up deadline: Mon 6:13 PM (23h left)". Adds `fmtDeadline` to `lib/fmt.ts`.
4. **"Signup open" pill → interactive toggle** (`role="switch"`). Optimistic flip + `PUT /api/session { signupOpen }`, rollback on failure. Only ever the active session (this card), so the endpoint's active-session scope is fine.

**PaymentsCard**
5. **Card title** — `<CardHeader icon="payments" title="Payments" />` (icon already in the subset).

**ReceiptSheet** (sheet chrome only — the shared receipt *image* is intentionally unchanged)
6. **Fix the Group/Individual segment overlap.** `.segment-control` sets no `display`, so its `gap` was inert and the active pill overlapped its neighbor. Adopted the canonical `flex` wrapper + `flex-1` centered children (same markup every other segment control uses).
7. **Tidy typography** — route raw inline font sizes through `--fs-*`/`.fs-*`, section labels as uppercase eyebrows.

## Test plan

- [x] `NextSessionCard.test.tsx`: advance opens a sheet (Confirm advance in a dialog); "Finalize cost" label; "Sign up deadline" label; signup toggle flips optimistically + PUTs `{ signupOpen: false }`.
- [x] `PaymentsCard.test.tsx`: the "Payments" title renders.
- [x] Full suite **1035/1035**, `tsc --noEmit` clean, `eslint` no new warnings, `design-canary` (segment-control contract) green.
- [x] **Real-browser smoke** (Playwright, dev:next): logged in as admin, confirmed the toggle switch, the "Sign up deadline: … (… left)" line, "Finalize cost" + "Advance to next week" in the footer, the "Payments" title, and the advance confirm rendering as a bottom-sheet dialog. (Screenshot verified.)

Note: the receipt-sheet segment fix wasn't reachable in the smoke without a settled session + recipient, but it's the canonical `.segment-control flex` pattern the rest of the app uses (the missing classes were the bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
