### PR TITLE
refactor(birds): shared snapshotBirdUsage helper + batch N+1 purchase reads

### DIFF
--- a/__tests__/birdUsages.helpers.test.ts
+++ b/__tests__/birdUsages.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tubesUsedAcross, avgTubesPerSession, runwayWeeks, mergeBirdUsageEdit } from '@/lib/birdUsages';
+import { tubesUsedAcross, avgTubesPerSession, runwayWeeks, mergeBirdUsageEdit, snapshotBirdUsage } from '@/lib/birdUsages';
 import type { Session, BirdUsage } from '@/lib/types';
 
 describe('mergeBirdUsageEdit — preserve other purchases when editing one', () => {
@@ -107,5 +107,27 @@ describe('runwayWeeks', () => {
 
   it('returns Infinity when avg is 0 but stock remains', () => {
     expect(runwayWeeks(10, 0)).toBe(Infinity);
+  });
+});
+
+describe('snapshotBirdUsage', () => {
+  const purchase = { id: 'p1', name: 'Victor Master No.3', costPerTube: 21.33 };
+
+  it('snapshots the purchase identity + cost, rounding to cents', () => {
+    const u = snapshotBirdUsage(purchase, 1.5);
+    expect(u).toEqual({
+      purchaseId: 'p1',
+      purchaseName: 'Victor Master No.3',
+      tubes: 1.5,
+      costPerTube: 21.33,
+      totalBirdCost: 31.99, // 1.5 * 21.33 = 31.994999… in float → 31.99 (same as all write paths)
+    });
+  });
+
+  it('rounds penny-fraction products the same way all write paths must', () => {
+    // 0.25 * 21.33 = 5.3325 → 5.33
+    expect(snapshotBirdUsage(purchase, 0.25).totalBirdCost).toBe(5.33);
+    // 3 * 21.33 = 63.99 exactly
+    expect(snapshotBirdUsage(purchase, 3).totalBirdCost).toBe(63.99);
   });
 });

--- a/app/api/session/advance/route.ts
+++ b/app/api/session/advance/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, setActiveSessionId, sessionIdFromDate } from '@/lib/cosmos';
 import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { toValidIso } from '@/app/api/session/route';
-import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
+import { normalizeBirdUsages, totalBirdCost, snapshotBirdUsage } from '@/lib/birdUsages';
 import type { BirdUsage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -135,36 +135,35 @@ export async function POST(req: NextRequest) {
     }
 
     // Resolve any bird tubes the admin chose to load into the new session at
-    // creation time. Body shape: birdUsages: [{ purchaseId, tubes }]. We look
-    // each purchase up in the inventory and snapshot its cost (same authoritative
-    // snapshotting as PATCH /api/session/bird-usage), so different-priced brands
-    // are costed correctly. Invalid/zero/unknown entries are skipped silently.
+    // creation time. Body shape: birdUsages: [{ purchaseId, tubes }]. Each
+    // purchase is looked up and its cost snapshotted via the shared
+    // `snapshotBirdUsage` (same formula as PUT /api/session and PATCH
+    // /api/session/bird-usage). Invalid/zero/unknown entries are skipped
+    // silently. Reads are batched (was an N+1 sequential loop).
     let birdUsages: BirdUsage[] = [];
     if (Array.isArray(body.birdUsages) && body.birdUsages.length > 0) {
-      const birdsContainer = getContainer('birds');
-      const resolved: BirdUsage[] = [];
+      // Validate + de-dupe first (same purchase twice → keep the last, in
+      // last-occurrence order, matching the previous splice-and-push behavior).
+      const wanted = new Map<string, number>();
       for (const entry of body.birdUsages) {
         const purchaseId = typeof entry?.purchaseId === 'string' ? entry.purchaseId : '';
         const tubes = Number(entry?.tubes);
         if (!purchaseId) continue;
         if (!Number.isFinite(tubes) || tubes <= 0 || tubes > 100) continue;
         if (Math.round(tubes * 4) !== tubes * 4) continue; // 0.25 increments only
-        // De-dupe: if the same purchase appears twice, keep the last.
-        const dupeIdx = resolved.findIndex((u) => u.purchaseId === purchaseId);
-        if (dupeIdx !== -1) resolved.splice(dupeIdx, 1);
-        try {
-          const { resource: purchase } = await birdsContainer.item(purchaseId, purchaseId).read();
-          if (!purchase) continue;
-          resolved.push({
-            purchaseId: purchase.id,
-            purchaseName: purchase.name,
-            tubes,
-            costPerTube: purchase.costPerTube,
-            totalBirdCost: Math.round(tubes * purchase.costPerTube * 100) / 100,
-          });
-        } catch {
-          continue;
-        }
+        wanted.delete(purchaseId); // re-insert at the end on dupe
+        wanted.set(purchaseId, tubes);
+      }
+      const birdsContainer = getContainer('birds');
+      const ids = Array.from(wanted.keys());
+      const reads = await Promise.all(
+        ids.map((id) => birdsContainer.item(id, id).read().catch(() => ({ resource: undefined }))),
+      );
+      const resolved: BirdUsage[] = [];
+      for (let i = 0; i < ids.length; i++) {
+        const purchase = reads[i].resource;
+        if (!purchase) continue; // unknown purchase — skip silently (pre-existing contract)
+        resolved.push(snapshotBirdUsage(purchase, wanted.get(ids[i])!));
       }
       birdUsages = resolved;
     }

--- a/app/api/session/bird-usage/route.ts
+++ b/app/api/session/bird-usage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
 import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
-import { normalizeBirdUsages } from '@/lib/birdUsages';
+import { normalizeBirdUsages, snapshotBirdUsage } from '@/lib/birdUsages';
 import type { BirdUsage, Session } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -57,13 +57,7 @@ export async function PATCH(req: NextRequest) {
 
     const next: BirdUsage[] = [...existing];
     if (tubes > 0) {
-      next.push({
-        purchaseId: purchase.id,
-        purchaseName: purchase.name,
-        tubes,
-        costPerTube: purchase.costPerTube,
-        totalBirdCost: Math.round(tubes * purchase.costPerTube * 100) / 100,
-      });
+      next.push(snapshotBirdUsage(purchase, tubes));
     }
 
     const updated: Session = { ...session, birdUsages: next };

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, POINTER_ID, DEFAULT_SESSION } from '@/lib/cosmos';
 import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
+import { snapshotBirdUsage } from '@/lib/birdUsages';
 import type { BirdUsage, ETransferRecipient } from '@/lib/types';
 
 function isValidETransferRecipient(value: unknown): value is ETransferRecipient {
@@ -86,11 +87,12 @@ export async function PUT(req: NextRequest) {
     if (typeof body.showCostBreakdown === 'boolean') updates.showCostBreakdown = body.showCostBreakdown;
 
     // Handle bird usages — array of { purchaseId, tubes }. Each entry is
-    // looked up live so cost snapshots are authoritative.
+    // looked up live so cost snapshots are authoritative. Validate everything
+    // synchronously first, then batch the purchase reads (was an N+1 loop —
+    // one sequential read per entry).
     let birdUsages: BirdUsage[] | undefined = undefined;
     if (Array.isArray(body.birdUsages)) {
-      const entries: BirdUsage[] = [];
-      const birdsContainer = getContainer('birds');
+      const wanted: Array<{ purchaseId: string; tubes: number }> = [];
       for (const entry of body.birdUsages) {
         const tubes = Number(entry?.tubes);
         if (!Number.isFinite(tubes) || tubes <= 0 || tubes > 100) {
@@ -104,17 +106,19 @@ export async function PUT(req: NextRequest) {
         if (typeof purchaseId !== 'string' || !purchaseId) {
           return NextResponse.json({ error: 'Bird purchase must be selected' }, { status: 400 });
         }
-        const { resource: purchase } = await birdsContainer.item(purchaseId, purchaseId).read();
+        wanted.push({ purchaseId, tubes });
+      }
+      const birdsContainer = getContainer('birds');
+      const purchaseReads = await Promise.all(
+        wanted.map((w) => birdsContainer.item(w.purchaseId, w.purchaseId).read()),
+      );
+      const entries: BirdUsage[] = [];
+      for (let i = 0; i < wanted.length; i++) {
+        const purchase = purchaseReads[i].resource;
         if (!purchase) {
           return NextResponse.json({ error: 'Selected bird purchase not found' }, { status: 404 });
         }
-        entries.push({
-          purchaseId: purchase.id,
-          purchaseName: purchase.name,
-          tubes,
-          costPerTube: purchase.costPerTube,
-          totalBirdCost: Math.round(tubes * purchase.costPerTube * 100) / 100,
-        });
+        entries.push(snapshotBirdUsage(purchase, wanted[i].tubes));
       }
       birdUsages = entries;
     }

--- a/lib/birdUsages.ts
+++ b/lib/birdUsages.ts
@@ -1,4 +1,4 @@
-import type { BirdUsage, Session } from './types';
+import type { BirdPurchase, BirdUsage, Session } from './types';
 
 /**
  * Reads the bird usages off a session document, tolerating both the
@@ -27,6 +27,26 @@ export function totalTubes(usages: BirdUsage[]): number {
 export function totalBirdCost(usages: BirdUsage[]): number {
   const raw = usages.reduce((sum, u) => sum + (u.totalBirdCost ?? 0), 0);
   return Math.round(raw * 100) / 100;
+}
+
+/**
+ * Build the authoritative `BirdUsage` snapshot for one purchase + tube count.
+ * The SINGLE source of the per-entry cost formula — `PUT /api/session`,
+ * `PATCH /api/session/bird-usage`, and `POST /api/session/advance` all write
+ * through this, so the snapshot shape and rounding can't drift between the
+ * three write paths (each previously inlined its own copy).
+ */
+export function snapshotBirdUsage(
+  purchase: Pick<BirdPurchase, 'id' | 'name' | 'costPerTube'>,
+  tubes: number,
+): BirdUsage {
+  return {
+    purchaseId: purchase.id,
+    purchaseName: purchase.name,
+    tubes,
+    costPerTube: purchase.costPerTube,
+    totalBirdCost: Math.round(tubes * purchase.costPerTube * 100) / 100,
+  };
 }
 
 /**


### PR DESCRIPTION
## What & why

**PR 2.1 of the bird-inventory audit plan** (Phase 2 — consolidation). Pure refactor, no behavior change.

## Changes

1. **`lib/birdUsages.ts` gains `snapshotBirdUsage(purchase, tubes)`** — the per-entry cost-snapshot formula (`round(tubes × costPerTube × 100)/100` + the `BirdUsage` shape) was inlined identically at three write sites: `PUT /api/session`, `PATCH /api/session/bird-usage`, and `POST /api/session/advance`. All three now write through the one helper, so the snapshot shape/rounding can't drift between them (same single-source principle as `sessionCostTotals`).
2. **N+1 fix** — session PUT and advance read one purchase per bird entry inside sequential `for` loops. Both now validate all entries synchronously first, then batch the purchase reads with `Promise.all`.

**Intentionally unchanged:** validation contracts (PUT rejects `tubes <= 0`, advance silently skips invalid entries) — unifying those is PR 2.2's job, kept separate so this PR stays a provable no-behavior-change refactor.

## Test plan

- [x] +2 unit tests pinning the snapshot shape and cent-rounding (including the float-edge `1.5 × 21.33 → 31.99` case, matching what all write paths have always produced)
- [x] Existing `session-bird-usage` / `sessions` / `advance` suites green unchanged — behavior parity
- [x] Full suite **1038/1038**, `tsc --noEmit` clean, `eslint` clean

Independent of PR #205 (file-disjoint); both can merge in either order. Next: PR 1.2 (guard purchase delete) + PR 2.2 (unified validation) build on these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
