### PR TITLE
fix(tests): clear 7 pre-existing tsc errors in test files

### DIFF
--- a/__tests__/components/PageHeaders.test.tsx
+++ b/__tests__/components/PageHeaders.test.tsx
@@ -53,7 +53,7 @@ describe('PageHeaders', () => {
   it('AdminTab renders "Admin" as an h1', () => {
     render(
       <NextIntlClientProvider locale="en" messages={enMessages}>
-        <AdminTab />
+        <AdminTab onExit={() => {}} />
       </NextIntlClientProvider>
     );
     const heading = screen.getByRole('heading', { level: 1 });

--- a/__tests__/components/SkillsRadar.test.tsx
+++ b/__tests__/components/SkillsRadar.test.tsx
@@ -153,7 +153,7 @@ describe('SkillsRadar — sheet lifecycle (characterization, M1 mitigation)', ()
     // Characterization: clicking a level triggers a PATCH to /api/skills
     // with the new level for the active dimension.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toContain('/api/skills');
     expect(init.method).toBe('PATCH');
     const body = JSON.parse(init.body as string);

--- a/__tests__/players-delete.test.ts
+++ b/__tests__/players-delete.test.ts
@@ -8,6 +8,7 @@ import {
   makeRequest,
   makeAdminRequest,
   seedAdminMember,
+  getStore,
 } from './helpers';
 import { DELETE } from '@/app/api/players/route';
 
@@ -47,7 +48,7 @@ describe('DELETE /api/players', () => {
       expect(data.success).toBe(true);
 
       // ASSERT: player is soft-deleted in the store — removed flag is set
-      const store = global._mockStore as Record<string, Record<string, unknown>[]>;
+      const store = getStore() as Record<string, Record<string, unknown>[]>;
       const stored = store['players'].find((p) => p.id === player.id);
       expect(stored?.removed).toBe(true);
       expect(stored?.cancelledBySelf).toBe(true);
@@ -128,7 +129,7 @@ describe('DELETE /api/players', () => {
       expect(data.count).toBe(3);
 
       // ASSERT: store has no remaining player records for the session
-      const store = global._mockStore as Record<string, Record<string, unknown>[]>;
+      const store = getStore() as Record<string, Record<string, unknown>[]>;
       const remaining = (store['players'] ?? []).filter((p) => p.sessionId === SESSION_ID);
       expect(remaining).toHaveLength(0);
     });
@@ -154,7 +155,7 @@ describe('DELETE /api/players', () => {
       expect(data.count).toBe(2);
 
       // ASSERT: every player in the store now has removed: true
-      const store = global._mockStore as Record<string, Record<string, unknown>[]>;
+      const store = getStore() as Record<string, Record<string, unknown>[]>;
       const players = (store['players'] ?? []).filter((p) => p.sessionId === SESSION_ID);
       expect(players.every((p) => p.removed === true)).toBe(true);
     });

--- a/__tests__/players-signup-with-pin.test.ts
+++ b/__tests__/players-signup-with-pin.test.ts
@@ -93,7 +93,7 @@ describe('POST /api/players with PIN (v1.4 unified Home sign-in fix)', () => {
     // with a new salt. Verify the stored pinHash is unchanged by reading
     // the mock store directly.
     const { getStore } = await import('./helpers');
-    const storedBefore = (getStore().members?.find((m: { name?: string }) => m.name === 'Lin') as { pinHash?: string })?.pinHash;
+    const storedBefore = (getStore().members as Array<{ name?: string; pinHash?: string }> | undefined)?.find((m) => m.name === 'Lin')?.pinHash;
     expect(storedBefore).toBeTruthy();
 
     const req = makeRequest('POST', 'http://localhost:3000/api/players', {
@@ -103,7 +103,7 @@ describe('POST /api/players with PIN (v1.4 unified Home sign-in fix)', () => {
     const res = await POST(req);
     expect(res.status).toBe(201);
 
-    const storedAfter = (getStore().members?.find((m: { name?: string }) => m.name === 'Lin') as { pinHash?: string })?.pinHash;
+    const storedAfter = (getStore().members as Array<{ name?: string; pinHash?: string }> | undefined)?.find((m) => m.name === 'Lin')?.pinHash;
     expect(storedAfter).toBe(storedBefore);
   });
 });


### PR DESCRIPTION
## What & why

Pre-req cleanup surfaced while verifying the bird-inventory audit PRs. A cold `npx tsc --noEmit -p tsconfig.json` on `main` reports **7 errors** across four test files — the incremental `tsconfig.tsbuildinfo` cache was masking them on warm runs. They block the `tsc` verification gate for every in-flight audit PR (2.2, 2.3, 3.x…), so clearing them first keeps that gate meaningful.

All fixes are **type-only** — no runtime/behavior change, no test assertion touched.

## Changes

- **`__tests__/components/PageHeaders.test.tsx`** — `<AdminTab />` now passes the required `onExit={() => {}}` prop (TS2741).
- **`__tests__/components/SkillsRadar.test.tsx`** — `fetchMock.mock.calls[0]` (typed as the empty tuple `[]`) is cast via `as unknown as [string, RequestInit]`, per the compiler's own suggestion (TS2352).
- **`__tests__/players-delete.test.ts`** — reads the mock store through the existing `getStore()` helper instead of the untyped `global._mockStore` (TS7017 ×3).
- **`__tests__/players-signup-with-pin.test.ts`** — types the `members.find(...)` lookup by casting the array rather than the predicate parameter (TS2769 ×2).

## Test plan

- [x] Cold `tsc --noEmit -p tsconfig.json` (removed `tsconfig.tsbuildinfo` first) → **0 errors**
- [x] Full suite **1044/1044** green (unchanged — type-only)
- [x] `npm run lint` — no new warnings

Unblocks the `tsc` gate for PR 2.2 (unified bird validation) and the remainder of the audit plan.
