### PR TITLE
refactor(birds): adopt sessionCostTotals at 5 cost sites

### DIFF
--- a/app/api/members/[id]/history/route.ts
+++ b/app/api/members/[id]/history/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer } from '@/lib/cosmos';
 import { isAdminAuthed, unauthorized } from '@/lib/auth';
-import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
+import { sessionCostTotals } from '@/lib/sessionCost';
 import { expandAliasNames } from '@/lib/playerIdentity';
 import type { Alias, Member, Player, Session } from '@/lib/types';
 
@@ -93,9 +93,7 @@ export async function GET(req: NextRequest, context: { params: Promise<{ id: str
 
       let costPerPerson = 0;
       if (session) {
-        const courtTotal = (session.costPerCourt ?? 0) * (session.courts ?? 0);
-        const birdTotal = totalBirdCost(normalizeBirdUsages(session));
-        const totalCost = courtTotal + birdTotal;
+        const { totalCost } = sessionCostTotals(session);
         const playerCount = attendanceBySession.get(player.sessionId) ?? 0;
         if (totalCost > 0 && playerCount > 0) {
           costPerPerson = Math.round((totalCost / playerCount) * 100) / 100;

--- a/app/api/session/advance/route.ts
+++ b/app/api/session/advance/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, getActiveSessionId, setActiveSessionId, sessionIdFromDate } from '@/lib/cosmos';
 import { isAdminAuthedWithMember, unauthorized } from '@/lib/auth';
 import { toValidIso } from '@/app/api/session/route';
-import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
 import { resolveBirdUsages } from '@/lib/birdWrite';
+import { sessionCostTotals } from '@/lib/sessionCost';
 import type { BirdUsage } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -91,9 +91,7 @@ export async function POST(req: NextRequest) {
         prevCostPerPerson = currentSession.settled.costPerPerson;
         prevSessionDate = currentSession.datetime;
       } else {
-        const courtTotal = (currentSession.costPerCourt ?? 0) * (currentSession.courts ?? 0);
-        const birdTotal = totalBirdCost(normalizeBirdUsages(currentSession));
-        const totalCost = courtTotal + birdTotal;
+        const { totalCost } = sessionCostTotals(currentSession);
         if (totalCost > 0) {
           const playersContainer = getContainer('players');
           const { resources: prevPlayers } = await playersContainer.items

--- a/app/api/sessions/recent/route.ts
+++ b/app/api/sessions/recent/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getContainer, POINTER_ID } from '@/lib/cosmos';
 import { isAdminAuthed, unauthorized } from '@/lib/auth';
-import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
+import { sessionCostTotals } from '@/lib/sessionCost';
 import type { Session } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
@@ -73,9 +73,7 @@ export async function GET(req: NextRequest) {
       const active = (playersBySession.get(s.id) ?? []).filter((p) => !p.removed && !p.waitlisted);
       const paidCount = active.filter((p) => p.paid === true).length;
 
-      const courtTotal = (s.costPerCourt ?? 0) * (s.courts ?? 0);
-      const birdTotal = totalBirdCost(normalizeBirdUsages(s));
-      const totalCost = courtTotal + birdTotal;
+      const { totalCost } = sessionCostTotals(s);
 
       return {
         sessionId: s.id,

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -16,7 +16,7 @@ import PageHeader from './primitives/PageHeader';
 import AdminConsoleHero from './admin/CommandCenter/AdminConsoleHero';
 import { isFlagOn } from '@/lib/flags';
 import { avatarColors as profileAvaColors } from '@/lib/avatar';
-import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
+import { sessionCostTotals } from '@/lib/sessionCost';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -187,9 +187,8 @@ export default function ProfileTab({
         setSettledThisWeek(!!session.settled);
         const active = players.filter((p) => !p.removed && !p.waitlisted);
         const me = active.find((p) => typeof p.name === 'string' && p.name.toLowerCase() === identity.name.toLowerCase());
-        const courtTotal = (session.costPerCourt ?? 0) * (session.courts ?? 0);
-        const birdTotal = session.showCostBreakdown ? totalBirdCost(normalizeBirdUsages(session)) : 0;
-        const total = courtTotal + birdTotal;
+        const { courtTotal, birdTotal } = sessionCostTotals(session);
+        const total = courtTotal + (session.showCostBreakdown ? birdTotal : 0);
         const per = session.showCostBreakdown && total > 0 && active.length > 0 ? total / active.length : null;
         setOweThisWeek(me ? per : null);
         setPaidThisWeek(!!me?.paid);

--- a/components/admin/CommandCenter/CommandCenter.tsx
+++ b/components/admin/CommandCenter/CommandCenter.tsx
@@ -11,7 +11,7 @@ import PlayerProfileSheet from './PlayerProfileSheet';
 import ReceiptSheet from './ReceiptSheet';
 import type { AdminView } from '../types';
 import type { ReceiptInput } from '@/lib/receiptTemplate';
-import { normalizeBirdUsages, totalBirdCost } from '@/lib/birdUsages';
+import { sessionCostTotals } from '@/lib/sessionCost';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -97,9 +97,7 @@ export default function CommandCenter({ refreshKey, setView, onExit }: CommandCe
       }
 
       const active = players.filter((p) => !p.removed && !p.waitlisted);
-      const courtTotal = (session.costPerCourt ?? 0) * (session.courts ?? 0);
-      const birdTotal = totalBirdCost(normalizeBirdUsages(session));
-      const totalCost = courtTotal + birdTotal;
+      const { totalCost } = sessionCostTotals(session);
       const costPerPerson = active.length > 0 && totalCost > 0
         ? Math.round((totalCost / active.length) * 100) / 100
         : 0;


### PR DESCRIPTION
## What & why

**PR 2.3 of the bird-inventory audit plan** (Phase 2 — consolidation). Pure refactor, no behavior change. Five sites hand-rolled the same `courtTotal + birdTotal` computation; they now all go through the single `sessionCostTotals` resolver (`lib/sessionCost.ts`), so session-cost math can't drift between callers.

> Stacked on #209 (PR 2.2). Base is `fix/birds-validation-contract`; review after #209.

## Changes

Swapped the inlined 3-line calc for `sessionCostTotals(...)` at all 5 sites (and dropped the now-unused `normalizeBirdUsages` / `totalBirdCost` imports at each):

1. `app/api/sessions/recent/route.ts`
2. `app/api/members/[id]/history/route.ts`
3. `app/api/session/advance/route.ts`
4. `components/admin/CommandCenter/CommandCenter.tsx`
5. `components/ProfileTab.tsx` — **the `showCostBreakdown` gate is preserved exactly** (bird cost only counts when the breakdown is shown); only the court/bird sub-totals are sourced from the resolver.

**No behavior change** — `sessionCostTotals` already encapsulates the identical `round2(costPerCourt × courts) + totalBirdCost(normalizeBirdUsages(...))` formula.

## Test plan

- [x] Behavior parity proven by the existing suites (`sessions`, `members-history`, `session-advance-snapshot`, `ProfileTab`, `CommandCenter`) — **1057/1057 green**, unchanged.
- [x] `npm run build` clean; `npm run lint` no new warnings; `tsc` no new errors (7 pre-existing test-file errors tracked separately in #208).

Builds on #205–#207 + #209.