### PR TITLE
fix(birds): honest failures, clamped stock + drift signal, one rounding rule

### DIFF
--- a/__tests__/birds.test.ts
+++ b/__tests__/birds.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as cosmos from '@/lib/cosmos';
 import {
   resetMockStore,
   setupAdminPin,
@@ -10,6 +11,7 @@ import {
   seedAdminMember,
 } from './helpers';
 import { GET, POST, DELETE, PATCH } from '@/app/api/birds/route';
+import { POST as reconcile } from '@/app/api/birds/reconcile/route';
 
 describe('Birds API', () => {
   beforeEach(() => {
@@ -151,6 +153,93 @@ describe('Birds API', () => {
       const res = await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'));
       const data = await res.json();
       expect(data.remainingByPurchase[purchaseId]).toBe(0);
+    });
+
+    it('returns 503 when the read throws (not a lying 200 + zero stock)', async () => {
+      vi.spyOn(cosmos, 'getContainer').mockImplementation(() => {
+        throw new Error('cosmos down');
+      });
+      try {
+        const res = await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'));
+        expect(res.status).toBe(503);
+        const body = await res.json();
+        expect(body.error).toBeTruthy();
+      } finally {
+        vi.restoreAllMocks();
+      }
+    });
+
+    it('clamps over-consumed stock at 0 and reports the overshoot as stockDrift', async () => {
+      // Purchase 2 tubes, but sessions recorded 5 used (e.g. the purchase was
+      // edited down after the fact) → raw stock would be -3.
+      const createRes = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Over-used', tubes: 2, totalCost: 20,
+      }));
+      const { id: purchaseId } = await createRes.json();
+
+      seedPointer('session-2026-05-08');
+      seedSession('session-2026-05-08', {
+        birdUsages: [
+          { purchaseId, purchaseName: 'Over-used', tubes: 5, costPerTube: 10, totalBirdCost: 50 },
+        ],
+      });
+
+      const res = await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'));
+      const data = await res.json();
+      expect(data.currentStock).toBe(0);        // clamped, never negative
+      expect(data.stockDrift).toBe(3);          // overshoot surfaced, not hidden
+      expect(data.remainingByPurchase[purchaseId]).toBe(0); // per-purchase clamp
+    });
+
+    it('GET stock and reconcile agree: counting exactly the displayed stock is a no-op', async () => {
+      await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Parity', tubes: 10, totalCost: 100,
+      }));
+      const { id: purchaseId } = (await (await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'))).json()).purchases[0];
+      seedPointer('session-2026-05-15');
+      seedSession('session-2026-05-15', {
+        birdUsages: [
+          { purchaseId, purchaseName: 'Parity', tubes: 0.25, costPerTube: 10, totalBirdCost: 2.5 },
+          { purchaseId, purchaseName: 'Parity', tubes: 0.5, costPerTube: 10, totalBirdCost: 5 },
+        ],
+      });
+
+      const getData = await (await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'))).json();
+      expect(getData.currentStock).toBe(9.25);
+      const res = await reconcile(makeAdminRequest('POST', 'http://localhost:3000/api/birds/reconcile', {
+        countedTotal: getData.currentStock,
+      }));
+      // Same number on both sides → "already matches" (400 no-op), never a
+      // spurious penny adjustment.
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/already matches/i);
+    });
+
+    it('off-grid legacy usage: counting zero reconciles to exactly minus the displayed stock', async () => {
+      // 0.1-tube values are off the 0.25 grid AND inexact in binary — the
+      // raw-sum-round-once rule must keep GET's displayed stock and
+      // reconcile's delta in exact agreement anyway.
+      await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'OffGrid', tubes: 10, totalCost: 100,
+      }));
+      const { id: purchaseId } = (await (await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'))).json()).purchases[0];
+      seedPointer('session-2026-05-22');
+      seedSession('session-2026-05-22', {
+        birdUsages: [
+          { purchaseId, purchaseName: 'OffGrid', tubes: 0.1, costPerTube: 10, totalBirdCost: 1 },
+          { purchaseId, purchaseName: 'OffGrid', tubes: 0.1, costPerTube: 10, totalBirdCost: 1 },
+          { purchaseId, purchaseName: 'OffGrid', tubes: 0.1, costPerTube: 10, totalBirdCost: 1 },
+        ],
+      });
+
+      const getData = await (await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'))).json();
+      const res = await reconcile(makeAdminRequest('POST', 'http://localhost:3000/api/birds/reconcile', {
+        countedTotal: 0,
+      }));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.delta).toBe(-getData.currentStock);
     });
   });
 

--- a/app/api/birds/reconcile/route.ts
+++ b/app/api/birds/reconcile/route.ts
@@ -40,11 +40,17 @@ export async function POST(req: NextRequest) {
     const { resources: sessions } = await sessionsContainer.items
       .query({ query: 'SELECT c.birdUsage, c.birdUsages FROM c WHERE IS_DEFINED(c.birdUsage) OR IS_DEFINED(c.birdUsages)' })
       .fetchAll();
+    // Sum RAW, round once — the same rule GET /api/birds uses, so this delta
+    // can never disagree with the displayed stock by a rounding penny.
     const totalUsed = (sessions as Pick<Session, 'birdUsage' | 'birdUsages'>[]).reduce(
       (sum, s) => sum + totalTubes(normalizeBirdUsages(s)),
       0,
     );
 
+    // Deliberately UNCLAMPED (GET clamps its display at 0 + reports the
+    // overshoot as stockDrift): the delta must offset the true raw stock so
+    // that after reconciling, raw stock === counted. Clamping here would
+    // under-adjust a drifted inventory.
     const currentStock = Math.round((totalPurchased + totalAdjustments - totalUsed) * 100) / 100;
     const delta = Math.round((counted - currentStock) * 100) / 100;
 

--- a/app/api/birds/route.ts
+++ b/app/api/birds/route.ts
@@ -35,20 +35,27 @@ export async function GET(req: NextRequest) {
     // All-time tubes used, both in total and per purchase. The per-purchase
     // map drives `remainingByPurchase`, which the create-session bird picker
     // uses to hide depleted purchases (remaining <= 0).
+    // Sum RAW and round once at the end — the same rule reconcile uses, so a
+    // stock-take delta can never be a rounding penny off from the stock this
+    // GET displays. (Previously totalUsed was pre-rounded before the stock
+    // formula while reconcile summed raw.)
     const usedByPurchase = new Map<string, number>();
-    let totalUsed = 0;
+    let totalUsedRaw = 0;
     for (const s of sessions as Pick<Session, 'birdUsage' | 'birdUsages'>[]) {
       for (const u of normalizeBirdUsages(s)) {
         const t = u.tubes ?? 0;
-        totalUsed += t;
+        totalUsedRaw += t;
         usedByPurchase.set(u.purchaseId, (usedByPurchase.get(u.purchaseId) ?? 0) + t);
       }
     }
-    totalUsed = Math.round(totalUsed * 100) / 100;
+    const totalUsed = Math.round(totalUsedRaw * 100) / 100;
 
+    // Clamped at 0 for display — a purchase can be over-consumed (e.g. its
+    // tubes were edited down after sessions used them), but negative
+    // "remaining" is meaningless to the picker (which hides remaining <= 0).
     const remainingByPurchase: Record<string, number> = {};
     for (const p of purchases as { id: string; tubes: number }[]) {
-      remainingByPurchase[p.id] = Math.round((p.tubes - (usedByPurchase.get(p.id) ?? 0)) * 100) / 100;
+      remainingByPurchase[p.id] = Math.max(0, Math.round((p.tubes - (usedByPurchase.get(p.id) ?? 0)) * 100) / 100);
     }
 
     const sixtyDaysAgo = Date.now() - 60 * 86_400_000;
@@ -65,11 +72,21 @@ export async function GET(req: NextRequest) {
       ? recentUsedLast60d / recentSessionsLast60d
       : 0;
 
+    // Stock can go negative when recorded usage exceeds recorded purchases
+    // (a purchase edited down or deleted after sessions consumed it). Display
+    // clamps at 0; the overshoot is surfaced as `stockDrift` so the skew is
+    // visible instead of silently rendering "-3 tubes on hand".
+    const currentStockRaw = Math.round((totalPurchased + totalAdjustments - totalUsedRaw) * 100) / 100;
+    const currentStock = Math.max(0, currentStockRaw);
+    const stockDrift = currentStockRaw < 0 ? Math.abs(currentStockRaw) : 0;
+
     return NextResponse.json({
       purchases,
       adjustments,
       remainingByPurchase,
-      currentStock: Math.round((totalPurchased + totalAdjustments - totalUsed) * 100) / 100,
+      currentStock,
+      /** Tubes recorded as used beyond recorded purchases (0 when records balance). */
+      stockDrift,
       totalPurchased,
       totalAdjustments,
       totalUsed,
@@ -79,8 +96,11 @@ export async function GET(req: NextRequest) {
       burnPerSession,
     });
   } catch (error) {
+    // 503, never a lying 200 + zero stock (CLAUDE.md: lying empty state is
+    // forbidden) — a confident "0 tubes on hand" on a broken backend reads
+    // as "time to reorder". Clients guard on res.ok.
     console.error('GET birds error:', error);
-    return NextResponse.json({ purchases: [], currentStock: 0 });
+    return NextResponse.json({ error: 'Failed to load bird inventory' }, { status: 503 });
   }
 }
 

--- a/components/admin/BirdInventoryView.tsx
+++ b/components/admin/BirdInventoryView.tsx
@@ -57,6 +57,8 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
   const [currentStock, setCurrentStock] = useState(0);
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
+  // Distinct from loaded-but-empty — see loadAll's !ok guard.
+  const [loadError, setLoadError] = useState(false);
   const [shuttleName, setShuttleName] = useState('');
   const [tubes, setTubes] = useState(0);
   const [totalCost, setTotalCost] = useState(0);
@@ -76,21 +78,25 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
 
   const loadAll = useCallback(async () => {
     setLoading(true);
+    setLoadError(false);
     try {
       const [birdsRes, sessionsRes] = await Promise.all([
         fetch(`${BASE}/api/birds`, { cache: 'no-store' }),
         fetch(`${BASE}/api/sessions`, { cache: 'no-store' }),
       ]);
-      if (birdsRes.ok) {
-        const data = await birdsRes.json();
-        setPurchases(data.purchases ?? []);
-        setCurrentStock(data.currentStock ?? 0);
+      // A failed fetch must NOT render the same UI as an empty inventory
+      // (lying-empty rule) — "0 tubes / out of stock" on a broken backend
+      // reads as "time to reorder".
+      if (!birdsRes.ok || !sessionsRes.ok) {
+        setLoadError(true);
+        return;
       }
-      if (sessionsRes.ok) {
-        setSessions((await sessionsRes.json()) as Session[]);
-      }
+      const data = await birdsRes.json();
+      setPurchases(data.purchases ?? []);
+      setCurrentStock(data.currentStock ?? 0);
+      setSessions((await sessionsRes.json()) as Session[]);
     } catch {
-      /* ignore */
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -218,6 +224,21 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
     } finally {
       setSavingEdit(false);
     }
+  }
+
+  if (loadError) {
+    return (
+      <div className="animate-slideInRight space-y-4">
+        <AdminBackHeader onBack={onBack} title="Bird Inventory" />
+        <div role="alert" style={{ padding: '40px 24px', textAlign: 'center', color: 'var(--text-muted)' }}>
+          <p style={{ fontWeight: 600, color: 'var(--text-primary)' }}>Couldn&apos;t load bird inventory</p>
+          <p style={{ fontSize: 13, marginTop: 6 }}>You may be offline. Reconnect, then retry.</p>
+          <button type="button" className="btn-primary" style={{ marginTop: 14 }} onClick={() => void loadAll()}>
+            Retry
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/components/admin/CommandCenter/BirdsPage.tsx
+++ b/components/admin/CommandCenter/BirdsPage.tsx
@@ -50,6 +50,7 @@ function Stars({ n }: { n: number }) {
 export default function BirdsPage({ onBack }: BirdsPageProps) {
   const [purchases, setPurchases] = useState<BirdPurchase[]>([]);
   const [currentStock, setCurrentStock] = useState(0);
+  const [stockDrift, setStockDrift] = useState(0);
   const [totalAdjustments, setTotalAdjustments] = useState(0);
   const [usedByPurchase, setUsedByPurchase] = useState<Map<string, number>>(new Map());
   const [recentSessionCount, setRecentSessionCount] = useState(0);
@@ -91,8 +92,15 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         fetch(`${BASE}/api/birds`, { cache: 'no-store' }),
         fetch(`${BASE}/api/sessions`, { cache: 'no-store' }),
       ]);
-      const birds = birdsRes.ok ? await birdsRes.json() as { purchases: BirdPurchase[]; currentStock: number; totalAdjustments?: number } : { purchases: [], currentStock: 0, totalAdjustments: 0 };
-      const sessions = sessionsRes.ok ? await sessionsRes.json() as Session[] : [];
+      // A non-ok response is a load FAILURE, not an empty inventory — falling
+      // back to a zero object here rendered the forbidden lying-empty state
+      // (confident "0 tubes" on a broken backend).
+      if (!birdsRes.ok || !sessionsRes.ok) {
+        setLoadError(true);
+        return;
+      }
+      const birds = await birdsRes.json() as { purchases: BirdPurchase[]; currentStock: number; stockDrift?: number; totalAdjustments?: number };
+      const sessions = await sessionsRes.json() as Session[];
 
       // Build two independent quantities:
       //   - `used` is all-time per-purchase usage (used to compute remaining
@@ -121,6 +129,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
       }
       setPurchases(birds.purchases ?? []);
       setCurrentStock(birds.currentStock ?? 0);
+      setStockDrift(birds.stockDrift ?? 0);
       setTotalAdjustments(birds.totalAdjustments ?? 0);
       setUsedByPurchase(used);
       setRecentSessionCount(recentSessions);
@@ -428,6 +437,12 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         {totalAdjustments !== 0 && (
           <p style={{ fontSize: 11, color: 'var(--ink-faint)', margin: '4px 0 0' }}>
             includes {totalAdjustments > 0 ? '+' : '−'}{Math.abs(totalAdjustments)} from a manual recount
+          </p>
+        )}
+        {stockDrift > 0 && (
+          <p role="alert" style={{ fontSize: 11, color: 'var(--amber)', margin: '4px 0 0', display: 'flex', alignItems: 'center', gap: 5 }}>
+            <span className="material-icons" style={{ fontSize: 14 }} aria-hidden="true">warning</span>
+            Records show {stockDrift} more tube{stockDrift === 1 ? '' : 's'} used than purchased — run a recount to true up.
           </p>
         )}
         {burnPerSession > 0 && recentSessionCount > 0 && (


### PR DESCRIPTION
## What & why

**PR 1.1 of the bird-inventory audit plan** (Phase 1 — correctness). Fixes the domain's honesty problems: a failed read must not look like an empty inventory, and stock records must not silently go negative.

## Changes

1. **`GET /api/birds` → 503 on read failure** (was `200 + {purchases:[], currentStock:0}` — the forbidden lying-empty state; a broken backend rendered as "0 tubes on hand, time to reorder"). This also makes the existing `BirdInventoryCard.loaderror` test honest — it previously mocked a 503 the route could never emit.
2. **BirdsPage stops zero-filling on `!res.ok`** — it only tripped `loadError` on thrown fetches; an HTTP error fell back to a zero object. Both failure shapes now show the retry surface.
3. **Clamped stock + drift signal** — `currentStock` and `remainingByPurchase` clamp at 0; the overshoot (usage recorded beyond purchases, e.g. a purchase edited down after sessions consumed it) surfaces as a new additive `stockDrift` field and a warning chip in BirdsPage: *"Records show N more tubes used than purchased — run a recount to true up."*
4. **One rounding rule** — GET pre-rounded `totalUsed` before the stock formula while reconcile summed raw; both now sum raw and round once, so a stock-take delta can never disagree with displayed stock by a penny. Reconcile stays deliberately **unclamped** (documented) so a drifted inventory reconciles to the true raw count.
5. **Legacy `BirdInventoryView` (bpm-stable) gains `loadError`** — it had `catch { /* ignore */ }` and confidently rendered "0 tubes / out of stock" on failure. Patched now (per decision) rather than waiting for flag retirement.

## Behavior change to note

`GET /api/birds` failures now return **503** instead of 200+empty. All shipped consumers guard on `res.ok` (BirdsPage, AdvanceSessionForm, SetupPage, SessionDetailsEditor, AdminDashTiles, AdminConsoleHero) — verified during the audit.

## Test plan

- [x] +4 tests: 503 on forced container throw; over-consumed purchase → clamp + `stockDrift`; on-grid parity (counting exactly the displayed stock → 400 no-op); off-grid legacy usage (0.1 tubes) → count-zero delta === −displayed stock
- [x] Full suite **1040/1040** (was 1036), `tsc --noEmit` clean, `eslint` no new warnings

Part of the audit plan in `docs`-less plan doc; next up: PR 1.2 (guard purchase delete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
