### PR TITLE
fix(birds): AssignUsageSheet survives partial failures + offline gate

### DIFF
--- a/__tests__/components/AssignUsageSheet.test.tsx
+++ b/__tests__/components/AssignUsageSheet.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import AssignUsageSheet from '../../components/admin/AssignUsageSheet';
+import type { BirdPurchase } from '../../lib/types';
+
+const PURCHASE: BirdPurchase = {
+  id: 'pur-1',
+  name: 'RSL 4',
+  tubes: 10,
+  totalCost: 250,
+  costPerTube: 25,
+  date: '2026-06-01',
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+// Three sessions with no existing usage for this purchase
+const SESSIONS = [
+  { id: 'session-2026-06-10', title: 'Tue A', datetime: '2026-06-10T19:00:00Z', birdUsages: [] },
+  { id: 'session-2026-06-17', title: 'Tue B', datetime: '2026-06-17T19:00:00Z', birdUsages: [] },
+  { id: 'session-2026-06-24', title: 'Tue C', datetime: '2026-06-24T19:00:00Z', birdUsages: [] },
+];
+
+describe('AssignUsageSheet — resilience (partial-failure)', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('attempts all rows even when the 2nd PATCH fails and surfaces a partial-failure message', async () => {
+    const onSaved = vi.fn();
+    const onClose = vi.fn();
+    let patchCount = 0;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url);
+        const method = init?.method ?? 'GET';
+
+        if (method === 'GET' && u.includes('/api/sessions')) {
+          return new Response(JSON.stringify(SESSIONS), { status: 200 });
+        }
+        if (method === 'PATCH' && u.includes('/api/session/bird-usage')) {
+          patchCount++;
+          if (patchCount === 2) {
+            // The 2nd PATCH fails with a server error
+            return new Response(JSON.stringify({ error: 'server error' }), { status: 500 });
+          }
+          return new Response('{}', { status: 200 });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+
+    render(
+      <AssignUsageSheet
+        open={true}
+        onClose={onClose}
+        purchase={PURCHASE}
+        onSaved={onSaved}
+      />,
+    );
+
+    // Wait for the 3 session rows to load
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Increase tubes').length).toBe(3);
+    });
+
+    // Make all 3 rows dirty by clicking + once on each
+    const plusButtons = screen.getAllByLabelText('Increase tubes');
+    fireEvent.click(plusButtons[0]);
+    fireEvent.click(plusButtons[1]);
+    fireEvent.click(plusButtons[2]);
+
+    // Save button should now be enabled (rows are dirty)
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
+    expect(saveBtn.hasAttribute('disabled')).toBe(false);
+    fireEvent.click(saveBtn);
+
+    // All 3 PATCHes must be attempted (no early abort)
+    await waitFor(() => {
+      expect(patchCount).toBe(3);
+    });
+
+    // Partial-failure message must appear
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toMatch(/Saved 2 of 3/);
+    });
+
+    // Sheet stays open (onClose NOT called)
+    expect(onClose).not.toHaveBeenCalled();
+
+    // onSaved IS called because 2 rows succeeded
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the sheet and calls onSaved when all PATCHes succeed', async () => {
+    const onSaved = vi.fn();
+    const onClose = vi.fn();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init?: RequestInit) => {
+        const u = String(url);
+        const method = init?.method ?? 'GET';
+        if (method === 'GET' && u.includes('/api/sessions')) {
+          return new Response(JSON.stringify(SESSIONS), { status: 200 });
+        }
+        if (method === 'PATCH' && u.includes('/api/session/bird-usage')) {
+          return new Response('{}', { status: 200 });
+        }
+        return new Response('not found', { status: 404 });
+      }),
+    );
+
+    render(
+      <AssignUsageSheet
+        open={true}
+        onClose={onClose}
+        purchase={PURCHASE}
+        onSaved={onSaved}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText('Increase tubes').length).toBe(3);
+    });
+
+    // Make one row dirty
+    fireEvent.click(screen.getAllByLabelText('Increase tubes')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/components/admin/AssignUsageSheet.tsx
+++ b/components/admin/AssignUsageSheet.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 import type { BirdPurchase, Session } from '@/lib/types';
 import { normalizeBirdUsages } from '@/lib/birdUsages';
+import { useOnline, useReportFetchFailure } from '@/lib/useOnline';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -37,6 +38,8 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const online = useOnline();
+  const reportFetchFailure = useReportFetchFailure();
 
   const loadSessions = useCallback(async () => {
     if (!purchase) return;
@@ -95,8 +98,12 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
     }
     setSaving(true);
     setError('');
-    try {
-      for (const row of changed) {
+
+    const failed: Row[] = [];
+    let savedCount = 0;
+
+    for (const row of changed) {
+      try {
         const res = await fetch(`${BASE}/api/session/bird-usage`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
@@ -107,16 +114,36 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
           }),
         });
         if (!res.ok) {
-          const data = await res.json().catch(() => ({}));
-          throw new Error(data.error ?? `Failed to update ${row.sessionId}`);
+          failed.push(row);
+        } else {
+          savedCount++;
         }
+      } catch {
+        failed.push(row);
+        reportFetchFailure();
       }
+    }
+
+    setSaving(false);
+
+    if (savedCount > 0) {
+      // Mark successfully saved rows as clean so the admin can retry only the failed ones.
+      const failedIds = new Set(failed.map((r) => r.sessionId));
+      setRows((prev) =>
+        prev.map((r) =>
+          changed.some((c) => c.sessionId === r.sessionId) && !failedIds.has(r.sessionId)
+            ? { ...r, initial: r.tubes }
+            : r,
+        ),
+      );
       onSaved();
+    }
+
+    if (failed.length === 0) {
       onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Save failed');
-    } finally {
-      setSaving(false);
+    } else {
+      const labels = failed.map((r) => fmtSessionDate(r.datetime)).join(', ');
+      setError(`Saved ${savedCount} of ${changed.length} — couldn't update ${labels}`);
     }
   }
 
@@ -236,11 +263,11 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
           <button
             type="button"
             onClick={handleSave}
-            disabled={saving || !dirty}
+            disabled={saving || !dirty || !online}
             className="cc-btn cc-btn-primary flex-1"
             style={{ minHeight: 44 }}
           >
-            {saving ? 'Saving…' : 'Save'}
+            {saving ? 'Saving…' : !online ? 'Offline' : 'Save'}
           </button>
         </div>
       </BottomSheetBody>


### PR DESCRIPTION
## What & why

**PR 3.3 of the bird-inventory audit plan** (Phase 3 — cleanup). `AssignUsageSheet` (retro-assign tubes across sessions) PATCHed each changed row in a loop that **threw on the first failure** — later rows were silently skipped and the admin had no idea which sessions actually saved. It also let you attempt a save while offline (execute-then-break), violating the app's legible-fail posture.

> Stacked on #212 (PR 3.2). Base is `fix/birds-assign-older-purchases`.

## Changes

`components/admin/AssignUsageSheet.tsx`:
- **Resilience:** `handleSave` now attempts **every** changed row, collecting successes and failures. Successful rows persist (their baseline syncs so they're no longer "dirty", and `onSaved()` fires); on partial failure the sheet stays open with `"Saved N of M — couldn't update <session dates>"` (`role="alert"`) so the admin can retry the rest. The sheet closes only on full success.
- **Offline gate:** Save is `disabled` when `useOnline()` is false (button reads "Offline"); `useReportFetchFailure()` nudges the offline signal on fetch failure.

## Test plan

- [x] **New** `__tests__/components/AssignUsageSheet.test.tsx` (2 cases):
  - partial-failure — 3 dirty rows, 2nd PATCH 500s → asserts **all 3** PATCHes fire (no early abort), "Saved 2 of 3" shows, sheet stays open, `onSaved` fired once.
  - all-success — sheet closes, `onSaved` fired, no error alert.
- [x] `tsc` no new errors; `npm test` **1058 green (133 files)**; `npm run lint` no new warnings; `npm run build` clean.
- [x] Browser smoke (offline mock, admin Grant): AssignUsageSheet renders; Save button reflects disabled/label state.

Builds on #205–#207, #209–#212.