### PR TITLE
fix(birds): one validation contract for all bird writes

### DIFF
--- a/__tests__/birds.test.ts
+++ b/__tests__/birds.test.ts
@@ -75,6 +75,47 @@ describe('Birds API', () => {
       expect(res.status).toBe(400);
     });
 
+    // PR 2.2: POST gained the same grid + ceiling tube validation as every other
+    // bird write. A purchase is a bulk buy, so its ceiling is 1000 (not the
+    // per-session 100). Previously any tubes > 0 was accepted.
+    it.each([
+      { label: 'off the 0.25 grid', tubes: 4.1 },
+      { label: 'over the 1000-tube ceiling', tubes: 1001 },
+    ])('rejects tubes $label with 400', async ({ tubes }) => {
+      const res = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Test', tubes, totalCost: 80,
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts an on-grid purchase at the 1000-tube ceiling', async () => {
+      const res = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Bulk Buy', tubes: 1000, totalCost: 5000, date: '2026-05-01',
+      }));
+      expect(res.status).toBe(201);
+    });
+
+    // PR 2.2: date is validated to a real YYYY-MM-DD instead of stored verbatim
+    // via slice(0,10) — which let "garbage!!!!" become the persisted date.
+    it.each([
+      { label: 'a non-date string', date: 'garbage!!!!' }, // fails the shape regex
+      { label: 'an impossible calendar date', date: '9999-99-99' }, // passes regex, fails Date.parse
+    ])('rejects $label date with 400', async ({ date }) => {
+      const res = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Test', tubes: 4, totalCost: 80, date,
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('defaults date to today when omitted', async () => {
+      const res = await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Test', tubes: 4, totalCost: 80,
+      }));
+      const data = await res.json();
+      expect(res.status).toBe(201);
+      expect(data.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
     it('rejects non-admin', async () => {
       const res = await POST(makeRequest('POST', 'http://localhost:3000/api/birds', {
         name: 'Test', tubes: 4, totalCost: 80,
@@ -417,6 +458,32 @@ describe('Birds API', () => {
 
       const res = await PATCH(makeAdminRequest('PATCH', 'http://localhost:3000/api/birds', {
         id, tubes: 0,
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    // PR 2.2: PATCH shares POST's tube (grid + 1000 ceiling) and date
+    // (real YYYY-MM-DD) validation — off-grid tubes and garbage date strings
+    // were previously accepted.
+    it.each([
+      { label: 'off the 0.25 grid', tubes: 4.1 },
+      { label: 'over the 1000-tube ceiling', tubes: 1001 },
+    ])('rejects a tubes update $label with 400', async ({ tubes }) => {
+      const { id } = await (await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Test', tubes: 4, totalCost: 80,
+      }))).json();
+      const res = await PATCH(makeAdminRequest('PATCH', 'http://localhost:3000/api/birds', {
+        id, tubes,
+      }));
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects a malformed date update with 400', async () => {
+      const { id } = await (await POST(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+        name: 'Test', tubes: 4, totalCost: 80,
+      }))).json();
+      const res = await PATCH(makeAdminRequest('PATCH', 'http://localhost:3000/api/birds', {
+        id, date: 'garbage!!!!',
       }));
       expect(res.status).toBe(400);
     });

--- a/__tests__/session-advance-snapshot.test.ts
+++ b/__tests__/session-advance-snapshot.test.ts
@@ -95,29 +95,40 @@ describe('POST /api/session/advance — snapshot fields', () => {
     });
   });
 
-  it('skips unknown / zero / malformed bird entries', async () => {
+  // Advance now enforces the SAME bird contract as PUT /api/session (PR 2.2):
+  // tubes:0 omits the entry, but a malformed entry 400s and an unknown
+  // purchase 404s (previously all three were silently dropped).
+  function advanceWithBirds(birdUsages: unknown) {
     const store = getStore();
     store['birds'] = [
       { id: 'pur-a', name: 'Yonex AS-30', tubes: 20, totalCost: 60, costPerTube: 3, date: '2026-04-20', createdAt: new Date().toISOString() },
     ];
     seedPointer('session-2026-04-29');
     seedSession('session-2026-04-29', { courts: 2, costPerCourt: 30, maxPlayers: 12 });
-
-    const req = makeAdminRequest('POST', 'http://localhost:3000/api/session/advance', {
+    return ADVANCE(makeAdminRequest('POST', 'http://localhost:3000/api/session/advance', {
       datetime: '2026-05-06T20:00:00-04:00',
       deadline: '2026-05-06T18:00:00-04:00',
       courts: 2,
       maxPlayers: 12,
-      birdUsages: [
-        { purchaseId: 'pur-a', tubes: 0 },        // zero → skipped
-        { purchaseId: 'nope', tubes: 2 },          // unknown purchase → skipped
-        { purchaseId: 'pur-a', tubes: 0.1 },       // not a 0.25 step → skipped
-      ],
-    });
-    const res = await ADVANCE(req);
+      birdUsages,
+    }));
+  }
+
+  it('omits a tubes:0 bird entry (0 = remove) and advances with no birdUsages', async () => {
+    const res = await advanceWithBirds([{ purchaseId: 'pur-a', tubes: 0 }]);
     expect(res.status).toBe(201);
-    const body = await res.json();
-    expect(body.birdUsages).toBeUndefined();
+    expect((await res.json()).birdUsages).toBeUndefined();
+  });
+
+  it('rejects a malformed bird entry with 400 (was silently skipped)', async () => {
+    const res = await advanceWithBirds([{ purchaseId: 'pur-a', tubes: 0.1 }]); // off the 0.25 grid
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/0\.25/);
+  });
+
+  it('rejects an unknown bird purchase with 404 (was silently skipped)', async () => {
+    const res = await advanceWithBirds([{ purchaseId: 'nope', tubes: 2 }]);
+    expect(res.status).toBe(404);
   });
 
   it('flags cost_changed in anomaliesAtAdvance when costPerCourt differs', async () => {

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -267,6 +267,50 @@ describe('PUT /api/session', () => {
     expect(Array.isArray(data.birdUsages)).toBe(true);
     expect(data.birdUsages).toHaveLength(0);
   });
+
+  // Decision 3: tubes:0 is now VALID on PUT and means "remove that purchase's
+  // entry", aligning PUT to the retro-assign PATCH contract. PUT previously
+  // 400'd on tubes <= 0 — this is the one genuinely new PUT behavior in PR 2.2.
+  it('omits a tubes:0 entry and keeps the rest (0 = remove)', async () => {
+    const a = await (await CREATE_BIRD(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+      name: 'Victor A', tubes: 4, totalCost: 80,
+    }))).json();
+    const b = await (await CREATE_BIRD(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+      name: 'Yonex B', tubes: 4, totalCost: 100,
+    }))).json();
+
+    const res = await PUT(makeAdminRequest('PUT', 'http://localhost:3000/api/session', {
+      title: 'Test',
+      courts: 2,
+      maxPlayers: 12,
+      birdUsages: [
+        { purchaseId: a.id, tubes: 2 },
+        { purchaseId: b.id, tubes: 0 }, // 0 = remove this entry
+      ],
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.birdUsages).toHaveLength(1);
+    expect(data.birdUsages[0].purchaseId).toBe(a.id);
+  });
+
+  it('treats an all-zero birdUsages array as clearing every entry', async () => {
+    const bird = await (await CREATE_BIRD(makeAdminRequest('POST', 'http://localhost:3000/api/birds', {
+      name: 'Solo', tubes: 4, totalCost: 80,
+    }))).json();
+
+    const res = await PUT(makeAdminRequest('PUT', 'http://localhost:3000/api/session', {
+      title: 'Test',
+      courts: 2,
+      maxPlayers: 12,
+      birdUsages: [{ purchaseId: bird.id, tubes: 0 }],
+    }));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.birdUsages).toHaveLength(0);
+  });
 });
 
 describe('POST /api/session/advance', () => {

--- a/app/api/birds/route.ts
+++ b/app/api/birds/route.ts
@@ -2,8 +2,20 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
 import { randomBytes } from 'crypto';
 import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
-import { normalizeBirdUsages, totalTubes } from '@/lib/birdUsages';
+import { normalizeBirdUsages, totalTubes, validPurchaseDate } from '@/lib/birdUsages';
 import type { Session } from '@/lib/types';
+
+// A single purchase is a bulk buy — allow far more than a session's per-entry
+// cap (100), but still reject a fat-fingered 99999. Whole/half/quarter tubes
+// only, matching the usage grid.
+const MAX_PURCHASE_TUBES = 1000;
+function validPurchaseTubes(tubes: number): string | null {
+  if (!Number.isFinite(tubes) || tubes <= 0 || tubes > MAX_PURCHASE_TUBES) {
+    return `Tubes must be between 0 and ${MAX_PURCHASE_TUBES}`;
+  }
+  if (Math.round(tubes * 4) !== tubes * 4) return 'Tubes must be in 0.25 increments';
+  return null;
+}
 
 export async function GET(req: NextRequest) {
   if (!isAdminAuthed(req)) return unauthorized();
@@ -112,10 +124,19 @@ export async function POST(req: NextRequest) {
     const name = typeof body.name === 'string' ? body.name.trim().slice(0, 100) : '';
     const tubes = typeof body.tubes === 'number' ? body.tubes : 0;
     const totalCost = typeof body.totalCost === 'number' ? body.totalCost : 0;
-    const date = typeof body.date === 'string' ? body.date.slice(0, 10) : new Date().toISOString().slice(0, 10);
+    // Absent date → today. Provided-but-invalid → 400 (was stored verbatim,
+    // so "garbage!!!!".slice(0,10) became the date).
+    let date: string;
+    if (body.date === undefined || body.date === null) {
+      date = new Date().toISOString().slice(0, 10);
+    } else {
+      date = validPurchaseDate(body.date);
+      if (!date) return NextResponse.json({ error: 'Date must be YYYY-MM-DD' }, { status: 400 });
+    }
 
     if (!name) return NextResponse.json({ error: 'Shuttle name required' }, { status: 400 });
-    if (tubes <= 0) return NextResponse.json({ error: 'Tubes must be greater than 0' }, { status: 400 });
+    const tubesError = validPurchaseTubes(tubes);
+    if (tubesError) return NextResponse.json({ error: tubesError }, { status: 400 });
     if (totalCost <= 0) return NextResponse.json({ error: 'Cost must be greater than 0' }, { status: 400 });
 
     const purchase: Record<string, unknown> = {
@@ -217,15 +238,18 @@ export async function PATCH(req: NextRequest) {
       updated.name = name;
     }
     if (typeof body.tubes === 'number') {
-      if (body.tubes <= 0) return NextResponse.json({ error: 'Tubes must be greater than 0' }, { status: 400 });
+      const tubesError = validPurchaseTubes(body.tubes);
+      if (tubesError) return NextResponse.json({ error: tubesError }, { status: 400 });
       updated.tubes = body.tubes;
     }
     if (typeof body.totalCost === 'number') {
       if (body.totalCost <= 0) return NextResponse.json({ error: 'Cost must be greater than 0' }, { status: 400 });
       updated.totalCost = Math.round(body.totalCost * 100) / 100;
     }
-    if (typeof body.date === 'string') {
-      updated.date = body.date.slice(0, 10);
+    if (body.date !== undefined) {
+      const date = validPurchaseDate(body.date);
+      if (!date) return NextResponse.json({ error: 'Date must be YYYY-MM-DD' }, { status: 400 });
+      updated.date = date;
     }
 
     // Recalculate costPerTube only when cost inputs change

--- a/app/api/session/advance/route.ts
+++ b/app/api/session/advance/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, setActiveSessionId, sessionIdFromDate } from '@/lib/cosmos';
 import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { toValidIso } from '@/app/api/session/route';
-import { normalizeBirdUsages, totalBirdCost, snapshotBirdUsage } from '@/lib/birdUsages';
+import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
+import { resolveBirdUsages } from '@/lib/birdWrite';
 import type { BirdUsage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -134,39 +135,16 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Resolve any bird tubes the admin chose to load into the new session at
-    // creation time. Body shape: birdUsages: [{ purchaseId, tubes }]. Each
-    // purchase is looked up and its cost snapshotted via the shared
-    // `snapshotBirdUsage` (same formula as PUT /api/session and PATCH
-    // /api/session/bird-usage). Invalid/zero/unknown entries are skipped
-    // silently. Reads are batched (was an N+1 sequential loop).
-    let birdUsages: BirdUsage[] = [];
-    if (Array.isArray(body.birdUsages) && body.birdUsages.length > 0) {
-      // Validate + de-dupe first (same purchase twice → keep the last, in
-      // last-occurrence order, matching the previous splice-and-push behavior).
-      const wanted = new Map<string, number>();
-      for (const entry of body.birdUsages) {
-        const purchaseId = typeof entry?.purchaseId === 'string' ? entry.purchaseId : '';
-        const tubes = Number(entry?.tubes);
-        if (!purchaseId) continue;
-        if (!Number.isFinite(tubes) || tubes <= 0 || tubes > 100) continue;
-        if (Math.round(tubes * 4) !== tubes * 4) continue; // 0.25 increments only
-        wanted.delete(purchaseId); // re-insert at the end on dupe
-        wanted.set(purchaseId, tubes);
-      }
-      const birdsContainer = getContainer('birds');
-      const ids = Array.from(wanted.keys());
-      const reads = await Promise.all(
-        ids.map((id) => birdsContainer.item(id, id).read().catch(() => ({ resource: undefined }))),
-      );
-      const resolved: BirdUsage[] = [];
-      for (let i = 0; i < ids.length; i++) {
-        const purchase = reads[i].resource;
-        if (!purchase) continue; // unknown purchase — skip silently (pre-existing contract)
-        resolved.push(snapshotBirdUsage(purchase, wanted.get(ids[i])!));
-      }
-      birdUsages = resolved;
+    // Resolve any bird tubes the admin chose to load into the new session,
+    // through the SAME shared contract PUT /api/session uses (validate → dedup
+    // → drop tubes:0 → batch-read → snapshot). Previously this silently dropped
+    // invalid/unknown entries where PUT 400s — now both reject identically, so
+    // a carried-forward typo surfaces instead of quietly losing tubes.
+    const resolvedBirds = await resolveBirdUsages(body.birdUsages);
+    if (!resolvedBirds.ok) {
+      return NextResponse.json({ error: resolvedBirds.error }, { status: resolvedBirds.status });
     }
+    const birdUsages: BirdUsage[] = resolvedBirds.usages;
 
     const newSession = {
       id: newId,

--- a/app/api/session/bird-usage/route.ts
+++ b/app/api/session/bird-usage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
 import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
-import { normalizeBirdUsages, snapshotBirdUsage } from '@/lib/birdUsages';
+import { normalizeBirdUsages, snapshotBirdUsage, validateBirdEntry } from '@/lib/birdUsages';
 import type { BirdUsage, Session } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -22,17 +22,14 @@ export async function PATCH(req: NextRequest) {
   try {
     const body = await req.json();
     const sessionId = typeof body?.sessionId === 'string' ? body.sessionId : '';
-    const purchaseId = typeof body?.purchaseId === 'string' ? body.purchaseId : '';
-    const tubes = Number(body?.tubes);
-
     if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 });
-    if (!purchaseId) return NextResponse.json({ error: 'purchaseId required' }, { status: 400 });
-    if (!Number.isFinite(tubes) || tubes < 0 || tubes > 100) {
-      return NextResponse.json({ error: 'tubes must be between 0 and 100' }, { status: 400 });
-    }
-    if (Math.round(tubes * 4) !== tubes * 4) {
-      return NextResponse.json({ error: 'tubes must be in 0.25 increments' }, { status: 400 });
-    }
+
+    // Same tube/purchase contract as every other bird write (tubes ∈ [0,100],
+    // 0.25 grid, 0 = remove). This endpoint always allowed 0 as "remove"; the
+    // shared validator now makes that the rule everywhere.
+    const v = validateBirdEntry({ purchaseId: body?.purchaseId, tubes: body?.tubes });
+    if (!v.ok) return NextResponse.json({ error: v.error }, { status: 400 });
+    const { purchaseId, tubes } = v.value;
 
     const sessionsContainer = getContainer('sessions');
     const { resources } = await sessionsContainer.items

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, POINTER_ID, DEFAULT_SESSION } from '@/lib/cosmos';
 import { isAdminAuthed, isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
-import { snapshotBirdUsage } from '@/lib/birdUsages';
+import { resolveBirdUsages } from '@/lib/birdWrite';
 import type { BirdUsage, ETransferRecipient } from '@/lib/types';
 
 function isValidETransferRecipient(value: unknown): value is ETransferRecipient {
@@ -86,41 +86,17 @@ export async function PUT(req: NextRequest) {
     if (typeof body.costPerCourt === 'number') updates.costPerCourt = Math.max(0, Math.min(500, body.costPerCourt));
     if (typeof body.showCostBreakdown === 'boolean') updates.showCostBreakdown = body.showCostBreakdown;
 
-    // Handle bird usages — array of { purchaseId, tubes }. Each entry is
-    // looked up live so cost snapshots are authoritative. Validate everything
-    // synchronously first, then batch the purchase reads (was an N+1 loop —
-    // one sequential read per entry).
+    // Handle bird usages — array of { purchaseId, tubes }. Resolved through the
+    // shared contract (validate → dedup → drop tubes:0 → batch-read → snapshot)
+    // so this and advance can never validate or cost differently. An entry with
+    // tubes:0 removes that purchase (Decision: 0 = remove, same as the
+    // retro-assign PATCH). Only run when the client actually sent the array —
+    // absent means "leave birdUsages untouched".
     let birdUsages: BirdUsage[] | undefined = undefined;
     if (Array.isArray(body.birdUsages)) {
-      const wanted: Array<{ purchaseId: string; tubes: number }> = [];
-      for (const entry of body.birdUsages) {
-        const tubes = Number(entry?.tubes);
-        if (!Number.isFinite(tubes) || tubes <= 0 || tubes > 100) {
-          return NextResponse.json({ error: 'Bird tubes must be between 0 and 100' }, { status: 400 });
-        }
-        // Multiple of 0.25 — rejects 0.33, 1.7, etc.
-        if (Math.round(tubes * 4) !== tubes * 4) {
-          return NextResponse.json({ error: 'Bird tubes must be in 0.25 increments' }, { status: 400 });
-        }
-        const purchaseId = entry?.purchaseId;
-        if (typeof purchaseId !== 'string' || !purchaseId) {
-          return NextResponse.json({ error: 'Bird purchase must be selected' }, { status: 400 });
-        }
-        wanted.push({ purchaseId, tubes });
-      }
-      const birdsContainer = getContainer('birds');
-      const purchaseReads = await Promise.all(
-        wanted.map((w) => birdsContainer.item(w.purchaseId, w.purchaseId).read()),
-      );
-      const entries: BirdUsage[] = [];
-      for (let i = 0; i < wanted.length; i++) {
-        const purchase = purchaseReads[i].resource;
-        if (!purchase) {
-          return NextResponse.json({ error: 'Selected bird purchase not found' }, { status: 404 });
-        }
-        entries.push(snapshotBirdUsage(purchase, wanted[i].tubes));
-      }
-      birdUsages = entries;
+      const resolved = await resolveBirdUsages(body.birdUsages);
+      if (!resolved.ok) return NextResponse.json({ error: resolved.error }, { status: resolved.status });
+      birdUsages = resolved.usages;
     }
 
     if (body.eTransferRecipient !== undefined && !isValidETransferRecipient(body.eTransferRecipient)) {

--- a/lib/birdUsages.ts
+++ b/lib/birdUsages.ts
@@ -30,6 +30,46 @@ export function totalBirdCost(usages: BirdUsage[]): number {
 }
 
 /**
+ * The one bird-tube validation contract, shared by every write path.
+ * Tubes ∈ [0, 100] on the 0.25 grid; `0` is valid and means "remove this
+ * purchase's entry" (Decision: session PUT, the retro-assign PATCH, and
+ * advance all agree). `purchaseId` must be a non-empty string.
+ *
+ * Returns the normalized `{ purchaseId, tubes }` or a human-readable error —
+ * callers turn `!ok` into a 400.
+ */
+export function validateBirdEntry(
+  entry: { purchaseId?: unknown; tubes?: unknown } | null | undefined,
+): { ok: true; value: { purchaseId: string; tubes: number } } | { ok: false; error: string } {
+  const tubes = Number(entry?.tubes);
+  if (!Number.isFinite(tubes) || tubes < 0 || tubes > 100) {
+    return { ok: false, error: 'Bird tubes must be between 0 and 100' };
+  }
+  // Multiple of 0.25 — rejects 0.33, 1.7, etc. (0.25-grid values are exact in
+  // binary floating point, so this comparison is safe).
+  if (Math.round(tubes * 4) !== tubes * 4) {
+    return { ok: false, error: 'Bird tubes must be in 0.25 increments' };
+  }
+  const purchaseId = entry?.purchaseId;
+  if (typeof purchaseId !== 'string' || !purchaseId) {
+    return { ok: false, error: 'Bird purchase must be selected' };
+  }
+  return { ok: true, value: { purchaseId, tubes } };
+}
+
+const YMD_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Validate a purchase `date` to a real `YYYY-MM-DD` string, or return '' if it
+ * isn't one. (POST/PATCH /api/birds previously stored `body.date.slice(0,10)`
+ * verbatim — so "garbage!!!!" became the stored date.)
+ */
+export function validPurchaseDate(input: unknown): string {
+  const s = typeof input === 'string' ? input.slice(0, 10) : '';
+  return YMD_RE.test(s) && !Number.isNaN(Date.parse(s)) ? s : '';
+}
+
+/**
  * Build the authoritative `BirdUsage` snapshot for one purchase + tube count.
  * The SINGLE source of the per-entry cost formula — `PUT /api/session`,
  * `PATCH /api/session/bird-usage`, and `POST /api/session/advance` all write

--- a/lib/birdWrite.ts
+++ b/lib/birdWrite.ts
@@ -1,0 +1,45 @@
+import { getContainer } from './cosmos';
+import { snapshotBirdUsage, validateBirdEntry } from './birdUsages';
+import type { BirdUsage } from './types';
+
+export type ResolveBirdUsagesResult =
+  | { ok: true; usages: BirdUsage[] }
+  | { ok: false; status: number; error: string };
+
+/**
+ * Resolve a raw request `birdUsages` array into authoritative BirdUsage
+ * snapshots — the SINGLE shared contract for the array-style write endpoints
+ * (`PUT /api/session`, `POST /api/session/advance`), so they can't validate or
+ * cost differently:
+ *   - each entry validated via `validateBirdEntry` → 400 on bad shape/range/grid
+ *   - de-duplicated by purchaseId, last occurrence wins
+ *   - `tubes === 0` omits that purchase (Decision: 0 = remove)
+ *   - each surviving purchase read from inventory (batched) → 404 if unknown
+ *   - cost snapshotted via `snapshotBirdUsage`
+ *
+ * A non-array input resolves to `[]` (the caller decides whether that means
+ * "clear the array" or "leave untouched").
+ */
+export async function resolveBirdUsages(raw: unknown): Promise<ResolveBirdUsagesResult> {
+  if (!Array.isArray(raw)) return { ok: true, usages: [] };
+
+  const byId = new Map<string, number>();
+  for (const entry of raw) {
+    const v = validateBirdEntry(entry);
+    if (!v.ok) return { ok: false, status: 400, error: v.error };
+    byId.set(v.value.purchaseId, v.value.tubes); // last occurrence wins
+  }
+
+  const wanted = [...byId].filter(([, tubes]) => tubes > 0); // 0 = remove/omit
+  if (wanted.length === 0) return { ok: true, usages: [] };
+
+  const birds = getContainer('birds');
+  const reads = await Promise.all(wanted.map(([id]) => birds.item(id, id).read()));
+  const usages: BirdUsage[] = [];
+  for (let i = 0; i < wanted.length; i++) {
+    const purchase = reads[i].resource;
+    if (!purchase) return { ok: false, status: 404, error: 'Selected bird purchase not found' };
+    usages.push(snapshotBirdUsage(purchase, wanted[i][1]));
+  }
+  return { ok: true, usages };
+}


### PR DESCRIPTION
## Summary

Introduces a single, shared validation contract for every path that writes bird usage/purchase data, replacing the previous "accept anything `> 0` / any string" behavior.

- Shared `validateBirdEntry` — tubes in **[0, 100] on the 0.25 grid**, `0` = remove.
- `validPurchaseDate` in `lib/birdUsages` — enforces a real `YYYY-MM-DD`.
- New `lib/birdWrite.resolveBirdUsages` — the single resolver for array-style writes (session `PUT`, `advance`).

## Changes

- **`POST`/`PATCH /api/birds`** now validate tubes (grid + 1000 ceiling) and date (real `YYYY-MM-DD`) instead of accepting anything `> 0` / any string.
- **`advance`** now returns `400`/`404` on invalid/unknown bird entries like `PUT` (previously **silently dropped** them) — ⚠️ behavior change.
- **session `PUT`**: `tubes: 0` removes an entry (Decision 3), aligning it with the retro-assign `PATCH` contract.

## Tests

- `POST`/`PATCH` grid / ceiling / date validation
- `PUT` `tubes: 0` removal
- `advance` `400` / `404` / omit cases

Builds on #205–#207.

## Notes

9 files changed (+278 / −96). Single commit `e48f059`.