### PR TITLE
fix(birds): guard purchase delete against session references + in-sheet confirm

### DIFF
--- a/__tests__/birds.test.ts
+++ b/__tests__/birds.test.ts
@@ -255,6 +255,55 @@ describe('Birds API', () => {
       expect(res.status).toBe(200);
     });
 
+    it('refuses (409) to delete a purchase that sessions still reference', async () => {
+      const createRes = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Referenced', tubes: 4, totalCost: 80,
+      }));
+      const { id } = await createRes.json();
+
+      seedPointer('session-2026-06-01');
+      seedSession('session-2026-06-01', {
+        datetime: '2026-06-01T19:00:00-04:00',
+        birdUsages: [
+          { purchaseId: id, purchaseName: 'Referenced', tubes: 2, costPerTube: 20, totalBirdCost: 40 },
+        ],
+      });
+
+      const res = await DELETE(makeAdminRequest('DELETE', 'http://localhost:3000/api/birds', { id }));
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toMatch(/used by 1 session/i);
+      expect(body.error).toMatch(/move its tubes/i);
+      expect(body.sessionCount).toBe(1);
+      expect(body.sessionDates).toEqual(['2026-06-01T19:00:00-04:00']);
+
+      // Doc untouched — still visible in GET, stock math intact.
+      const getData = await (await GET(makeAdminRequest('GET', 'http://localhost:3000/api/birds'))).json();
+      expect(getData.purchases).toHaveLength(1);
+      expect(getData.currentStock).toBe(2);
+    });
+
+    it('still deletes an adjustment doc (reconcile undo) even when sessions have usage', async () => {
+      const createRes = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Stocked', tubes: 4, totalCost: 80,
+      }));
+      const { id: purchaseId } = await createRes.json();
+      seedPointer('session-2026-06-08');
+      seedSession('session-2026-06-08', {
+        birdUsages: [
+          { purchaseId, purchaseName: 'Stocked', tubes: 1, costPerTube: 20, totalBirdCost: 20 },
+        ],
+      });
+      // Create an adjustment via reconcile, then undo it via DELETE.
+      const recRes = await reconcile(makeAdminRequest('POST', 'http://localhost:3000/api/birds/reconcile', {
+        countedTotal: 2,
+      }));
+      const { adjustment } = await recRes.json();
+
+      const res = await DELETE(makeAdminRequest('DELETE', 'http://localhost:3000/api/birds', { id: adjustment.id }));
+      expect(res.status).toBe(200);
+    });
+
     it('rejects missing id', async () => {
       const res = await DELETE(makeAdminRequest('DELETE', 'http://localhost:3000/api/birds', {}));
       expect(res.status).toBe(400);

--- a/app/api/birds/route.ts
+++ b/app/api/birds/route.ts
@@ -158,6 +158,32 @@ export async function DELETE(req: NextRequest) {
       return NextResponse.json({ error: 'ID required' }, { status: 400 });
     }
 
+    // Referential guard: a purchase that sessions' birdUsages still reference
+    // cannot be hard-deleted — its usage would keep counting toward totalUsed
+    // while totalPurchased dropped, silently skewing stock into drift. The
+    // admin moves the tubes first via the existing retro-assign flow
+    // (PATCH /api/session/bird-usage: set 0 on this purchase, re-add on
+    // another), then deletes. Adjustment docs are never referenced by
+    // sessions, so reconcile-undo (deleting an adjustment) is unaffected.
+    const sessionsContainer = getContainer('sessions');
+    const { resources: sessions } = await sessionsContainer.items
+      .query({ query: 'SELECT c.id, c.datetime, c.birdUsage, c.birdUsages FROM c WHERE IS_DEFINED(c.birdUsage) OR IS_DEFINED(c.birdUsages)' })
+      .fetchAll();
+    const referencing = (sessions as Array<Pick<Session, 'birdUsage' | 'birdUsages'> & { datetime?: string }>)
+      .filter((s) => normalizeBirdUsages(s).some((u) => u.purchaseId === id && (u.tubes ?? 0) > 0));
+    if (referencing.length > 0) {
+      const sessionDates = referencing
+        .map((s) => (typeof s.datetime === 'string' ? s.datetime : ''))
+        .filter(Boolean)
+        .sort()
+        .slice(-6); // most recent few — enough to identify, bounded payload
+      return NextResponse.json({
+        error: `This purchase is used by ${referencing.length} session${referencing.length === 1 ? '' : 's'}. Move its tubes to another purchase first (Edit → Assign tubes to sessions), then delete.`,
+        sessionCount: referencing.length,
+        sessionDates,
+      }, { status: 409 });
+    }
+
     const container = getContainer('birds');
     await container.item(id, id).delete();
     return NextResponse.json({ success: true });

--- a/components/admin/CommandCenter/BirdsPage.tsx
+++ b/components/admin/CommandCenter/BirdsPage.tsx
@@ -75,6 +75,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
   const [formNotes, setFormNotes] = useState('');
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [formError, setFormError] = useState('');
 
   // Reconcile-count sheet — correct the on-hand total to a physical recount.
@@ -148,6 +149,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
   useEffect(() => { void load(); }, [load]);
 
   function openAddSheet() {
+    setConfirmingDelete(false);
     setEditingId(null);
     setFormName('');
     setFormTubes('');
@@ -161,6 +163,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
   }
 
   function openEditSheet(p: BirdPurchase) {
+    setConfirmingDelete(false);
     setEditingId(p.id);
     setFormName(p.name);
     setFormTubes(p.tubes);
@@ -214,7 +217,6 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
 
   async function handleDelete() {
     if (!editingId) return;
-    if (!confirm('Delete this purchase? This cannot be undone.')) return;
     setDeleting(true);
     setFormError('');
     try {
@@ -225,13 +227,18 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
+        // 409 = referenced by sessions; the server message carries the
+        // "move its tubes first" guidance. Drop back out of the confirm row
+        // so the error is what the admin reads.
         setFormError(data.error ?? 'Failed to delete.');
+        setConfirmingDelete(false);
         return;
       }
       setSheetOpen(false);
       await load();
     } catch {
       setFormError('Network error.');
+      setConfirmingDelete(false);
     } finally {
       setDeleting(false);
     }
@@ -870,37 +877,65 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
               );
             })()}
 
-            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-              {editingId && (
+            {/* Two-step delete confirm — in-sheet (no stacked sheet, no native
+                confirm()). A referenced purchase comes back 409 with guidance
+                ("move its tubes first"), surfaced via formError above. */}
+            {confirmingDelete ? (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <span className="fs-sm" style={{ color: 'var(--text-secondary)', flex: 1, minWidth: 160 }}>
+                  Delete this purchase? This cannot be undone.
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingDelete(false)}
+                  className="cc-btn cc-btn-ghost"
+                  disabled={deleting}
+                >
+                  Keep it
+                </button>
                 <button
                   type="button"
                   onClick={handleDelete}
-                  disabled={saving || deleting}
+                  disabled={deleting}
                   className="cc-btn cc-btn-danger"
-                  aria-label="Delete this purchase"
+                  aria-label="Confirm delete purchase"
                 >
-                  {deleting ? 'Deleting…' : 'Delete'}
+                  {deleting ? 'Deleting…' : 'Confirm delete'}
                 </button>
-              )}
-              <div style={{ flex: 1 }} />
-              <button
-                type="button"
-                onClick={() => setSheetOpen(false)}
-                className="cc-btn cc-btn-ghost"
-                disabled={saving || deleting}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleSave}
-                className="cc-btn cc-btn-primary"
-                disabled={saving || deleting}
-                style={{ minWidth: 100 }}
-              >
-                {saving ? 'Saving…' : editingId ? 'Save' : 'Add'}
-              </button>
-            </div>
+              </div>
+            ) : (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                {editingId && (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingDelete(true)}
+                    disabled={saving || deleting}
+                    className="cc-btn cc-btn-danger"
+                    aria-label="Delete this purchase"
+                  >
+                    Delete
+                  </button>
+                )}
+                <div style={{ flex: 1 }} />
+                <button
+                  type="button"
+                  onClick={() => setSheetOpen(false)}
+                  className="cc-btn cc-btn-ghost"
+                  disabled={saving || deleting}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  className="cc-btn cc-btn-primary"
+                  disabled={saving || deleting}
+                  style={{ minWidth: 100 }}
+                >
+                  {saving ? 'Saving…' : editingId ? 'Save' : 'Add'}
+                </button>
+              </div>
+            )}
           </div>
         </BottomSheetBody>
       </BottomSheet>


### PR DESCRIPTION
## What & why

**PR 1.2 of the bird-inventory audit plan** (Phase 1 — correctness). Deleting a purchase that past sessions used tubes from silently corrupted the stock math: the sessions' usage kept counting toward `totalUsed` while `totalPurchased` dropped — driving stock into (previously invisible, now `stockDrift`-flagged) negative territory.

## Changes

- **`DELETE /api/birds` gains a referential guard**: if any session's `birdUsages` references the purchase, it returns **409** with `{ error, sessionCount, sessionDates }` and guidance: *"Move its tubes to another purchase first (Edit → Assign tubes to sessions), then delete."* — pointing at the **existing** retro-assign flow (set 0 on X, re-add on Y), which is the "move the birds around" capability, no new machinery. Adjustment docs (reconcile-undo deletes) are never session-referenced — unaffected.
- **BirdsPage**: the native `confirm()` dialog is replaced with an in-sheet two-step confirm (`Delete` → *"Delete this purchase? This cannot be undone."* + `Keep it` / `Confirm delete`). Chose in-sheet over a stacked BottomSheet because the button lives inside the already-open edit sheet, and sheet-over-sheet isn't an app pattern. On 409 the confirm row collapses so the server's guidance message is what the admin reads.

## Test plan

- [x] +2 tests: referenced purchase → 409 with count/dates/guidance + doc untouched + stock intact; adjustment doc still deletable (reconcile undo preserved)
- [x] Full suite **1044/1044**, `tsc` clean, `eslint` no new warnings

Builds on #205/#206 (merged). Next: PR 2.2 (unified validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
