### PR TITLE
chore(ci): enforce tsc --noEmit typecheck gate

### DIFF
--- a/.github/workflows/deploy-next.yml
+++ b/.github/workflows/deploy-next.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Typecheck gate. `next build` does NOT run `tsc --noEmit`, so a type
+      # error in a module the build doesn't reach (or in a test file) can
+      # slip past build + tests. Running it here fails the PR instead.
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## What & why

Makes `tsc --noEmit` a real CI gate. `next build` does **not** run a full typecheck, so a type error in a module the build doesn't reach — or in a test file — can pass `build` + `test` and only surface on a cold `tsc` run. That's exactly how the 7 errors #208 fixes stayed hidden behind the incremental `tsbuildinfo` cache.

> **Stacked on #208** (base `fix/tsc-test-typing`) so this branch's own `tsc` is already green. **Merge order: after #208 _and_ the birds stack (#209–#214).** Because the birds PRs branch off pre-#208 `main`, they still carry the 7 errors — landing this gate before they merge would retro-fail their CI. Merge it last (or merge `main` into any still-open PR after #208 lands).

## Changes

- **`package.json`** — new `"typecheck": "tsc --noEmit"` script (was a manual-only step).
- **`.github/workflows/pr-ci.yml`** — `Typecheck` step after `Lint`, before `Run tests`.
- **`.github/workflows/deploy-next.yml`** and **`deploy-stable.yml`** — same `Typecheck` step after install, before tests (mirrors the PR gate so a type error can't reach a deploy either).

## Test plan

- [x] `npm run typecheck` → exit 0 on this base (the #208 fixes are included).
- [x] Steps present in all three workflows; no other CI changes.

Addresses the "add `tsc` to CI" recommendation from the bird-inventory audit wrap-up.