### PR TITLE
design: token/consistency remediation (audit P0–P2 + items #1–#5)

### DIFF
--- a/__tests__/components/ErrorEmptyState.test.tsx
+++ b/__tests__/components/ErrorEmptyState.test.tsx
@@ -11,7 +11,7 @@ describe('ErrorState', () => {
     render(<ErrorState message="Couldn't load" />);
     const el = screen.getByRole('alert');
     expect(el.textContent).toBe("Couldn't load");
-    expect(el.className).toContain('text-red-400');
+    expect(el.className).toContain('field-error');
   });
 });
 

--- a/__tests__/design-canary.test.ts
+++ b/__tests__/design-canary.test.ts
@@ -25,6 +25,8 @@ const REQUIRED_TOKENS = [
   '--fs-2xs', '--fs-xs', '--fs-sm', '--fs-base', '--fs-md', '--fs-lg',
   // stats headline data scale + compat aliases (design-audit P0/P1)
   '--fs-stat', '--fs-stat-lg', '--color-red', '--color-amber', '--sev-warn',
+  // icon glyph-size ladder (mirrors .icon-* classes; design-audit item #3)
+  '--icon-xs', '--icon-sm', '--icon-md', '--icon-lg', '--icon-xl',
   // type families (--font-mono was a phantom token; see design-audit)
   '--font-display', '--font-sans', '--font-mono',
   '--lh-tight', '--lh-snug', '--lh-normal',

--- a/__tests__/design-canary.test.ts
+++ b/__tests__/design-canary.test.ts
@@ -23,6 +23,10 @@ const REQUIRED_TOKENS = [
   '--radius-xs', '--radius-sm', '--radius-md', '--radius-lg', '--radius-xl', '--radius-pill',
   // type-size scale (standardization Phase 0)
   '--fs-2xs', '--fs-xs', '--fs-sm', '--fs-base', '--fs-md', '--fs-lg',
+  // stats headline data scale + compat aliases (design-audit P0/P1)
+  '--fs-stat', '--fs-stat-lg', '--color-red', '--color-amber', '--sev-warn',
+  // type families (--font-mono was a phantom token; see design-audit)
+  '--font-display', '--font-sans', '--font-mono',
   '--lh-tight', '--lh-snug', '--lh-normal',
   // inline spacing scale (Phase 0)
   '--space-1', '--space-2', '--space-3', '--space-4', '--space-5', '--space-6',
@@ -32,6 +36,7 @@ const REQUIRED_TOKENS = [
 const REQUIRED_CLASSES = [
   '.glass-card', '.glass-card-soft', '.bpm-h1', '.bpm-h2', '.bpm-h3',
   '.section-label', '.fs-2xs', '.fs-sm', '.fs-base', '.cc-btn', '.segment-control',
+  '.fs-stat', '.field-error',
 ];
 
 describe('design-system canary: globals.css token/class contract', () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -320,6 +320,13 @@
   [data-theme="light"] .hover\:text-red-400:hover { color: #dc2626; }
   [data-theme="light"] .hover\:text-green-300:hover { color: #22c55e; }
   [data-theme="light"] .hover\:text-amber-300:hover { color: #b45309; }
+  /* Gaps closed in the design-audit palette pass — these hover utilities were
+     used without a light override, so on light theme they showed the raw
+     (low-contrast) Tailwind hue on hover. Values mirror the base overrides above. */
+  [data-theme="light"] .hover\:text-amber-400:hover { color: #d97706; }
+  [data-theme="light"] .hover\:text-blue-400:hover { color: #2563eb; }
+  [data-theme="light"] .hover\:text-blue-300:hover { color: #1d4ed8; }
+  [data-theme="light"] .hover\:text-gray-200:hover { color: #374151; }
 }
 [data-theme="light"] .border-white\/10 { border-color: rgba(0, 0, 0, 0.08); }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -455,6 +455,15 @@ body {
      tokens so those hand-typed 20/22px values stop being magic numbers. */
   --fs-stat: 20px;
   --fs-stat-lg: 22px;
+  /* Icon glyph-size ladder — token mirror of the .icon-xs..xl utility classes
+     (below), so inline `.material-icons` styles use a token instead of a raw px.
+     Same values as the classes; these exist for the inline-style call sites the
+     way --fs-* mirrors .fs-*. */
+  --icon-xs: 13px;
+  --icon-sm: 16px;
+  --icon-md: 18px;
+  --icon-lg: 24px;
+  --icon-xl: 40px;
   --lh-tight: 1.25;
   --lh-snug: 1.35;
   --lh-normal: 1.5;

--- a/app/globals.css
+++ b/app/globals.css
@@ -530,7 +530,7 @@ h1, h2, h3, h4 {
    line rendered below an input. One class so the pattern is deduped and
    theme-aware (was hand-coded as `text-red-400 text-xs` across ~30 sites). */
 .field-error {
-  font-size: var(--fs-xs);
+  font-size: var(--fs-sm);
   line-height: var(--lh-snug);
   color: var(--sev-crit-text);
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -347,6 +347,36 @@
   --sev-code-text: #15803d;
 }
 
+/* ── Compatibility aliases (design-audit P0) ──
+   These custom properties were referenced via var() across the app
+   (e.g. `var(--color-red, #ef4444)`) but never defined, so they always
+   resolved to a hardcoded, NON-theme-aware fallback. Defining them here
+   (dark values == the previous fallbacks, so dark mode is a visual no-op)
+   makes those call sites theme-aware and pulls them into the token system.
+   Prefer the semantic tokens above in NEW code; these exist so existing
+   call sites stop being frozen literals. */
+:root {
+  --color-red: #ef4444;
+  --color-amber: #f59e0b;
+  --text: var(--text-primary);
+  --border: rgba(255, 255, 255, 0.12);
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --sev-warn: #f59e0b;
+  --bg-surface: #1a1a1a;
+  --bg-elevated: #1a1a1a;
+  /* easeOutQuart — was silently falling back to plain `ease-out`. */
+  --ease-out-quart: cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+[data-theme="light"] {
+  --color-red: #dc2626;
+  --color-amber: #b45309;
+  --border: rgba(0, 0, 0, 0.08);
+  --border-subtle: rgba(0, 0, 0, 0.05);
+  --sev-warn: #b45309;
+  --bg-surface: #ffffff;
+  --bg-elevated: #ffffff;
+}
+
 /* ══════════════════════════════════════════════════════════
    Base resets
    ══════════════════════════════════════════════════════════ */
@@ -386,7 +416,15 @@ body {
   --font-sans:
     var(--ff-ibm-plex, 'IBM Plex Sans'),
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  /* --font-mono is set in .bpm-mono below and via --ff-jetbrains. */
+  /* --font-mono (JetBrains Mono, the "data" face) — resolves through the
+     next/font variable --ff-jetbrains (app/layout.tsx). Was previously
+     UNDEFINED: ~67 `var(--font-mono)` call sites (47 with no fallback) were
+     silently inheriting the sans body font, so tabular/data numbers (levels,
+     streaks, PINs, money, timestamps) lost their monospace face. Defining it
+     here — same phantom-token fix as the aliases above — repairs all sites. */
+  --font-mono:
+    var(--ff-jetbrains, 'JetBrains Mono'),
+    ui-monospace, 'SF Mono', Menlo, monospace;
 
   /* Corner radii ladder — rectangular surfaces capped at 16px per design
      bundle v3. Use these tokens in inline styles (`borderRadius:
@@ -412,6 +450,11 @@ body {
   --fs-base: 13px;
   --fs-md: 14px;
   --fs-lg: 16px;
+  /* Stats-tab headline data numbers (Level, Overall, streak count, partner
+     counts) — a deliberate larger mono scale with no Home equivalent. Named
+     tokens so those hand-typed 20/22px values stop being magic numbers. */
+  --fs-stat: 20px;
+  --fs-stat-lg: 22px;
   --lh-tight: 1.25;
   --lh-snug: 1.35;
   --lh-normal: 1.5;
@@ -480,6 +523,17 @@ h1, h2, h3, h4 {
 .fs-base { font-size: var(--fs-base); line-height: var(--lh-normal); }
 .fs-md  { font-size: var(--fs-md);  line-height: var(--lh-tight); }
 .fs-lg  { font-size: var(--fs-lg);  line-height: var(--lh-tight); }
+.fs-stat    { font-size: var(--fs-stat);    line-height: 1; }
+.fs-stat-lg { font-size: var(--fs-stat-lg); line-height: 1; }
+
+/* Sanctioned inline field-error text (DESIGN.md §7): the red, xs, role="alert"
+   line rendered below an input. One class so the pattern is deduped and
+   theme-aware (was hand-coded as `text-red-400 text-xs` across ~30 sites). */
+.field-error {
+  font-size: var(--fs-xs);
+  line-height: var(--lh-snug);
+  color: var(--sev-crit-text);
+}
 
 /* ── TopBar / PageHeader (sticky scroll-condensed) ──
    Per `TopBar Spec.html` design handoff (2026-05-06). At-rest is

--- a/components/AdminErrorBoundary.tsx
+++ b/components/AdminErrorBoundary.tsx
@@ -97,7 +97,7 @@ export default class AdminErrorBoundary extends Component<Props, State> {
           <p style={{ fontWeight: 600, color: 'var(--text)' }}>
             {this.state.isChunkError ? 'Admin needs a connection' : 'Couldn’t load admin'}
           </p>
-          <p style={{ fontSize: 13, marginTop: 6 }}>
+          <p style={{ fontSize: 'var(--fs-base)', marginTop: 6 }}>
             {this.state.isChunkError
               ? 'It’ll reload automatically when you’re back online.'
               : 'Something went wrong loading this view.'}

--- a/components/AdminTab.tsx
+++ b/components/AdminTab.tsx
@@ -72,7 +72,7 @@ export default function AdminTab({ onExit }: { onExit: () => void }) {
           <div className="glass-card p-6 w-full max-w-xs space-y-5">
             <div className="text-center">
               <span className="material-icons icon-xl text-green-400">lock</span>
-              <p className="text-sm text-gray-400 mt-2">{pageT('signInHelp')}</p>
+              <p className="fs-md text-gray-400 mt-2">{pageT('signInHelp')}</p>
             </div>
             <form onSubmit={handleSubmit} className="space-y-3">
               <div>

--- a/components/AdminTab.tsx
+++ b/components/AdminTab.tsx
@@ -98,7 +98,7 @@ export default function AdminTab({ onExit }: { onExit: () => void }) {
                 ariaInvalid={!!error}
                 autoFocus={!!name}
               />
-              {error && <p id="admin-error" role="alert" className="text-xs text-red-400">{error}</p>}
+              {error && <p id="admin-error" role="alert" className="field-error">{error}</p>}
               <button
                 type="submit"
                 disabled={checking || !name.trim() || pin.length !== 4}

--- a/components/CreateAccountSheet.tsx
+++ b/components/CreateAccountSheet.tsx
@@ -94,14 +94,14 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={t('title')} maxHeight="75vh" className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('title')}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{t('title')}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={tRecovery('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
@@ -111,7 +111,7 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
           </p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>{t('body')}</p>
+            <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', margin: 0 }}>{t('body')}</p>
             <input
               type="text"
               aria-label={t('nameLabel')}
@@ -122,11 +122,11 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
               autoComplete="nickname"
             />
             <div>
-              <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{t('pinLabel')}</p>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', marginBottom: 4 }}>{t('pinLabel')}</p>
               <PinInput value={pin} onChange={setPin} digits={4} label={t('pinLabel')} ariaInvalid={error === 'pin_problem'} />
             </div>
             <div>
-              <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{t('confirmPinLabel')}</p>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', marginBottom: 4 }}>{t('confirmPinLabel')}</p>
               <PinInput value={confirmPin} onChange={setConfirmPin} digits={4} label={t('confirmPinLabel')} ariaInvalid={error === 'pin_problem'} />
             </div>
             <button
@@ -139,16 +139,16 @@ export default function CreateAccountSheet({ open, onClose, sessionId }: Props) 
               {submitting ? t('submitting') : t('submit')}
             </button>
             {error === 'pin_problem' && (
-              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>{t('errorPinProblem')}</p>
+              <p role="alert" style={{ color: 'var(--color-red)', fontSize: 'var(--fs-sm)' }}>{t('errorPinProblem')}</p>
             )}
             {error === 'try_later' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorTryLater')}</p>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>{t('errorTryLater')}</p>
             )}
             {error === 'account_exists' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorAccountExists')}</p>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>{t('errorAccountExists')}</p>
             )}
             {error === 'invite_only' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>{t('errorInviteOnly')}</p>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>{t('errorInviteOnly')}</p>
             )}
           </div>
         )}

--- a/components/DatePicker.tsx
+++ b/components/DatePicker.tsx
@@ -146,7 +146,7 @@ export default function DatePicker({ value, onChange, placeholder = 'Date' }: Pr
           aria-label="Previous month"
           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1 }}
         >
-          <span className="material-icons" style={{ fontSize: 18 }}>chevron_left</span>
+          <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>chevron_left</span>
         </button>
         <span style={{ color: 'var(--text-primary)', fontWeight: 600, fontSize: '0.75rem' }}>
           {MONTHS_FULL[viewMonth]} {viewYear}
@@ -157,7 +157,7 @@ export default function DatePicker({ value, onChange, placeholder = 'Date' }: Pr
           aria-label="Next month"
           style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1 }}
         >
-          <span className="material-icons" style={{ fontSize: 18 }}>chevron_right</span>
+          <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>chevron_right</span>
         </button>
       </div>
 

--- a/components/DatePicker.tsx
+++ b/components/DatePicker.tsx
@@ -200,7 +200,7 @@ export default function DatePicker({ value, onChange, placeholder = 'Date' }: Pr
                 alignItems: 'center',
                 justifyContent: 'center',
               }}
-              onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.08)'; }}
+              onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLButtonElement).style.background = 'rgba(var(--glass-tint), 0.08)'; }}
               onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
             >
               {day}

--- a/components/DatePicker.tsx
+++ b/components/DatePicker.tsx
@@ -242,7 +242,7 @@ export default function DatePicker({ value, onChange, placeholder = 'Date' }: Pr
         <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {value ? formatDisplay(value) : placeholder}
         </span>
-        <span className="material-icons" style={{ fontSize: 14, flexShrink: 0, color: 'var(--text-muted)' }}>
+        <span className="material-icons" style={{ fontSize: 'var(--fs-md)', flexShrink: 0, color: 'var(--text-muted)' }}>
           calendar_today
         </span>
       </button>

--- a/components/DemoMode.tsx
+++ b/components/DemoMode.tsx
@@ -78,7 +78,7 @@ export default function DemoMode({ onClose }: Props) {
         >
           Demo mode
         </h1>
-        <p style={{ fontSize: 14, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-muted)', lineHeight: 1.5 }}>
           Placeholder. A guided tour of the app lands here in a future pass.
         </p>
       </div>

--- a/components/EnterCodeSheet.tsx
+++ b/components/EnterCodeSheet.tsx
@@ -72,14 +72,14 @@ export default function EnterCodeSheet({ open, onClose, sessionId, onRecovered }
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={t('codePathTitle')} className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('codePathTitle')}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{t('codePathTitle')}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={t('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
@@ -89,7 +89,7 @@ export default function EnterCodeSheet({ open, onClose, sessionId, onRecovered }
           </p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: 0 }}>
+            <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-secondary)', margin: 0 }}>
               {t('codePathHelp')}
             </p>
             <input
@@ -125,22 +125,22 @@ export default function EnterCodeSheet({ open, onClose, sessionId, onRecovered }
               {t('submitCode')}
             </button>
             {error === 'invalid' && (
-              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>
+              <p role="alert" style={{ color: 'var(--color-red)', fontSize: 'var(--fs-sm)' }}>
                 {t('errorInvalid')}
               </p>
             )}
             {error === 'rate_limited' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>
                 {t('errorRateLimited')}
               </p>
             )}
             {error === 'admin_logged_in' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>
                 {t('errorAdminLoggedIn')}
               </p>
             )}
             {error === 'server' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>
                 {t('errorNetwork')}
               </p>
             )}

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -558,7 +558,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
                   />
                 </>
               )}
-              {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
+              {error && <p id="signup-error" role="alert" className="field-error">{error}</p>}
               <button
                 type="submit"
                 disabled={
@@ -630,7 +630,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
                   />
                 </>
               )}
-              {error && <p id="signup-error" role="alert" className="text-red-400 text-xs">{error}</p>}
+              {error && <p id="signup-error" role="alert" className="field-error">{error}</p>}
               <button
                 type="submit"
                 disabled={

--- a/components/HomeTab.tsx
+++ b/components/HomeTab.tsx
@@ -406,12 +406,12 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
                 href={mapsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-gray-300 underline underline-offset-2 decoration-dotted line-clamp-2 block"
+                className="fs-sm text-gray-300 underline underline-offset-2 decoration-dotted line-clamp-2 block"
               >
                 {session.locationAddress}
               </a>
             ) : (
-              <p className="text-xs text-gray-300 line-clamp-2">{session.locationAddress}</p>
+              <p className="fs-sm text-gray-300 line-clamp-2">{session.locationAddress}</p>
             )
           ) : null}
         </div>
@@ -438,7 +438,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
       {effectiveAnnouncement && (
         <div className="glass-card p-5 space-y-2">
           <p className="section-label">{t('announcement.label')}</p>
-          <div className="announcement-body text-sm text-gray-200 leading-relaxed">
+          <div className="announcement-body fs-md text-gray-200 leading-relaxed">
             {renderMarkdown(effectiveAnnouncement.text)}
           </div>
         </div>
@@ -475,7 +475,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <p className="bpm-h2">{t('signup.heading')}</p>
-              <p key={spotsTotal - activePlayers.length} className="text-sm text-gray-400 animate-count-tick">{t('signup.spotsRemaining', { remaining: spotsTotal - activePlayers.length, total: spotsTotal })}</p>
+              <p key={spotsTotal - activePlayers.length} className="fs-md text-gray-400 animate-count-tick">{t('signup.spotsRemaining', { remaining: spotsTotal - activePlayers.length, total: spotsTotal })}</p>
             </div>
             <StatusBanner
               tone="success"
@@ -494,7 +494,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
             <div className="flex items-start justify-between">
               <p className="bpm-h2">{t('signup.heading')}</p>
               <div className="text-right">
-                <p className="text-xs text-gray-400">{tStates('waitlistLabel')}</p>
+                <p className="fs-sm text-gray-400">{tStates('waitlistLabel')}</p>
                 <p className="text-2xl font-bold text-amber-400 leading-none mt-0.5">
                   #{waitlistPosition}
                 </p>
@@ -515,7 +515,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <p className="bpm-h2">{t('signup.heading')}</p>
-              <p key={activePlayers.length} className="text-sm text-gray-400 animate-count-tick">{t('signup.spotsFull', { count: activePlayers.length })}</p>
+              <p key={activePlayers.length} className="fs-md text-gray-400 animate-count-tick">{t('signup.spotsFull', { count: activePlayers.length })}</p>
             </div>
             <StatusBanner tone="warn" icon="lock" title={t('signup.full')} body={t('signup.allSpotsTaken', { total: spotsTotal })} />
             <form onSubmit={handleJoinWaitlist} className="space-y-3">
@@ -574,7 +574,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
                 <button
                   type="button"
                   onClick={() => setEnterCodeOpen(true)}
-                  className="text-xs underline mx-auto"
+                  className="fs-sm underline mx-auto"
                   style={{ color: 'var(--text-secondary)', background: 'transparent', border: 'none', cursor: 'pointer', padding: '8px 12px', minHeight: 44 }}
                 >
                   {t('signup.forgotPin')}
@@ -587,7 +587,7 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
           <div className="space-y-4">
             <div className="flex items-start justify-between">
               <p className="bpm-h2">{t('signup.heading')}</p>
-              <p key={spotsTotal - activePlayers.length} className="text-sm text-gray-400 animate-count-tick">{t('signup.spotsRemaining', { remaining: spotsTotal - activePlayers.length, total: spotsTotal })}</p>
+              <p key={spotsTotal - activePlayers.length} className="fs-md text-gray-400 animate-count-tick">{t('signup.spotsRemaining', { remaining: spotsTotal - activePlayers.length, total: spotsTotal })}</p>
             </div>
             <form onSubmit={handleSignUp} className="space-y-3">
               <NameAutocompleteInput
@@ -647,14 +647,14 @@ export default function HomeTab({ onTabChange, onTitleTap, devOverrides, initial
                 <button
                   type="button"
                   onClick={() => setEnterCodeOpen(true)}
-                  className="text-xs underline mx-auto"
+                  className="fs-sm underline mx-auto"
                   style={{ color: 'var(--text-secondary)', background: 'transparent', border: 'none', cursor: 'pointer', padding: '8px 12px', minHeight: 44 }}
                 >
                   {t('signup.forgotPin')}
                 </button>
               )}
               {session?.deadline && authMode === 'anon' && (
-                <p className={`text-center text-xs font-medium ${isDeadlineApproaching ? 'text-red-400' : 'text-gray-400'}`}>
+                <p className={`text-center fs-sm font-medium ${isDeadlineApproaching ? 'text-red-400' : 'text-gray-400'}`}>
                   {t('signup.closesOn', { date: format.dateTime(new Date(session.deadline), DAY_LONG) })}
                 </p>
               )}

--- a/components/InstallBanner.tsx
+++ b/components/InstallBanner.tsx
@@ -52,7 +52,7 @@ export default function InstallBanner() {
         <span
           aria-hidden="true"
           className="material-icons"
-          style={{ fontSize: 22, color: 'var(--accent)', flex: '0 0 auto' }}
+          style={{ fontSize: 'var(--fs-stat-lg)', color: 'var(--accent)', flex: '0 0 auto' }}
         >
           install_mobile
         </span>
@@ -68,7 +68,7 @@ export default function InstallBanner() {
               padding: 0,
               background: 'none',
               border: 'none',
-              fontSize: 12,
+              fontSize: 'var(--fs-sm)',
               color: 'var(--accent)',
               fontWeight: 600,
               cursor: 'pointer',

--- a/components/InstallBanner.tsx
+++ b/components/InstallBanner.tsx
@@ -84,7 +84,7 @@ export default function InstallBanner() {
           className="cc-btn cc-btn-ghost"
           style={{ padding: 6, flex: '0 0 auto' }}
         >
-          <span className="material-icons" aria-hidden="true" style={{ fontSize: 18 }}>close</span>
+          <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-md)' }}>close</span>
         </button>
       </div>
       <InstallSheet open={open} onClose={() => setOpen(false)} />

--- a/components/InstallSheet.tsx
+++ b/components/InstallSheet.tsx
@@ -45,7 +45,7 @@ export default function InstallSheet({ open, onClose }: Props) {
           aria-label={t('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center', marginRight: -8 }}
         >
-          <span className="material-icons" aria-hidden="true" style={{ fontSize: 20, color: 'var(--text-muted)' }}>close</span>
+          <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat)', color: 'var(--text-muted)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="px-5 pb-6" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>

--- a/components/InstallSheet.tsx
+++ b/components/InstallSheet.tsx
@@ -70,7 +70,7 @@ export default function InstallSheet({ open, onClose }: Props) {
                   color: 'var(--accent)',
                 }}
               >
-                <span className="material-icons" style={{ fontSize: 17 }}>{s.icon}</span>
+                <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>{s.icon}</span>
               </span>
               <span className="fs-md" style={{ color: 'var(--text-primary)' }}>
                 {s.text}

--- a/components/PlayersTab.tsx
+++ b/components/PlayersTab.tsx
@@ -192,7 +192,7 @@ export default function PlayersTab() {
                         </button>
                       )}
                       {cancelError && (
-                        <span className="text-xs text-red-400">{cancelError}</span>
+                        <span className="field-error">{cancelError}</span>
                       )}
                     </div>
                   )}
@@ -252,7 +252,7 @@ export default function PlayersTab() {
                           </button>
                         )}
                         {cancelError && (
-                          <span className="text-xs text-red-400">{cancelError}</span>
+                          <span className="field-error">{cancelError}</span>
                         )}
                       </div>
                     )}

--- a/components/PlayersTab.tsx
+++ b/components/PlayersTab.tsx
@@ -109,7 +109,7 @@ export default function PlayersTab() {
       <div className="space-y-5">
         <PageHeader>{pageT('title')}</PageHeader>
         <div className="p-10 text-center">
-          <p className="text-sm text-gray-400" role="alert">{t('loadError')}</p>
+          <p className="fs-md text-gray-400" role="alert">{t('loadError')}</p>
           <div className="h-3" />
           <button type="button" onClick={() => loadPlayers()} className="cc-btn cc-btn-ghost">{t('retry')}</button>
         </div>
@@ -127,7 +127,7 @@ export default function PlayersTab() {
               Material's sports_tennis racquet. */}
           <ShuttleIcon size={36} color="var(--text-muted)" ariaLabel="No players yet" />
           <div className="h-2" />
-          <p className="text-gray-500 text-sm">{t('empty')}</p>
+          <p className="text-gray-500 fs-md">{t('empty')}</p>
         </div>
       </div>
     );
@@ -160,13 +160,13 @@ export default function PlayersTab() {
                      rows animate; poll refreshes don't replay it. */
                   style={{ animationDelay: `${Math.min(i, 8) * 40}ms` }}
                 >
-                  <span className="text-xs text-gray-500 w-5 text-right font-mono tabular-nums">
+                  <span className="fs-sm text-gray-500 w-5 text-right font-mono tabular-nums">
                     {i + 1}
                   </span>
-                  <span className="flex-1 text-sm text-gray-200 font-medium">
+                  <span className="flex-1 fs-md text-gray-200 font-medium">
                     {player.name}
                     {isMe && (
-                      <span className="ml-1.5 text-xs font-normal" style={{ color: 'var(--text-muted)' }}>
+                      <span className="ml-1.5 fs-sm font-normal" style={{ color: 'var(--text-muted)' }}>
                         {t('youSuffix')}
                       </span>
                     )}
@@ -186,7 +186,7 @@ export default function PlayersTab() {
                           type="button"
                           onClick={() => setConfirmingCancel(true)}
                           disabled={!online}
-                          className="text-xs text-red-400 hover:text-red-300 transition-colors ml-1"
+                          className="fs-sm text-red-400 hover:text-red-300 transition-colors ml-1"
                         >
                           {t('cancelAction')}
                         </button>
@@ -220,13 +220,13 @@ export default function PlayersTab() {
                     className={`flex items-center px-3 py-2.5 gap-3 rounded-xl animate-fadeIn${isMe ? ' player-highlight-amber' : ''}`}
                     style={{ animationDelay: `${Math.min(i, 8) * 40}ms` }}
                   >
-                    <span className="text-xs text-gray-500 w-5 text-right font-mono tabular-nums">
+                    <span className="fs-sm text-gray-500 w-5 text-right font-mono tabular-nums">
                       {activePlayers.length + i + 1}
                     </span>
-                    <span className="flex-1 text-sm text-gray-400 font-medium">
+                    <span className="flex-1 fs-md text-gray-400 font-medium">
                       {player.name}
                       {isMe && (
-                        <span className="ml-1.5 text-xs font-normal" style={{ color: 'var(--text-muted)' }}>
+                        <span className="ml-1.5 fs-sm font-normal" style={{ color: 'var(--text-muted)' }}>
                           {t('youSuffix')}
                         </span>
                       )}
@@ -246,7 +246,7 @@ export default function PlayersTab() {
                             type="button"
                             onClick={() => setConfirmingCancel(true)}
                             disabled={!online}
-                            className="text-xs text-red-400 hover:text-red-300 transition-colors ml-1"
+                            className="fs-sm text-red-400 hover:text-red-300 transition-colors ml-1"
                           >
                             {t('leaveAction')}
                           </button>

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -115,7 +115,7 @@ export default function PreviewBanner() {
               right: 12,
               zIndex: 10000,
               background: 'var(--bg-elevated)',
-              border: '1px solid rgba(255,255,255,0.12)',
+              border: '1px solid rgba(var(--glass-tint), 0.12)',
               borderRadius: 'var(--radius-lg)',
               padding: 8,
               boxShadow: '0 10px 30px rgba(0,0,0,0.5)',

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -114,7 +114,7 @@ export default function PreviewBanner() {
               top: BANNER_HEIGHT + 8,
               right: 12,
               zIndex: 10000,
-              background: 'var(--bg-elevated, #1a1a1a)',
+              background: 'var(--bg-elevated)',
               border: '1px solid rgba(255,255,255,0.12)',
               borderRadius: 'var(--radius-lg)',
               padding: 8,
@@ -140,7 +140,7 @@ export default function PreviewBanner() {
                 color: 'var(--text-primary, #fff)',
                 textDecoration: 'none',
                 borderRadius: 'var(--radius-sm)',
-                fontSize: 14,
+                fontSize: 'var(--fs-md)',
               }}
             >
               <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: '#ef4444' }}>
@@ -163,7 +163,7 @@ export default function PreviewBanner() {
                 color: 'var(--text-primary, #fff)',
                 textDecoration: 'none',
                 borderRadius: 'var(--radius-sm)',
-                fontSize: 14,
+                fontSize: 'var(--fs-md)',
               }}
             >
               <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: 'var(--accent, #22c55e)' }}>
@@ -184,7 +184,7 @@ export default function PreviewBanner() {
                 color: 'var(--text-muted, #aaa)',
                 textDecoration: 'none',
                 borderRadius: 'var(--radius-sm)',
-                fontSize: 13,
+                fontSize: 'var(--fs-base)',
               }}
             >
               <span className="material-icons" aria-hidden="true" style={{ fontSize: 18 }}>

--- a/components/PreviewBanner.tsx
+++ b/components/PreviewBanner.tsx
@@ -143,7 +143,7 @@ export default function PreviewBanner() {
                 fontSize: 'var(--fs-md)',
               }}
             >
-              <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: '#ef4444' }}>
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-md)', color: '#ef4444' }}>
                 error
               </span>
               Report a bug
@@ -166,7 +166,7 @@ export default function PreviewBanner() {
                 fontSize: 'var(--fs-md)',
               }}
             >
-              <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: 'var(--accent, #22c55e)' }}>
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-md)', color: 'var(--accent, #22c55e)' }}>
                 auto_fix_high
               </span>
               Suggest a feature
@@ -187,7 +187,7 @@ export default function PreviewBanner() {
                 fontSize: 'var(--fs-base)',
               }}
             >
-              <span className="material-icons" aria-hidden="true" style={{ fontSize: 18 }}>
+              <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-md)' }}>
                 schedule
               </span>
               Private email instead

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -641,7 +641,7 @@ function ProfileIdentityCard({ name, memberCreatedAt, isSignedUp, isAdmin, nameL
             fontWeight: 600,
             fontSize: 'var(--fs-stat)',
             flexShrink: 0,
-            border: '1px solid rgba(255,255,255,0.10)',
+            border: '1px solid rgba(var(--glass-tint), 0.10)',
           }}
         >
           {name.slice(0, 1).toUpperCase()}

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -463,7 +463,7 @@ function SettingsList({ title, rows }: { title?: string; rows: SettingsRow[] }) 
                 border: 'none',
                 cursor: 'pointer',
                 color: row.destructive ? 'var(--color-amber)' : 'var(--text-primary)',
-                fontSize: 15,
+                fontSize: 'var(--fs-lg)',
                 textAlign: 'left',
               }}
             >
@@ -662,7 +662,7 @@ function ProfileIdentityCard({ name, memberCreatedAt, isSignedUp, isAdmin, nameL
             {name}
           </p>
           {memberSince && (
-            <p style={{ fontSize: 12.5, color: 'var(--text-secondary)', marginTop: 2 }}>
+            <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', marginTop: 2 }}>
               Member since {memberSince}
             </p>
           )}
@@ -685,7 +685,7 @@ function ProfileIdentityCard({ name, memberCreatedAt, isSignedUp, isAdmin, nameL
                 border: '1px solid rgba(167,139,250,0.28)',
                 padding: '3px 10px',
                 borderRadius: 'var(--radius-pill)',
-                fontSize: 10.5,
+                fontSize: 'var(--fs-xs)',
                 fontFamily: 'var(--font-display, "Space Grotesk")',
                 fontWeight: 600,
                 letterSpacing: '0.04em',

--- a/components/ProfileTab.tsx
+++ b/components/ProfileTab.tsx
@@ -266,7 +266,7 @@ export default function ProfileTab({
               alignItems: 'center',
               gap: 8,
               color: 'var(--text-muted)',
-              fontSize: 11,
+              fontSize: 'var(--fs-xs)',
               textTransform: 'uppercase',
               letterSpacing: '0.1em',
             }}
@@ -314,7 +314,7 @@ export default function ProfileTab({
           type="button"
           onClick={() => setReportOpen(true)}
           className="btn-ghost"
-          style={{ width: '100%', fontSize: 13 }}
+          style={{ width: '100%', fontSize: 'var(--fs-base)' }}
         >
           {tSettings('reportProblem')}
         </button>
@@ -437,7 +437,7 @@ function SettingsList({ title, rows }: { title?: string; rows: SettingsRow[] }) 
         <p
           style={{
             padding: '14px 16px 8px',
-            fontSize: 11,
+            fontSize: 'var(--fs-xs)',
             fontWeight: 600,
             letterSpacing: '0.08em',
             textTransform: 'uppercase',
@@ -462,7 +462,7 @@ function SettingsList({ title, rows }: { title?: string; rows: SettingsRow[] }) 
                 background: 'transparent',
                 border: 'none',
                 cursor: 'pointer',
-                color: row.destructive ? 'var(--color-amber, #f59e0b)' : 'var(--text-primary)',
+                color: row.destructive ? 'var(--color-amber)' : 'var(--text-primary)',
                 fontSize: 15,
                 textAlign: 'left',
               }}
@@ -470,13 +470,13 @@ function SettingsList({ title, rows }: { title?: string; rows: SettingsRow[] }) 
               <span
                 className="material-icons"
                 aria-hidden="true"
-                style={{ fontSize: 20, color: 'var(--text-secondary)' }}
+                style={{ fontSize: 'var(--fs-stat)', color: 'var(--text-secondary)' }}
               >
                 {row.icon}
               </span>
               <span style={{ flex: 1 }}>{row.label}</span>
               {row.meta && (
-                <span style={{ fontSize: 13, color: 'var(--text-secondary)' }}>{row.meta}</span>
+                <span style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)' }}>{row.meta}</span>
               )}
               <span
                 className="material-icons"
@@ -564,13 +564,13 @@ function CostRow({
   return (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
       <div style={{ minWidth: 0, display: 'flex', alignItems: 'baseline', gap: 6, flexWrap: 'wrap' }}>
-        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>{label}</span>
-        {date && <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{date}</span>}
+        <span style={{ fontSize: 'var(--fs-base)', fontWeight: 600, color: 'var(--text-primary)' }}>{label}</span>
+        {date && <span style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>{date}</span>}
       </div>
       <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', flex: '0 0 auto' }}>
         <span
           style={{
-            fontSize: 10,
+            fontSize: 'var(--fs-2xs)',
             fontWeight: 700,
             letterSpacing: '0.06em',
             textTransform: 'uppercase',
@@ -583,7 +583,7 @@ function CostRow({
         <span
           style={{
             fontFamily: 'var(--font-mono)',
-            fontSize: 16,
+            fontSize: 'var(--fs-lg)',
             fontWeight: 700,
             color: amountColor,
             lineHeight: 1.25,
@@ -615,7 +615,7 @@ function ProfileIdentityCard({ name, memberCreatedAt, isSignedUp, isAdmin, nameL
       <p
         style={{
           fontFamily: 'var(--font-display, "Space Grotesk")',
-          fontSize: 10,
+          fontSize: 'var(--fs-2xs)',
           fontWeight: 700,
           letterSpacing: '0.16em',
           textTransform: 'uppercase',
@@ -639,7 +639,7 @@ function ProfileIdentityCard({ name, memberCreatedAt, isSignedUp, isAdmin, nameL
             justifyContent: 'center',
             fontFamily: 'var(--font-display, "Space Grotesk")',
             fontWeight: 600,
-            fontSize: 20,
+            fontSize: 'var(--fs-stat)',
             flexShrink: 0,
             border: '1px solid rgba(255,255,255,0.10)',
           }}
@@ -650,7 +650,7 @@ function ProfileIdentityCard({ name, memberCreatedAt, isSignedUp, isAdmin, nameL
           <p
             style={{
               fontFamily: 'var(--font-display, "Space Grotesk")',
-              fontSize: 22,
+              fontSize: 'var(--fs-stat-lg)',
               fontWeight: 700,
               letterSpacing: '-0.02em',
               margin: 0,
@@ -740,7 +740,7 @@ function ProfileEyebrow({ children }: { children: React.ReactNode }) {
     <p
       style={{
         fontFamily: 'var(--font-display, "Space Grotesk")',
-        fontSize: 11,
+        fontSize: 'var(--fs-xs)',
         fontWeight: 700,
         letterSpacing: '0.16em',
         textTransform: 'uppercase',

--- a/components/RecoveryPinSheet.tsx
+++ b/components/RecoveryPinSheet.tsx
@@ -109,20 +109,20 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, auth
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={title} maxHeight="75vh" className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{title}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{title}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={tRecovery('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
         {firstSetBlocked ? (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-            <p role="alert" style={{ fontSize: 14, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-md)', color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
               {t('pinNeedsSignIn')}
             </p>
             <button type="button" className="cc-btn cc-btn-secondary cc-btn-lg" onClick={onClose}>
@@ -133,7 +133,7 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, auth
         <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
           {hasPin && (
             <div>
-              <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('currentLabel')}</p>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('currentLabel')}</p>
               <PinInput
                 value={currentPin}
                 onChange={(v) => { setCurrentPin(v); setPinError(null); }}
@@ -145,7 +145,7 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, auth
             </div>
           )}
           <div>
-            <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('newLabel')}</p>
+            <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('newLabel')}</p>
             <PinInput
               value={newPin}
               onChange={(v) => { setNewPin(v); setPinError(null); }}
@@ -155,7 +155,7 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, auth
             />
           </div>
           <div>
-            <p style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('confirmLabel')}</p>
+            <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', marginBottom: 4 }}>{tPin('confirmLabel')}</p>
             <PinInput
               value={confirmPin}
               onChange={(v) => { setConfirmPin(v); setPinError(null); }}
@@ -164,37 +164,37 @@ export default function RecoveryPinSheet({ open, onClose, identity, hasPin, auth
             />
           </div>
           {pinError === 'too_common' && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
               {t('pinTooCommon')}
             </p>
           )}
           {pinError === 'invalid' && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
               {t('pinInvalid')}
             </p>
           )}
           {pinError === 'wrong_current' && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
               {t('pinWrongCurrent')}
             </p>
           )}
           {pinError === 'rate_limited' && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-amber, #f59e0b)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-amber)', margin: 0 }}>
               {t('pinRateLimited')}
             </p>
           )}
           {pinError === 'failed' && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
               {t('pinUpdateFailed')}
             </p>
           )}
           {pinError === 'needs_signin' && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-amber, #f59e0b)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-amber)', margin: 0 }}>
               {t('pinNeedsSignIn')}
             </p>
           )}
           {newPin && confirmPin && newPin !== confirmPin && (
-            <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
               {tPin('mismatch')}
             </p>
           )}

--- a/components/RecoverySheet.tsx
+++ b/components/RecoverySheet.tsx
@@ -47,14 +47,14 @@ export default function RecoverySheet({ open, onClose, sessionId, onForgotPin }:
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={t('sheetTitle')} className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('sheetTitle')}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{t('sheetTitle')}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={t('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">

--- a/components/ReleaseNotesTrigger.tsx
+++ b/components/ReleaseNotesTrigger.tsx
@@ -34,7 +34,7 @@ function ReleaseNotesTrigger({ releases, onOpen }: ReleaseNotesTriggerProps) {
     <button
       type="button"
       onClick={onOpen}
-      className={`text-xs px-2 transition-colors text-left ${
+      className={`fs-sm px-2 transition-colors text-left ${
         isUnread ? 'terminal-accent-text font-semibold' : 'text-gray-400'
       }`}
     >

--- a/components/ReportProblemSheet.tsx
+++ b/components/ReportProblemSheet.tsx
@@ -65,14 +65,14 @@ export default function ReportProblemSheet({ open, onClose, name }: Props) {
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={t('title')} className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('title')}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{t('title')}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={t('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
@@ -82,7 +82,7 @@ export default function ReportProblemSheet({ open, onClose, name }: Props) {
           </p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: 0 }}>{t('help')}</p>
+            <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-secondary)', margin: 0 }}>{t('help')}</p>
             <textarea
               aria-label={t('placeholder')}
               placeholder={t('placeholder')}
@@ -99,7 +99,7 @@ export default function ReportProblemSheet({ open, onClose, name }: Props) {
                 color: 'var(--text-primary)',
                 resize: 'vertical',
                 fontFamily: 'inherit',
-                fontSize: 14,
+                fontSize: 'var(--fs-md)',
               }}
             />
             <button
@@ -112,17 +112,17 @@ export default function ReportProblemSheet({ open, onClose, name }: Props) {
               {submitting ? t('sending') : t('send')}
             </button>
             {!online && (
-              <p role="status" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+              <p role="status" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>
                 {t('offline')}
               </p>
             )}
             {error === 'required' && (
-              <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12 }}>
+              <p role="alert" style={{ color: 'var(--color-red)', fontSize: 'var(--fs-sm)' }}>
                 {t('errorRequired')}
               </p>
             )}
             {error === 'server' && (
-              <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12 }}>
+              <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)' }}>
                 {t('errorServer')}
               </p>
             )}

--- a/components/SignInForm.tsx
+++ b/components/SignInForm.tsx
@@ -116,7 +116,7 @@ export default function SignInForm({ sessionId, onSuccess, onForgotPin }: SignIn
             background: 'transparent',
             border: 'none',
             color: 'var(--text-secondary)',
-            fontSize: 12,
+            fontSize: 'var(--fs-sm)',
             textDecoration: 'underline',
             cursor: 'pointer',
             alignSelf: 'center',
@@ -130,22 +130,22 @@ export default function SignInForm({ sessionId, onSuccess, onForgotPin }: SignIn
         </button>
       )}
       {error === 'invalid' && (
-        <p role="alert" style={{ color: 'var(--color-red, #ef4444)', fontSize: 12, margin: 0 }}>
+        <p role="alert" style={{ color: 'var(--color-red)', fontSize: 'var(--fs-sm)', margin: 0 }}>
           {t('errorInvalid')}
         </p>
       )}
       {error === 'rate_limited' && (
-        <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12, margin: 0 }}>
+        <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)', margin: 0 }}>
           {t('errorRateLimited')}
         </p>
       )}
       {error === 'admin_logged_in' && (
-        <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12, margin: 0 }}>
+        <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)', margin: 0 }}>
           {t('errorAdminLoggedIn')}
         </p>
       )}
       {error === 'network' && (
-        <p role="alert" style={{ color: 'var(--color-amber, #f59e0b)', fontSize: 12, margin: 0 }}>
+        <p role="alert" style={{ color: 'var(--color-amber)', fontSize: 'var(--fs-sm)', margin: 0 }}>
           {t('errorNetwork')}
         </p>
       )}

--- a/components/SkillsRadar.tsx
+++ b/components/SkillsRadar.tsx
@@ -135,7 +135,7 @@ export default function SkillsRadar({
               <button
                 key={m}
                 onClick={() => setMode(m)}
-                className={`flex-1 flex items-center justify-center text-xs capitalize transition-all ${
+                className={`flex-1 flex items-center justify-center fs-sm capitalize transition-all ${
                   mode === m ? 'segment-tab-active' : 'segment-tab-inactive'
                 }`}
               >
@@ -177,7 +177,7 @@ export default function SkillsRadar({
                 style={{ width: 8, height: 8, background: color }}
               />
               <span
-                className="text-sm font-medium whitespace-nowrap"
+                className="fs-md font-medium whitespace-nowrap"
                 style={{ color: isActive ? color : 'var(--text-secondary)' }}
               >
                 {p.name}
@@ -241,7 +241,7 @@ export default function SkillsRadar({
       </div>
 
       {/* Helper text */}
-      <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+      <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
         Tap a category to see your ACE level description
       </p>
 
@@ -257,10 +257,10 @@ export default function SkillsRadar({
               className="glass-card p-3 text-left transition-all active:scale-[0.97]"
               style={{ minHeight: 44 }}
             >
-              <p className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+              <p className="fs-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
                 {dim.name}
               </p>
-              <p className="text-sm font-bold mt-1" style={{ color: 'var(--text-primary)' }}>
+              <p className="fs-md font-bold mt-1" style={{ color: 'var(--text-primary)' }}>
                 {score > 0 ? `${score} — ${levelName}` : 'Not rated'}
               </p>
             </button>
@@ -404,7 +404,7 @@ function DetailContent({
           }}
         >
           <div className="flex items-center gap-2 mb-2">
-            <span className="text-sm font-bold" style={{ color: 'var(--text-primary)' }}>
+            <span className="fs-md font-bold" style={{ color: 'var(--text-primary)' }}>
               {playerName}
             </span>
             <span
@@ -417,7 +417,7 @@ function DetailContent({
               {score} — {levelName}
             </span>
           </div>
-          <p className="text-sm leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
+          <p className="fs-md leading-relaxed" style={{ color: 'var(--text-secondary)' }}>
             {dim.levels[score]}
           </p>
         </div>
@@ -430,7 +430,7 @@ function DetailContent({
         style={{ height: 44 }}
       >
         <span className="material-icons" style={{ fontSize: 16 }}>edit</span>
-        <span className="text-sm font-medium">Edit level</span>
+        <span className="fs-md font-medium">Edit level</span>
       </button>
 
       {/* All levels */}
@@ -449,19 +449,19 @@ function DetailContent({
           return (
             <div key={l.level} className="flex gap-3">
               <span
-                className="text-sm font-bold shrink-0 mt-0.5"
+                className="fs-md font-bold shrink-0 mt-0.5"
                 style={{ color: isActive ? 'var(--text-primary)' : 'var(--text-muted)', width: 14 }}
               >
                 {l.level}
               </span>
               <div className="min-w-0">
                 <span
-                  className="text-sm font-semibold"
+                  className="fs-md font-semibold"
                   style={{ color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)' }}
                 >
                   {l.name} —{' '}
                 </span>
-                <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                <span className="fs-sm" style={{ color: 'var(--text-muted)' }}>
                   {dim.levels[l.level]?.slice(0, 80)}...
                 </span>
               </div>
@@ -483,7 +483,7 @@ function EditContent({
 }) {
   return (
     <div className="space-y-3">
-      <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+      <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
         Tap a level to set your rating for {dim.name}
       </p>
 
@@ -503,7 +503,7 @@ function EditContent({
           >
             <div className="flex items-center gap-2 mb-1">
               <span
-                className="text-sm font-bold"
+                className="fs-md font-bold"
                 style={{ color: isActive ? 'var(--accent)' : 'var(--text-secondary)' }}
               >
                 {l.level}. {l.name}
@@ -514,7 +514,7 @@ function EditContent({
                 </span>
               )}
             </div>
-            <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+            <p className="fs-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
               {dim.levels[l.level]}
             </p>
           </button>

--- a/components/SkillsTab.tsx
+++ b/components/SkillsTab.tsx
@@ -291,7 +291,7 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
             </button>
           </div>
           {addError && (
-            <p id="skills-add-error" role="alert" className="text-red-400 text-xs">
+            <p id="skills-add-error" role="alert" className="field-error">
               {addError}
             </p>
           )}

--- a/components/SkillsTab.tsx
+++ b/components/SkillsTab.tsx
@@ -244,7 +244,7 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span
             style={{
-              fontSize: 10,
+              fontSize: 'var(--fs-2xs)',
               padding: '2px 8px',
               borderRadius: 'var(--radius-pill)',
               fontWeight: 600,
@@ -257,7 +257,7 @@ export default function SkillsTab({ isAdmin, onTabChange }: { isAdmin?: boolean;
           >
             Sample
           </span>
-          <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: 0 }}>
+          <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: 0 }}>
             Example profile — self-rating coming soon.
           </p>
         </div>

--- a/components/UnpaidSessionsCard.tsx
+++ b/components/UnpaidSessionsCard.tsx
@@ -91,7 +91,7 @@ export default function UnpaidSessionsCard({ name, variant = 'profile' }: Props)
 
   const showPaidUp = isHome && owesNothing;
   const title = isHome ? tBal('title') : t('title');
-  const titleColor = showPaidUp ? 'var(--accent)' : 'var(--sev-warn, #f59e0b)';
+  const titleColor = showPaidUp ? 'var(--accent)' : 'var(--sev-warn)';
   const lineItems = data?.sessions ?? [];
 
   return (
@@ -119,7 +119,7 @@ export default function UnpaidSessionsCard({ name, variant = 'profile' }: Props)
                   key={s.sessionId}
                   style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}
                 >
-                  <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                  <span style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>
                     {format.dateTime(new Date(s.date), DAY_SHORT)}
                   </span>
                   <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-md, 14px)', color: 'var(--text-primary)', whiteSpace: 'nowrap' }}>
@@ -149,7 +149,7 @@ export default function UnpaidSessionsCard({ name, variant = 'profile' }: Props)
             </div>
 
             {etransferEmail && (
-              <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)' }}>
+              <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>
                 {tPay('etransfer', { email: etransferEmail })}
               </p>
             )}

--- a/components/WelcomeCard.tsx
+++ b/components/WelcomeCard.tsx
@@ -25,12 +25,12 @@ function WelcomeCard({ onDismiss }: WelcomeCardProps) {
           <span className="material-icons" style={{ fontSize: '18px' }}>close</span>
         </button>
       </div>
-      <ul className="space-y-1.5 text-sm text-gray-300">
+      <ul className="space-y-1.5 fs-md text-gray-300">
         <li>{t('schedule')}</li>
         <li>{t('invite')}</li>
         <li>{t('payment')}</li>
       </ul>
-      <p className="text-xs text-gray-400">{t('help')}</p>
+      <p className="fs-sm text-gray-400">{t('help')}</p>
     </div>
   );
 }

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -233,12 +233,12 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
           {/* AI result */}
           {anno.polished && (
             <div className="inner-card-green p-3 space-y-2">
-              <p className="text-xs font-semibold text-green-400">AI Result</p>
-              <p className="text-sm text-gray-200 leading-relaxed">{anno.polished}</p>
+              <p className="fs-sm font-semibold text-green-400">AI Result</p>
+              <p className="fs-md text-gray-200 leading-relaxed">{anno.polished}</p>
               <button
                 onClick={() => anno.handlePost(anno.polished)}
                 disabled={anno.posting}
-                className="cc-btn cc-btn-primary cc-btn-lg text-sm"
+                className="cc-btn cc-btn-primary cc-btn-lg fs-md"
               >
                 {anno.posting ? 'Posting\u2026' : 'Post to Home'}
               </button>
@@ -273,19 +273,19 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                       value={anno.editAnnoText}
                       onChange={(e) => anno.setEditAnnoText(e.target.value)}
                       maxLength={800}
-                      className="w-full text-sm"
+                      className="w-full fs-md"
                     />
-                    <p className="text-right text-xs text-gray-500">{anno.editAnnoText.length}/800</p>
+                    <p className="text-right fs-sm text-gray-500">{anno.editAnnoText.length}/800</p>
                     {anno.editAnnoError && <p className="field-error">{anno.editAnnoError}</p>}
                     <div className="flex gap-2">
                       <button
                         onClick={() => anno.handleSaveAnno(a.id)}
                         disabled={anno.savingAnno || !anno.editAnnoText.trim()}
-                        className="cc-btn cc-btn-primary text-xs"
+                        className="cc-btn cc-btn-primary fs-sm"
                       >
                         {anno.savingAnno ? 'Saving\u2026' : 'Save'}
                       </button>
-                      <button onClick={() => anno.cancelEditAnno()} className="btn-ghost text-xs px-3 py-1.5">
+                      <button onClick={() => anno.cancelEditAnno()} className="btn-ghost fs-sm px-3 py-1.5">
                         Cancel
                       </button>
                     </div>
@@ -293,23 +293,23 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                 ) : (
                   <div key={a.id} className="glass-card-soft p-3">
                     <div className="flex items-start justify-between gap-2">
-                      <div className="announcement-body text-sm text-gray-200 flex-1">{renderMarkdown(a.text)}</div>
+                      <div className="announcement-body fs-md text-gray-200 flex-1">{renderMarkdown(a.text)}</div>
                       <div className="flex gap-3 shrink-0">
                         <button
                           onClick={() => anno.startEditAnno(a)}
-                          className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                          className="fs-sm text-blue-400 hover:text-blue-300 transition-colors"
                         >
                           Edit
                         </button>
                         <button
                           onClick={() => anno.handleDeleteAnnouncement(a.id)}
-                          className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                          className="fs-sm text-red-400 hover:text-red-300 transition-colors"
                         >
                           Delete
                         </button>
                       </div>
                     </div>
-                    <p className="text-xs text-gray-500 mt-1 flex items-center gap-1.5">
+                    <p className="fs-sm text-gray-500 mt-1 flex items-center gap-1.5">
                       <span>
                         {new Date(a.time).toLocaleString(undefined, {
                           month: 'short',
@@ -345,13 +345,13 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               <span className="material-icons" style={{ fontSize: 'var(--icon-lg)' }}>chevron_left</span>
             </button>
             <div className="text-center">
-              <p className="text-sm font-semibold text-white">
+              <p className="fs-md font-semibold text-white">
                 {nav.viewedSession ? fmtSessionNav(nav.viewedSession.datetime) : '\u2014'}
               </p>
               {nav.isViewingActive ? (
-                <p className="text-xs text-green-400 font-medium">Current session</p>
+                <p className="fs-sm text-green-400 font-medium">Current session</p>
               ) : (
-                <p className="text-xs text-gray-400">Past session</p>
+                <p className="fs-sm text-gray-400">Past session</p>
               )}
             </div>
             <button
@@ -371,7 +371,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
           {pm.loading ? (
             <div className="px-4"><ShimmerLoader lines={4} /></div>
           ) : pm.players.length === 0 ? (
-            <p className="text-center text-gray-500 text-sm p-8">No players signed up yet.</p>
+            <p className="text-center text-gray-500 fs-md p-8">No players signed up yet.</p>
           ) : (
             <div>
               <div className="list-header-green flex items-center justify-between">
@@ -381,7 +381,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                 <div className="flex items-center gap-2">
                   <button
                     onClick={pm.handleExportCSV}
-                    className="text-xs font-normal hover:text-green-300 transition-colors flex items-center gap-1"
+                    className="fs-sm font-normal hover:text-green-300 transition-colors flex items-center gap-1"
                   >
                     <span className="material-icons" style={{ fontSize: 'var(--fs-base)' }}>download</span>
                     Export CSV
@@ -400,14 +400,14 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                         <div className="absolute right-0 top-full mt-1 z-50 w-52 rounded-xl overflow-hidden border border-white/10" style={{ background: 'var(--dropdown-bg)', backdropFilter: 'blur(12px)' }}>
                           <button
                             onClick={() => { pm.setMoreMenuOpen(false); pm.setClearMode('soft'); pm.setClearError(''); pm.setConfirmingClear(true); }}
-                            className="w-full text-left px-4 py-3 text-sm text-gray-300 hover:bg-white/10 transition-colors flex items-center gap-3"
+                            className="w-full text-left px-4 py-3 fs-md text-gray-300 hover:bg-white/10 transition-colors flex items-center gap-3"
                           >
                             <span className="material-icons text-gray-500" style={{ fontSize: 'var(--icon-md)' }}>delete_sweep</span>
                             Clear Session
                           </button>
                           <button
                             onClick={() => { pm.setMoreMenuOpen(false); pm.setClearMode('hard'); pm.setClearError(''); pm.setConfirmingClear(true); }}
-                            className="w-full text-left px-4 py-3 text-sm text-red-400 hover:bg-white/10 transition-colors flex items-center gap-3"
+                            className="w-full text-left px-4 py-3 fs-md text-red-400 hover:bg-white/10 transition-colors flex items-center gap-3"
                           >
                             <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>delete_forever</span>
                             Purge All Records
@@ -421,8 +421,8 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               <div className="divide-y" style={{ borderColor: 'var(--divider)' }}>
                 {pm.players.map((player, i) => (
                   <div key={player.id} className="flex items-center px-4 py-3 gap-3">
-                    <span className="text-xs text-gray-500 w-5 text-right font-mono tabular-nums">{i + 1}</span>
-                    <span className="flex-1 text-sm text-gray-200 font-medium">{player.name}</span>
+                    <span className="fs-sm text-gray-500 w-5 text-right font-mono tabular-nums">{i + 1}</span>
+                    <span className="flex-1 fs-md text-gray-200 font-medium">{player.name}</span>
                     {player.selfReportedPaid && !player.paid && (
                       <span className="cc-pill cc-pill-amber" style={{ fontSize: 'var(--fs-2xs)', padding: '2px 6px' }}>
                         reported
@@ -431,14 +431,14 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                     <button
                       onClick={() => pm.handleTogglePaid(player)}
                       disabled={pm.togglingId === player.id}
-                      className={`text-xs font-medium transition-colors px-3 py-1.5 rounded-full ${player.paid ? 'pill-paid' : 'pill-unpaid'}`}
+                      className={`fs-sm font-medium transition-colors px-3 py-1.5 rounded-full ${player.paid ? 'pill-paid' : 'pill-unpaid'}`}
                       style={{ minHeight: 32 }}
                     >
                       {pm.savedId === player.id ? '\u2713' : pm.togglingId === player.id ? '\u2026' : player.paid ? 'Paid' : 'Pending'}
                     </button>
                     <button
                       onClick={() => handleResetAccess(player)}
-                      className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1 px-2"
+                      className="fs-sm text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1 px-2"
                       title={`Reset access for ${player.name}`}
                       aria-label={`Reset access for ${player.name}`}
                       style={{ minHeight: 44, minWidth: 44, justifyContent: 'center' }}
@@ -449,7 +449,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                     <button
                       onClick={() => pm.handleRemove(player)}
                       disabled={pm.removingId === player.id}
-                      className="text-xs text-gray-500 hover:text-amber-400 transition-colors flex items-center gap-1 px-2"
+                      className="fs-sm text-gray-500 hover:text-amber-400 transition-colors flex items-center gap-1 px-2"
                       title={`Remove ${player.name}`}
                       aria-label={`Remove ${player.name}`}
                       style={{ minHeight: 44, minWidth: 44, justifyContent: 'center' }}
@@ -500,19 +500,19 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
             <div className="divide-y" style={{ borderColor: 'var(--divider)' }}>
               {pm.waitlistPlayers.map((player, i) => (
                 <div key={player.id} className="flex items-center px-4 py-3 gap-3">
-                  <span className="text-xs text-gray-500 w-5 text-right font-mono tabular-nums">{pm.players.length + i + 1}</span>
-                  <span className="flex-1 text-sm text-gray-300 font-medium">{player.name}</span>
+                  <span className="fs-sm text-gray-500 w-5 text-right font-mono tabular-nums">{pm.players.length + i + 1}</span>
+                  <span className="flex-1 fs-md text-gray-300 font-medium">{player.name}</span>
                   <button
                     onClick={() => pm.handlePromote(player)}
                     disabled={pm.promotingId === player.id}
-                    className="text-xs text-amber-400 hover:text-amber-300 transition-colors py-2 px-1"
+                    className="fs-sm text-amber-400 hover:text-amber-300 transition-colors py-2 px-1"
                   >
                     {pm.promotingId === player.id ? '\u2026' : 'Promote'}
                   </button>
                   <button
                     onClick={() => pm.handleRemove(player)}
                     disabled={pm.removingId === player.id}
-                    className="text-xs text-gray-500 hover:text-red-400 transition-colors p-1 flex items-center gap-1"
+                    className="fs-sm text-gray-500 hover:text-red-400 transition-colors p-1 flex items-center gap-1"
                     title={`Remove ${player.name}`}
                   >
                     <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>person_remove</span>
@@ -559,11 +559,11 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                 })
                 .map((player, i) => (
                 <div key={player.id} className="flex items-center px-4 py-3 gap-3">
-                  <span className="text-xs text-gray-500 w-5 text-right font-mono tabular-nums">{i + 1}</span>
+                  <span className="fs-sm text-gray-500 w-5 text-right font-mono tabular-nums">{i + 1}</span>
                   <div className="flex-1 min-w-0">
-                    <span className="text-sm text-gray-500 font-medium line-through">{player.name}</span>
+                    <span className="fs-md text-gray-500 font-medium line-through">{player.name}</span>
                     {player.removedAt && (
-                      <p className="text-xs text-gray-500 mt-0.5">
+                      <p className="fs-sm text-gray-500 mt-0.5">
                         {player.cancelledBySelf ? 'Cancelled' : 'Removed'} &middot; {new Date(player.removedAt).toLocaleString(undefined, {
                           month: 'short', day: 'numeric',
                           hour: '2-digit', minute: '2-digit',
@@ -573,14 +573,14 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                   </div>
                   <button
                     onClick={() => pm.handleRestore(player)}
-                    className="text-xs text-amber-400 hover:text-amber-300 transition-colors p-1 flex items-center gap-1"
+                    className="fs-sm text-amber-400 hover:text-amber-300 transition-colors p-1 flex items-center gap-1"
                     title={`Restore ${player.name}`}
                   >
                     <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>restore</span>
                     <span className="hidden sm:inline">Restore</span>
                   </button>
                   {pm.confirmingPurgeId === player.id ? (
-                    <div className="flex items-center gap-2 text-xs">
+                    <div className="flex items-center gap-2 fs-sm">
                       <span className="text-gray-400">Delete?</span>
                       <button onClick={() => { pm.handlePurgeSingle(player); pm.setConfirmingPurgeId(null); }} className="text-red-400 hover:text-red-300 transition-colors">Yes</button>
                       <button onClick={() => pm.setConfirmingPurgeId(null)} className="text-gray-400 hover:text-white transition-colors">No</button>
@@ -588,7 +588,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                   ) : (
                     <button
                       onClick={() => pm.setConfirmingPurgeId(player.id)}
-                      className="text-xs text-gray-500 hover:text-red-400 transition-colors p-1 flex items-center gap-1"
+                      className="fs-sm text-gray-500 hover:text-red-400 transition-colors p-1 flex items-center gap-1"
                       title={`Permanently delete ${player.name}`}
                     >
                       <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>delete_forever</span>
@@ -646,7 +646,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                 <p id="clear-dialog-title" className="font-semibold text-white">
                   {pm.clearMode === 'soft' ? 'Clear session for new week?' : 'Permanently delete all records?'}
                 </p>
-                <p className="text-sm text-gray-400">
+                <p className="fs-md text-gray-400">
                   {pm.clearMode === 'soft' ? (
                     <>All <span className="text-white font-semibold">{pm.players.length}</span> player{pm.players.length !== 1 ? 's' : ''} will be moved to Cancelled. Data stays in the database.</>
                   ) : (
@@ -678,7 +678,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               </button>
               <button
                 onClick={() => { pm.setConfirmingClear(false); pm.setClearError(''); }}
-                className="w-full text-sm text-gray-400 hover:text-white transition-colors py-2"
+                className="w-full fs-md text-gray-400 hover:text-white transition-colors py-2"
               >
                 Cancel
               </button>

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -255,7 +255,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               {anno.posting ? 'Posting\u2026' : 'Post to Home'}
             </button>
           )}
-          {anno.postError && <p className="text-red-400 text-xs">{anno.postError}</p>}
+          {anno.postError && <p className="field-error">{anno.postError}</p>}
         </div>
 
         {/* Posted announcements */}
@@ -263,7 +263,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
           <div className="glass-card p-5 space-y-3">
             <h3 className="section-label-muted">ACTIVE ANNOUNCEMENTS</h3>
             <div className="space-y-2">
-              {anno.deletePostError && <p className="text-xs text-red-400 mb-1">{anno.deletePostError}</p>}
+              {anno.deletePostError && <p className="field-error mb-1">{anno.deletePostError}</p>}
               {anno.announcements.map((a) =>
                 anno.editingAnnoId === a.id ? (
                   <div key={a.id} className="glass-card-soft p-3 space-y-2">
@@ -276,7 +276,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                       className="w-full text-sm"
                     />
                     <p className="text-right text-xs text-gray-500">{anno.editAnnoText.length}/800</p>
-                    {anno.editAnnoError && <p className="text-red-400 text-xs">{anno.editAnnoError}</p>}
+                    {anno.editAnnoError && <p className="field-error">{anno.editAnnoError}</p>}
                     <div className="flex gap-2">
                       <button
                         onClick={() => anno.handleSaveAnno(a.id)}
@@ -485,12 +485,12 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               {pm.adding ? '\u2026' : 'Add'}
             </button>
           </div>
-          {pm.addError && <p id="add-error" role="alert" className="text-red-400 text-xs">{pm.addError}</p>}
+          {pm.addError && <p id="add-error" role="alert" className="field-error">{pm.addError}</p>}
         </form>
 
         {/* Waitlisted players */}
         {pm.promoteError && (
-          <p role="alert" className="text-xs text-red-400 px-1">{pm.promoteError}</p>
+          <p role="alert" className="field-error px-1">{pm.promoteError}</p>
         )}
         {pm.waitlistPlayers.length > 0 && (
           <div className="glass-card overflow-hidden">
@@ -526,7 +526,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
 
         {/* Removed players */}
         {pm.restoreError && (
-          <p role="alert" className="text-xs text-red-400 px-1">{pm.restoreError}</p>
+          <p role="alert" className="field-error px-1">{pm.restoreError}</p>
         )}
         {pm.removedPlayers.length > 0 && (
           <div className="glass-card overflow-hidden">
@@ -682,7 +682,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               >
                 Cancel
               </button>
-              {pm.clearError && <p role="alert" className="text-xs text-red-400 text-center">{pm.clearError}</p>}
+              {pm.clearError && <p role="alert" className="field-error text-center">{pm.clearError}</p>}
             </div>
           </div>
         </>,

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -383,7 +383,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                     onClick={pm.handleExportCSV}
                     className="text-xs font-normal hover:text-green-300 transition-colors flex items-center gap-1"
                   >
-                    <span className="material-icons" style={{ fontSize: 13 }}>download</span>
+                    <span className="material-icons" style={{ fontSize: 'var(--fs-base)' }}>download</span>
                     Export CSV
                   </button>
                   <div className="relative">
@@ -515,7 +515,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                     className="text-xs text-gray-500 hover:text-red-400 transition-colors p-1 flex items-center gap-1"
                     title={`Remove ${player.name}`}
                   >
-                    <span className="material-icons" style={{ fontSize: 16 }}>person_remove</span>
+                    <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>person_remove</span>
                     <span className="hidden sm:inline">Remove</span>
                   </button>
                 </div>
@@ -576,7 +576,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                     className="text-xs text-amber-400 hover:text-amber-300 transition-colors p-1 flex items-center gap-1"
                     title={`Restore ${player.name}`}
                   >
-                    <span className="material-icons" style={{ fontSize: 16 }}>restore</span>
+                    <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>restore</span>
                     <span className="hidden sm:inline">Restore</span>
                   </button>
                   {pm.confirmingPurgeId === player.id ? (
@@ -591,7 +591,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                       className="text-xs text-gray-500 hover:text-red-400 transition-colors p-1 flex items-center gap-1"
                       title={`Permanently delete ${player.name}`}
                     >
-                      <span className="material-icons" style={{ fontSize: 16 }}>delete_forever</span>
+                      <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>delete_forever</span>
                       <span className="hidden sm:inline">Delete</span>
                     </button>
                   )}

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -342,7 +342,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               className="text-white disabled:opacity-20 transition-opacity p-1"
               aria-label="Previous session"
             >
-              <span className="material-icons" style={{ fontSize: 24 }}>chevron_left</span>
+              <span className="material-icons" style={{ fontSize: 'var(--icon-lg)' }}>chevron_left</span>
             </button>
             <div className="text-center">
               <p className="text-sm font-semibold text-white">
@@ -361,7 +361,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
               className="text-white disabled:opacity-20 transition-opacity p-1"
               aria-label="Next session"
             >
-              <span className="material-icons" style={{ fontSize: 24 }}>chevron_right</span>
+              <span className="material-icons" style={{ fontSize: 'var(--icon-lg)' }}>chevron_right</span>
             </button>
           </div>
         )}
@@ -392,7 +392,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                       className="hover:text-green-300 transition-colors p-0.5"
                       aria-label="More actions"
                     >
-                      <span className="material-icons" style={{ fontSize: 18 }}>more_vert</span>
+                      <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>more_vert</span>
                     </button>
                     {pm.moreMenuOpen && (
                       <>
@@ -402,14 +402,14 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                             onClick={() => { pm.setMoreMenuOpen(false); pm.setClearMode('soft'); pm.setClearError(''); pm.setConfirmingClear(true); }}
                             className="w-full text-left px-4 py-3 text-sm text-gray-300 hover:bg-white/10 transition-colors flex items-center gap-3"
                           >
-                            <span className="material-icons text-gray-500" style={{ fontSize: 18 }}>delete_sweep</span>
+                            <span className="material-icons text-gray-500" style={{ fontSize: 'var(--icon-md)' }}>delete_sweep</span>
                             Clear Session
                           </button>
                           <button
                             onClick={() => { pm.setMoreMenuOpen(false); pm.setClearMode('hard'); pm.setClearError(''); pm.setConfirmingClear(true); }}
                             className="w-full text-left px-4 py-3 text-sm text-red-400 hover:bg-white/10 transition-colors flex items-center gap-3"
                           >
-                            <span className="material-icons" style={{ fontSize: 18 }}>delete_forever</span>
+                            <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>delete_forever</span>
                             Purge All Records
                           </button>
                         </div>
@@ -424,7 +424,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                     <span className="text-xs text-gray-500 w-5 text-right font-mono tabular-nums">{i + 1}</span>
                     <span className="flex-1 text-sm text-gray-200 font-medium">{player.name}</span>
                     {player.selfReportedPaid && !player.paid && (
-                      <span className="cc-pill cc-pill-amber" style={{ fontSize: 9, padding: '2px 6px' }}>
+                      <span className="cc-pill cc-pill-amber" style={{ fontSize: 'var(--fs-2xs)', padding: '2px 6px' }}>
                         reported
                       </span>
                     )}
@@ -443,7 +443,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                       aria-label={`Reset access for ${player.name}`}
                       style={{ minHeight: 44, minWidth: 44, justifyContent: 'center' }}
                     >
-                      <span className="material-icons" style={{ fontSize: 18 }}>key</span>
+                      <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>key</span>
                       <span className="hidden sm:inline">Reset</span>
                     </button>
                     <button
@@ -454,7 +454,7 @@ function Dashboard({ refreshKey, setView }: DashboardProps) {
                       aria-label={`Remove ${player.name}`}
                       style={{ minHeight: 44, minWidth: 44, justifyContent: 'center' }}
                     >
-                      <span className="material-icons" style={{ fontSize: 18 }}>person_remove</span>
+                      <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>person_remove</span>
                       <span className="hidden sm:inline">Remove</span>
                     </button>
                   </div>

--- a/components/admin/AdvanceSessionForm.tsx
+++ b/components/admin/AdvanceSessionForm.tsx
@@ -239,8 +239,8 @@ export default function AdvanceSessionForm({ onBack }: Props) {
             borderRadius: 'var(--radius-lg)',
             background: 'rgba(239,68,68,0.06)',
             border: '1px solid rgba(239,68,68,0.25)',
-            color: 'var(--color-red, #ef4444)',
-            fontSize: 13,
+            color: 'var(--color-red)',
+            fontSize: 'var(--fs-base)',
           }}
         >
           Couldn&apos;t load current session — fields below show defaults, not your last week&apos;s settings. Refresh before advancing.

--- a/components/admin/AdvanceSessionForm.tsx
+++ b/components/admin/AdvanceSessionForm.tsx
@@ -24,7 +24,7 @@ function withLocalTz(date: string, time: string): string {
 function Label({ text, children }: { text: string; children: React.ReactNode }) {
   return (
     <div className="space-y-1">
-      <p className="text-xs text-gray-400">{text}</p>
+      <p className="fs-sm text-gray-400">{text}</p>
       {children}
     </div>
   );
@@ -249,7 +249,7 @@ export default function AdvanceSessionForm({ onBack }: Props) {
 
       <form onSubmit={handleAdvance}>
         <div className="glass-card p-5 space-y-3">
-          <p className="text-xs text-gray-400">Creates a new session. The current session will be archived.</p>
+          <p className="fs-sm text-gray-400">Creates a new session. The current session will be archived.</p>
 
           <Label text="Session Name">
             <input
@@ -367,7 +367,7 @@ export default function AdvanceSessionForm({ onBack }: Props) {
           <Label text="Cost per court">
             <div className="relative">
               {costPerCourt !== null && costPerCourt > 0 && (
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm pointer-events-none" style={{ color: 'var(--text-muted)' }}>$</span>
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 fs-md pointer-events-none" style={{ color: 'var(--text-muted)' }}>$</span>
               )}
               <input
                 id="advance-cost-per-court"
@@ -423,7 +423,7 @@ export default function AdvanceSessionForm({ onBack }: Props) {
                         style={{ background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)' }}
                       >
                         <div className="min-w-0 flex-1">
-                          <p className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>{p.name}</p>
+                          <p className="fs-md font-medium truncate" style={{ color: 'var(--text-primary)' }}>{p.name}</p>
                           <p className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
                             ${p.costPerTube.toFixed(2)}/tube · {remaining} left
                           </p>
@@ -524,11 +524,11 @@ export default function AdvanceSessionForm({ onBack }: Props) {
         </BottomSheetHeader>
         <BottomSheetBody>
           <div className="space-y-4 pb-6">
-            <p className="text-sm text-gray-200">
+            <p className="fs-md text-gray-200">
               <strong>{date}</strong> is on your skip list — typically a holiday, travel date, or
               known venue closure.
             </p>
-            <p className="text-xs text-gray-400">
+            <p className="fs-sm text-gray-400">
               You can advance anyway if this is intentional. The skip date stays on the list.
             </p>
             <div className="flex flex-wrap gap-2 justify-end pt-2">

--- a/components/admin/AdvanceSessionForm.tsx
+++ b/components/admin/AdvanceSessionForm.tsx
@@ -465,7 +465,7 @@ export default function AdvanceSessionForm({ onBack }: Props) {
             );
           })()}
 
-          {advanceError && <p className="text-red-400 text-xs">{advanceError}</p>}
+          {advanceError && <p className="field-error">{advanceError}</p>}
 
           {success ? (
             <div className="space-y-3">

--- a/components/admin/AnnouncementComposer.tsx
+++ b/components/admin/AnnouncementComposer.tsx
@@ -156,7 +156,7 @@ export default function AnnouncementComposer({ draft, setDraft, maxLength = 800 
       {/* Editor / Preview pane */}
       {isPreview ? (
         <div
-          className="announcement-body text-sm text-gray-200 leading-relaxed glass-card p-4"
+          className="announcement-body fs-md text-gray-200 leading-relaxed glass-card p-4"
           style={{ minHeight: '5rem' }}
           aria-label="Announcement preview"
         >
@@ -175,7 +175,7 @@ export default function AnnouncementComposer({ draft, setDraft, maxLength = 800 
           maxLength={maxLength}
         />
       )}
-      <p className="text-right text-xs text-gray-500">{draft.length}/{maxLength}</p>
+      <p className="text-right fs-sm text-gray-500">{draft.length}/{maxLength}</p>
     </div>
   );
 }

--- a/components/admin/AnnouncementComposer.tsx
+++ b/components/admin/AnnouncementComposer.tsx
@@ -79,7 +79,7 @@ export default function AnnouncementComposer({ draft, setDraft, maxLength = 800 
   const tabStyle = (active: boolean): React.CSSProperties => ({
     padding: '8px 14px',
     minHeight: 36,
-    fontSize: 12,
+    fontSize: 'var(--fs-sm)',
     fontWeight: 600,
     letterSpacing: '0.02em',
     background: active ? 'var(--inner-card-green-bg, rgba(34,197,94,0.15))' : 'transparent',
@@ -142,13 +142,13 @@ export default function AnnouncementComposer({ draft, setDraft, maxLength = 800 
             I
           </button>
           <button type="button" onClick={() => handleFormat('ul')} aria-label="Bulleted list (- item)" title="Bulleted list — prefixes each line with -" style={formatBtnStyle}>
-            <span className="material-icons" style={{ fontSize: 20 }}>format_list_bulleted</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>format_list_bulleted</span>
           </button>
           <button type="button" onClick={() => handleFormat('ol')} aria-label="Numbered list (1. item)" title="Numbered list — prefixes each line with 1. 2. …" style={formatBtnStyle}>
-            <span className="material-icons" style={{ fontSize: 20 }}>format_list_numbered</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>format_list_numbered</span>
           </button>
           <button type="button" onClick={() => handleFormat('br')} aria-label="Paragraph break (blank line)" title="Paragraph break — inserts a blank line" style={formatBtnStyle}>
-            <span className="material-icons" style={{ fontSize: 20 }}>subdirectory_arrow_left</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>subdirectory_arrow_left</span>
           </button>
         </div>
       )}

--- a/components/admin/AssignUsageSheet.tsx
+++ b/components/admin/AssignUsageSheet.tsx
@@ -155,7 +155,7 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
             Assign to session
           </h2>
           {purchase && (
-            <p className="text-xs mt-0.5 truncate" style={{ color: 'var(--text-muted)' }}>
+            <p className="fs-sm mt-0.5 truncate" style={{ color: 'var(--text-muted)' }}>
               {purchase.name} · ${purchase.costPerTube.toFixed(2)}/tube
             </p>
           )}
@@ -171,10 +171,10 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
       </BottomSheetHeader>
 
       <BottomSheetBody className="p-5 pb-8">
-        {loading && <p className="text-sm text-gray-400">Loading sessions…</p>}
+        {loading && <p className="fs-md text-gray-400">Loading sessions…</p>}
 
         {!loading && rows.length === 0 && (
-          <p className="text-sm text-gray-400">No sessions yet.</p>
+          <p className="fs-md text-gray-400">No sessions yet.</p>
         )}
 
         {!loading && rows.length > 0 && (
@@ -182,10 +182,10 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
             {rows.map((r) => (
               <div key={r.sessionId} className="glass-card-soft p-3 flex items-center justify-between gap-3">
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                  <p className="fs-md font-medium" style={{ color: 'var(--text-primary)' }}>
                     {r.title ?? 'Session'}
                   </p>
-                  <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                  <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
                     {fmtSessionDate(r.datetime)}
                   </p>
                 </div>

--- a/components/admin/AssignUsageSheet.tsx
+++ b/components/admin/AssignUsageSheet.tsx
@@ -242,7 +242,7 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
           </div>
         )}
 
-        {error && <p className="text-red-400 text-xs mt-2" role="alert">{error}</p>}
+        {error && <p className="field-error mt-2" role="alert">{error}</p>}
 
         <div className="flex gap-2 mt-4">
           <button

--- a/components/admin/AssignUsageSheet.tsx
+++ b/components/admin/AssignUsageSheet.tsx
@@ -166,7 +166,7 @@ export default function AssignUsageSheet({ open, onClose, purchase, onSaved }: P
           aria-label="Close"
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
 

--- a/components/admin/BirdInventoryView.tsx
+++ b/components/admin/BirdInventoryView.tsx
@@ -516,7 +516,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                         title="Assign to session"
                         style={{ color: 'var(--accent)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                       >
-                        <span className="material-icons" style={{ fontSize: 18 }}>add</span>
+                        <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>add</span>
                       </button>
                       <button
                         onClick={() => startEdit(p)}

--- a/components/admin/BirdInventoryView.tsx
+++ b/components/admin/BirdInventoryView.tsx
@@ -232,7 +232,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
         <AdminBackHeader onBack={onBack} title="Bird Inventory" />
         <div role="alert" style={{ padding: '40px 24px', textAlign: 'center', color: 'var(--text-muted)' }}>
           <p style={{ fontWeight: 600, color: 'var(--text-primary)' }}>Couldn&apos;t load bird inventory</p>
-          <p style={{ fontSize: 13, marginTop: 6 }}>You may be offline. Reconnect, then retry.</p>
+          <p style={{ fontSize: 'var(--fs-base)', marginTop: 6 }}>You may be offline. Reconnect, then retry.</p>
           <button type="button" className="btn-primary" style={{ marginTop: 14 }} onClick={() => void loadAll()}>
             Retry
           </button>
@@ -269,7 +269,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
             <span
               className="material-icons"
               aria-hidden="true"
-              style={{ fontSize: 16, color: runwayColor }}
+              style={{ fontSize: 'var(--fs-lg)', color: runwayColor }}
             >
               trending_up
             </span>
@@ -341,7 +341,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                       {' total'}
                     </p>
                   </div>
-                  <span className="material-icons" aria-hidden="true" style={{ fontSize: 20, color: 'var(--text-muted)' }}>
+                  <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat)', color: 'var(--text-muted)' }}>
                     {expanded ? 'expand_less' : 'expand_more'}
                   </span>
                 </button>
@@ -448,7 +448,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                                 background: n <= (editForm.qualityRating ?? 0) ? 'var(--inner-card-green-bg)' : 'var(--inner-card-bg)',
                                 border: `1px solid ${n <= (editForm.qualityRating ?? 0) ? 'var(--inner-card-green-border)' : 'var(--inner-card-border)'}`,
                                 color: n <= (editForm.qualityRating ?? 0) ? 'var(--accent)' : 'var(--text-muted)',
-                                fontSize: 13, fontWeight: 600,
+                                fontSize: 'var(--fs-base)', fontWeight: 600,
                               }}
                             >
                               {n}
@@ -524,7 +524,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                         aria-label={`Edit purchase of ${p.name}`}
                         style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                       >
-                        <span className="material-icons" style={{ fontSize: 16 }}>edit</span>
+                        <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>edit</span>
                       </button>
                       <button
                         onClick={() => handleDelete(p.id)}
@@ -533,7 +533,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                         aria-label={`Delete purchase of ${p.name}`}
                         style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                       >
-                        <span className="material-icons" style={{ fontSize: 16 }}>
+                        <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>
                           {deletingId === p.id ? 'hourglass_empty' : 'delete'}
                         </span>
                       </button>
@@ -626,7 +626,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                       background: n <= qualityRating ? 'var(--inner-card-green-bg)' : 'var(--inner-card-bg)',
                       border: `1px solid ${n <= qualityRating ? 'var(--inner-card-green-border)' : 'var(--inner-card-border)'}`,
                       color: n <= qualityRating ? 'var(--accent)' : 'var(--text-muted)',
-                      fontSize: 13, fontWeight: 600,
+                      fontSize: 'var(--fs-base)', fontWeight: 600,
                     }}
                   >
                     {n}

--- a/components/admin/BirdInventoryView.tsx
+++ b/components/admin/BirdInventoryView.tsx
@@ -468,7 +468,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                         style={{ resize: 'none' }}
                       />
                     </Label>
-                    {editError && <p className="text-red-400 text-xs" role="alert">{editError}</p>}
+                    {editError && <p className="field-error" role="alert">{editError}</p>}
                     <div className="flex gap-2">
                       <button
                         onClick={handleSaveEdit}
@@ -647,7 +647,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
               style={{ resize: 'none' }}
             />
           </Label>
-          {addError && <p className="text-red-400 text-xs" role="alert">{addError}</p>}
+          {addError && <p className="field-error" role="alert">{addError}</p>}
           <button
             type="submit"
             disabled={adding || !shuttleName.trim() || tubes <= 0}

--- a/components/admin/BirdInventoryView.tsx
+++ b/components/admin/BirdInventoryView.tsx
@@ -13,7 +13,7 @@ const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 function Label({ text, children }: { text: string; children: React.ReactNode }) {
   return (
     <label className="block space-y-1">
-      <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
+      <span className="fs-sm font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
       {children}
     </label>
   );
@@ -261,11 +261,11 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
             >
               {currentStock}
             </span>
-            <span className="text-sm" style={{ color: 'var(--text-muted)' }}>
+            <span className="fs-md" style={{ color: 'var(--text-muted)' }}>
               tube{currentStock === 1 ? '' : 's'} remaining
             </span>
           </div>
-          <div className="flex items-center gap-2 text-xs" style={{ color: 'var(--text-muted)' }}>
+          <div className="flex items-center gap-2 fs-sm" style={{ color: 'var(--text-muted)' }}>
             <span
               className="material-icons"
               aria-hidden="true"
@@ -278,19 +278,19 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
           <div className="grid grid-cols-3 gap-2 pt-2" style={{ borderTop: '1px solid var(--inner-card-border)' }}>
             <div>
               <p className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>Avg/session</p>
-              <p className="text-base font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+              <p className="fs-lg font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
                 {avgPerSession || '—'}
               </p>
             </div>
             <div>
               <p className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>Total used</p>
-              <p className="text-base font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+              <p className="fs-lg font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
                 {totalUsed}
               </p>
             </div>
             <div>
               <p className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>Brands</p>
-              <p className="text-base font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
+              <p className="fs-lg font-semibold tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-primary)' }}>
                 {brandGroups.length}
               </p>
             </div>
@@ -325,8 +325,8 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                   }}
                 >
                   <div style={{ textAlign: 'left' }}>
-                    <p className="text-sm font-semibold">{g.brand}</p>
-                    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                    <p className="fs-md font-semibold">{g.brand}</p>
+                    <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
                       <span className="tabular-nums" style={{ fontFamily: 'var(--font-mono)' }}>
                         {g.remaining}
                       </span>
@@ -351,7 +351,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                       const used = usedByPurchase.get(p.id) ?? 0;
                       const remaining = Math.max(0, p.tubes - used);
                       return (
-                        <div key={p.id} className="text-xs flex justify-between" style={{ color: 'var(--text-muted)' }}>
+                        <div key={p.id} className="fs-sm flex justify-between" style={{ color: 'var(--text-muted)' }}>
                           <span>{parseBirdName(p.name).model || p.name}</span>
                           <span className="tabular-nums" style={{ fontFamily: 'var(--font-mono)' }}>
                             {remaining}/{p.tubes}
@@ -491,8 +491,8 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                 ) : (
                   <div className="flex items-start justify-between gap-2">
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{p.name}</p>
-                      <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+                      <p className="fs-md font-medium" style={{ color: 'var(--text-primary)' }}>{p.name}</p>
+                      <p className="fs-sm mt-0.5" style={{ color: 'var(--text-muted)' }}>
                         {new Date(p.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
                         {' · '}
                         {p.tubes} tube{p.tubes !== 1 ? 's' : ''} bought
@@ -502,12 +502,12 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
                         {p.qualityRating && ` · ${p.qualityRating}/5`}
                       </p>
                       {p.notes && (
-                        <p className="text-xs mt-0.5 italic" style={{ color: 'var(--text-muted)' }}>{p.notes}</p>
+                        <p className="fs-sm mt-0.5 italic" style={{ color: 'var(--text-muted)' }}>{p.notes}</p>
                       )}
                     </div>
                     <div className="flex items-center gap-1 shrink-0">
                       {p.totalCost > 0 && (
-                        <span className="text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>${p.totalCost.toFixed(2)}</span>
+                        <span className="fs-md font-medium" style={{ color: 'var(--text-secondary)' }}>${p.totalCost.toFixed(2)}</span>
                       )}
                       <button
                         onClick={() => setAssignPurchase(p)}
@@ -546,7 +546,7 @@ export default function BirdInventoryView({ onBack }: { onBack: () => void }) {
         </div>
       ) : (
         <div className="glass-card p-5">
-          <p className="text-sm text-center py-2" style={{ color: 'var(--text-muted)' }}>No purchases recorded yet.</p>
+          <p className="fs-md text-center py-2" style={{ color: 'var(--text-muted)' }}>No purchases recorded yet.</p>
         </div>
       )}
 

--- a/components/admin/CommandCenter/AdminConsoleHero.tsx
+++ b/components/admin/CommandCenter/AdminConsoleHero.tsx
@@ -122,7 +122,7 @@ export default function AdminConsoleHero({ onOpenAdmin }: AdminConsoleHeroProps)
         className="admin-hero"
         style={{ borderColor: 'rgba(239,68,68,0.3)', background: 'linear-gradient(160deg, rgba(239,68,68,0.06), rgba(255,255,255,0.02))' }}
       >
-        <span className="badge" style={{ color: 'var(--color-red, #ef4444)' }}>Admin console</span>
+        <span className="badge" style={{ color: 'var(--color-red)' }}>Admin console</span>
         <p className="ah-title">Couldn&apos;t load</p>
         <p className="ah-subtitle">Refresh to retry — your stats aren&apos;t available right now.</p>
       </div>

--- a/components/admin/CommandCenter/AdminConsoleHero.tsx
+++ b/components/admin/CommandCenter/AdminConsoleHero.tsx
@@ -186,7 +186,7 @@ export default function AdminConsoleHero({ onOpenAdmin }: AdminConsoleHeroProps)
         style={{ marginTop: 14, gap: 8 }}
       >
         Open admin home
-        <span className="material-icons" style={{ fontSize: 18 }}>arrow_forward</span>
+        <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>arrow_forward</span>
       </button>
     </div>
   );

--- a/components/admin/CommandCenter/AdminConsoleHero.tsx
+++ b/components/admin/CommandCenter/AdminConsoleHero.tsx
@@ -120,7 +120,7 @@ export default function AdminConsoleHero({ onOpenAdmin }: AdminConsoleHeroProps)
     return (
       <div
         className="admin-hero"
-        style={{ borderColor: 'rgba(239,68,68,0.3)', background: 'linear-gradient(160deg, rgba(239,68,68,0.06), rgba(255,255,255,0.02))' }}
+        style={{ borderColor: 'rgba(239,68,68,0.3)', background: 'linear-gradient(160deg, rgba(239,68,68,0.06), rgba(var(--glass-tint), 0.02))' }}
       >
         <span className="badge" style={{ color: 'var(--color-red)' }}>Admin console</span>
         <p className="ah-title">Couldn&apos;t load</p>

--- a/components/admin/CommandCenter/AdminDashTiles.tsx
+++ b/components/admin/CommandCenter/AdminDashTiles.tsx
@@ -77,7 +77,7 @@ export default function AdminDashTiles({ onOpenBirds, onOpenRoster }: AdminDashT
         role="alert"
         style={{ gridColumn: '1 / -1', display: 'block', padding: '12px 14px', borderRadius: 'var(--radius-xl)', background: 'rgba(239,68,68,0.06)', border: '1px solid rgba(239,68,68,0.2)' }}
       >
-        <p style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+        <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
           Couldn&apos;t load Birds + Roster summaries — refresh to retry.
         </p>
       </div>
@@ -129,7 +129,7 @@ export default function AdminDashTiles({ onOpenBirds, onOpenRoster }: AdminDashT
         </span>
         <span className="big" style={{ color: 'var(--accent)' }}>
           {data.activeMembers}
-          <span style={{ color: 'var(--ink-faint)', fontSize: 14, fontWeight: 500 }}>/{data.totalMembers}</span>
+          <span style={{ color: 'var(--ink-faint)', fontSize: 'var(--fs-md)', fontWeight: 500 }}>/{data.totalMembers}</span>
         </span>
         <span className="small">
           active{data.dormantMembers > 0 && ` · ${data.dormantMembers} dormant`}

--- a/components/admin/CommandCenter/AnnouncementsCard.tsx
+++ b/components/admin/CommandCenter/AnnouncementsCard.tsx
@@ -158,7 +158,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
       <header>
         <h3 className="bpm-h3">Announcements</h3>
         <p
-          className="text-xs text-gray-400 mt-0.5"
+          className="fs-sm text-gray-400 mt-0.5"
           role={loadError ? 'alert' : undefined}
           style={loadError ? { color: 'var(--color-red)' } : undefined}
         >
@@ -178,18 +178,18 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
             placeholder="Type your announcement…"
             rows={3}
             maxLength={800}
-            className="w-full text-sm rounded-lg p-3"
+            className="w-full fs-md rounded-lg p-3"
             style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
           />
 
           {polished && (
-            <div className="rounded-lg p-3 text-sm" style={{ background: 'rgba(124,58,237,0.10)', border: '1px solid rgba(124,58,237,0.3)' }}>
+            <div className="rounded-lg p-3 fs-md" style={{ background: 'rgba(124,58,237,0.10)', border: '1px solid rgba(124,58,237,0.3)' }}>
               <div className="flex items-center justify-between mb-2">
-                <span className="text-xs font-medium" style={{ color: '#c4b5fd' }}>AI polished version</span>
+                <span className="fs-sm font-medium" style={{ color: '#c4b5fd' }}>AI polished version</span>
                 <button
                   type="button"
                   onClick={() => setDraft(polished)}
-                  className="text-xs underline-offset-2 hover:underline"
+                  className="fs-sm underline-offset-2 hover:underline"
                   style={{ color: '#c4b5fd' }}
                 >
                   Use this
@@ -236,7 +236,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
           {items.map((a) => (
             <li
               key={a.id}
-              className="rounded-lg p-3 text-sm leading-relaxed"
+              className="rounded-lg p-3 fs-md leading-relaxed"
               style={{ background: 'rgba(var(--glass-tint), 0.04)' }}
             >
               {editingId === a.id ? (
@@ -246,7 +246,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
                     maxLength={800}
-                    className="w-full text-sm rounded-lg p-3"
+                    className="w-full fs-md rounded-lg p-3"
                     style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
                   />
                   {editError && <p className="field-error">{editError}</p>}
@@ -273,21 +273,21 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
                 <>
                   <div className="announcement-body">{renderMarkdown(a.text)}</div>
                   <div className="flex items-center justify-between mt-2">
-                    <time className="text-xs text-gray-400">
+                    <time className="fs-sm text-gray-400">
                       {new Date(a.time).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
                     </time>
                     <div className="flex gap-2">
                       <button
                         type="button"
                         onClick={() => startEdit(a)}
-                        className="text-xs text-gray-400 hover:text-gray-200"
+                        className="fs-sm text-gray-400 hover:text-gray-200"
                       >
                         Edit
                       </button>
                       <button
                         type="button"
                         onClick={() => handleDelete(a.id)}
-                        className="text-xs text-gray-400 hover:text-red-400"
+                        className="fs-sm text-gray-400 hover:text-red-400"
                       >
                         Delete
                       </button>

--- a/components/admin/CommandCenter/AnnouncementsCard.tsx
+++ b/components/admin/CommandCenter/AnnouncementsCard.tsx
@@ -179,7 +179,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
             rows={3}
             maxLength={800}
             className="w-full text-sm rounded-lg p-3"
-            style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+            style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
           />
 
           {polished && (
@@ -237,7 +237,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
             <li
               key={a.id}
               className="rounded-lg p-3 text-sm leading-relaxed"
-              style={{ background: 'rgba(255,255,255,0.04)' }}
+              style={{ background: 'rgba(var(--glass-tint), 0.04)' }}
             >
               {editingId === a.id ? (
                 <div className="space-y-2">
@@ -247,7 +247,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
                     rows={3}
                     maxLength={800}
                     className="w-full text-sm rounded-lg p-3"
-                    style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.12)' }}
+                    style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
                   />
                   {editError && <p className="field-error">{editError}</p>}
                   <div className="flex gap-2 justify-end">

--- a/components/admin/CommandCenter/AnnouncementsCard.tsx
+++ b/components/admin/CommandCenter/AnnouncementsCard.tsx
@@ -199,7 +199,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
             </div>
           )}
 
-          {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
+          {error && <p className="field-error" role="alert">{error}</p>}
 
           <div className="flex flex-wrap gap-2 justify-end">
             <button
@@ -249,7 +249,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
                     className="w-full text-sm rounded-lg p-3"
                     style={{ background: 'rgba(0,0,0,0.2)', border: '1px solid rgba(255,255,255,0.12)' }}
                   />
-                  {editError && <p className="text-xs text-red-400">{editError}</p>}
+                  {editError && <p className="field-error">{editError}</p>}
                   <div className="flex gap-2 justify-end">
                     <button
                       type="button"

--- a/components/admin/CommandCenter/AnnouncementsCard.tsx
+++ b/components/admin/CommandCenter/AnnouncementsCard.tsx
@@ -160,7 +160,7 @@ export default function AnnouncementsCard({ refreshKey = 0 }: AnnouncementsCardP
         <p
           className="text-xs text-gray-400 mt-0.5"
           role={loadError ? 'alert' : undefined}
-          style={loadError ? { color: 'var(--color-red, #ef4444)' } : undefined}
+          style={loadError ? { color: 'var(--color-red)' } : undefined}
         >
           {loadError
             ? "Couldn't load — refresh to retry"

--- a/components/admin/CommandCenter/AnomalyFeed.tsx
+++ b/components/admin/CommandCenter/AnomalyFeed.tsx
@@ -111,11 +111,11 @@ export default function AnomalyFeed({ refreshKey = 0 }: AnomalyFeedProps) {
                   ? 'rgba(239, 68, 68, 0.12)'
                   : anomaly.severity === 'warning'
                     ? 'rgba(245, 158, 11, 0.10)'
-                    : 'rgba(255, 255, 255, 0.04)',
+                    : 'rgba(var(--glass-tint), 0.04)',
               border:
                 anomaly.severity === 'blocking'
                   ? '1px solid rgba(239, 68, 68, 0.3)'
-                  : '1px solid rgba(255, 255, 255, 0.08)',
+                  : '1px solid rgba(var(--glass-tint), 0.08)',
             }}
           >
             <span

--- a/components/admin/CommandCenter/AnomalyFeed.tsx
+++ b/components/admin/CommandCenter/AnomalyFeed.tsx
@@ -87,7 +87,7 @@ export default function AnomalyFeed({ refreshKey = 0 }: AnomalyFeedProps) {
           border: '1px solid rgba(239,68,68,0.2)',
         }}
       >
-        <p style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+        <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
           Couldn&apos;t load anomalies — try refreshing.
         </p>
       </section>
@@ -145,7 +145,7 @@ export default function AnomalyFeed({ refreshKey = 0 }: AnomalyFeedProps) {
                   Dismiss
                 </button>
                 {dismissError === anomaly.code && (
-                  <span style={{ fontSize: 10, color: 'var(--color-red, #ef4444)' }}>
+                  <span style={{ fontSize: 'var(--fs-2xs)', color: 'var(--color-red)' }}>
                     Failed — retry
                   </span>
                 )}

--- a/components/admin/CommandCenter/AnomalyFeed.tsx
+++ b/components/admin/CommandCenter/AnomalyFeed.tsx
@@ -98,7 +98,7 @@ export default function AnomalyFeed({ refreshKey = 0 }: AnomalyFeedProps) {
     <section className="glass-card p-4 space-y-3" aria-label="Anomalies">
       <header className="flex items-center justify-between">
         <h3 className="bpm-h3">Heads up</h3>
-        <span className="text-xs text-gray-400">{items.length}</span>
+        <span className="fs-sm text-gray-400">{items.length}</span>
       </header>
       <ul className="space-y-2" role="list">
         {items.map((anomaly) => (
@@ -119,7 +119,7 @@ export default function AnomalyFeed({ refreshKey = 0 }: AnomalyFeedProps) {
             }}
           >
             <span
-              className="material-icons text-base"
+              className="material-icons fs-lg"
               aria-hidden="true"
               style={{
                 color:
@@ -132,14 +132,14 @@ export default function AnomalyFeed({ refreshKey = 0 }: AnomalyFeedProps) {
             >
               {anomaly.severity === 'blocking' ? 'error' : 'warning'}
             </span>
-            <p className="flex-1 text-sm leading-relaxed">{anomaly.message}</p>
+            <p className="flex-1 fs-md leading-relaxed">{anomaly.message}</p>
             {anomaly.dismissable && (
               <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
                 <button
                   type="button"
                   onClick={() => dismiss(anomaly.code)}
                   disabled={dismissing.has(anomaly.code)}
-                  className="text-xs text-gray-400 hover:text-gray-200 px-2 py-1 disabled:opacity-50"
+                  className="fs-sm text-gray-400 hover:text-gray-200 px-2 py-1 disabled:opacity-50"
                   aria-label={`Dismiss ${anomaly.code}`}
                 >
                   Dismiss

--- a/components/admin/CommandCenter/BirdsPage.tsx
+++ b/components/admin/CommandCenter/BirdsPage.tsx
@@ -38,7 +38,7 @@ function Stars({ n }: { n: number }) {
         <span
           key={i}
           className="material-icons"
-          style={{ fontSize: 'var(--fs-sm)', color: i <= n ? 'var(--amber)' : 'rgba(255,255,255,0.18)' }}
+          style={{ fontSize: 'var(--fs-sm)', color: i <= n ? 'var(--amber)' : 'rgba(var(--glass-tint), 0.18)' }}
         >
           star
         </span>
@@ -76,10 +76,10 @@ function PurchaseRow({
         cursor: 'pointer',
         padding: '12px 16px',
         border: 'none',
-        borderTop: index ? '1px solid rgba(255,255,255,0.05)' : 'none',
+        borderTop: index ? '1px solid rgba(var(--glass-tint), 0.05)' : 'none',
         transition: 'background 120ms ease',
       }}
-      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,255,255,0.03)'; }}
+      onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'rgba(var(--glass-tint), 0.03)'; }}
       onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
     >
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
@@ -111,9 +111,9 @@ function PurchaseRow({
             fontSize: 'var(--fs-2xs)',
             fontWeight: 600,
             fontFamily: 'var(--font-display, "Space Grotesk")',
-            background: 'rgba(255,255,255,0.06)',
+            background: 'rgba(var(--glass-tint), 0.06)',
             color: 'var(--text-muted)',
-            border: '1px solid rgba(255,255,255,0.1)',
+            border: '1px solid rgba(var(--glass-tint), 0.1)',
           }}
         >
           {left} left
@@ -457,7 +457,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
           padding: 18,
           overflow: 'hidden',
           position: 'relative',
-          background: 'linear-gradient(160deg, rgba(74,222,128,0.08), rgba(255,255,255,0.02))',
+          background: 'linear-gradient(160deg, rgba(74,222,128,0.08), rgba(var(--glass-tint), 0.02))',
         }}
       >
         <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-secondary)', margin: 0 }}>Runs out in</p>
@@ -682,7 +682,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
                   )}
                 </div>
               </div>
-              <div className="pbar" style={{ marginTop: 8, height: 6, borderRadius: 'var(--radius-pill)', background: 'rgba(255,255,255,0.07)', overflow: 'hidden' }}>
+              <div className="pbar" style={{ marginTop: 8, height: 6, borderRadius: 'var(--radius-pill)', background: 'rgba(var(--glass-tint), 0.07)', overflow: 'hidden' }}>
                 <div
                   style={{
                     height: '100%',
@@ -848,7 +848,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
                       className="material-icons"
                       style={{
                         fontSize: 24,
-                        color: i <= formQuality ? 'var(--amber)' : 'rgba(255,255,255,0.18)',
+                        color: i <= formQuality ? 'var(--amber)' : 'rgba(var(--glass-tint), 0.18)',
                       }}
                     >
                       star

--- a/components/admin/CommandCenter/BirdsPage.tsx
+++ b/components/admin/CommandCenter/BirdsPage.tsx
@@ -84,7 +84,7 @@ function PurchaseRow({
     >
       <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 0 }}>
-          <p style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 13.5, fontWeight: 600, margin: 0 }}>
+          <p style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 'var(--fs-md)', fontWeight: 600, margin: 0 }}>
             {p.name}
           </p>
           <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: 0 }}>
@@ -485,7 +485,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
                 alignItems: 'center',
                 padding: '3px 9px',
                 borderRadius: 'var(--radius-pill)',
-                fontSize: 10.5,
+                fontSize: 'var(--fs-xs)',
                 fontWeight: 600,
                 fontFamily: 'var(--font-display, "Space Grotesk")',
                 letterSpacing: '0.02em',
@@ -624,7 +624,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
             style={{ flex: 1, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
             onClick={openAddSheet}
           >
-            <span className="material-icons" style={{ fontSize: 18 }}>add_shopping_cart</span>
+            <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>add_shopping_cart</span>
             Log purchase
           </button>
           <button
@@ -633,7 +633,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
             style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}
             onClick={openReconcileSheet}
           >
-            <span className="material-icons" style={{ fontSize: 18 }}>fact_check</span>
+            <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>fact_check</span>
             Reconcile
           </button>
         </div>

--- a/components/admin/CommandCenter/BirdsPage.tsx
+++ b/components/admin/CommandCenter/BirdsPage.tsx
@@ -38,7 +38,7 @@ function Stars({ n }: { n: number }) {
         <span
           key={i}
           className="material-icons"
-          style={{ fontSize: 12, color: i <= n ? 'var(--amber)' : 'rgba(255,255,255,0.18)' }}
+          style={{ fontSize: 'var(--fs-sm)', color: i <= n ? 'var(--amber)' : 'rgba(255,255,255,0.18)' }}
         >
           star
         </span>
@@ -87,16 +87,16 @@ function PurchaseRow({
           <p style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 13.5, fontWeight: 600, margin: 0 }}>
             {p.name}
           </p>
-          <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>
+          <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: 0 }}>
             {fmtDate(p.date)} · {p.tubes} tube{p.tubes === 1 ? '' : 's'}
             {typeof p.speed === 'number' && ` · spd ${p.speed}`}
           </p>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
-          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 13, fontWeight: 600 }}>
+          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-base)', fontWeight: 600 }}>
             ${p.totalCost.toFixed(2)}
           </span>
-          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 10, color: 'var(--ink-faint)' }}>
+          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)' }}>
             ${p.costPerTube.toFixed(2)}/t
           </span>
         </div>
@@ -108,7 +108,7 @@ function PurchaseRow({
             display: 'inline-flex',
             padding: '3px 9px',
             borderRadius: 'var(--radius-pill)',
-            fontSize: 10,
+            fontSize: 'var(--fs-2xs)',
             fontWeight: 600,
             fontFamily: 'var(--font-display, "Space Grotesk")',
             background: 'rgba(255,255,255,0.06)',
@@ -121,7 +121,7 @@ function PurchaseRow({
         {p.notes && (
           <span
             style={{
-              fontSize: 11,
+              fontSize: 'var(--fs-xs)',
               color: 'var(--ink-faint)',
               flex: 1,
               overflow: 'hidden',
@@ -432,7 +432,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         <AdminBackHeader onBack={onBack} title="Birds" />
         <div role="alert" style={{ padding: '40px 24px', textAlign: 'center', color: 'var(--text-muted)' }}>
           <p style={{ fontWeight: 600, color: 'var(--text)' }}>Couldn&apos;t load birds</p>
-          <p style={{ fontSize: 13, marginTop: 6 }}>You may be offline. Reconnect, then retry.</p>
+          <p style={{ fontSize: 'var(--fs-base)', marginTop: 6 }}>You may be offline. Reconnect, then retry.</p>
           <button
             type="button"
             className="cc-btn cc-btn-ghost"
@@ -460,7 +460,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
           background: 'linear-gradient(160deg, rgba(74,222,128,0.08), rgba(255,255,255,0.02))',
         }}
       >
-        <p style={{ fontSize: 14, color: 'var(--text-secondary)', margin: 0 }}>Runs out in</p>
+        <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-secondary)', margin: 0 }}>Runs out in</p>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, marginTop: 2 }}>
           <span
             style={{
@@ -498,7 +498,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
             </span>
           )}
         </div>
-        <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '6px 0 0' }}>
+        <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-secondary)', margin: '6px 0 0' }}>
           <strong style={{ color: 'var(--text-primary)' }}>{currentStock} tubes</strong> on hand
           {burnPerSession > 0 && (
             <>
@@ -507,20 +507,20 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
           )}
         </p>
         {totalAdjustments !== 0 && (
-          <p style={{ fontSize: 11, color: 'var(--ink-faint)', margin: '4px 0 0' }}>
+          <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--ink-faint)', margin: '4px 0 0' }}>
             includes {totalAdjustments > 0 ? '+' : '−'}{Math.abs(totalAdjustments)} from a manual recount
           </p>
         )}
         {stockDrift > 0 && (
-          <p role="alert" style={{ fontSize: 11, color: 'var(--amber)', margin: '4px 0 0', display: 'flex', alignItems: 'center', gap: 5 }}>
-            <span className="material-icons" style={{ fontSize: 14 }} aria-hidden="true">warning</span>
+          <p role="alert" style={{ fontSize: 'var(--fs-xs)', color: 'var(--amber)', margin: '4px 0 0', display: 'flex', alignItems: 'center', gap: 5 }}>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-md)' }} aria-hidden="true">warning</span>
             Records show {stockDrift} more tube{stockDrift === 1 ? '' : 's'} used than purchased — run a recount to true up.
           </p>
         )}
         {burnPerSession > 0 && recentSessionCount > 0 && (
           <p
             style={{
-              fontSize: 11,
+              fontSize: 'var(--fs-xs)',
               color: 'var(--ink-faint)',
               margin: '4px 0 0',
               fontFamily: 'var(--font-mono, "JetBrains Mono")',
@@ -588,7 +588,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
                     top: -14,
                     left: -22,
                     fontFamily: 'var(--font-mono, "JetBrains Mono")',
-                    fontSize: 10,
+                    fontSize: 'var(--fs-2xs)',
                     color: 'var(--red-soft)',
                     fontWeight: 600,
                     whiteSpace: 'nowrap',
@@ -605,7 +605,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
               justifyContent: 'space-between',
               marginTop: 6,
               fontFamily: 'var(--font-mono, "JetBrains Mono")',
-              fontSize: 11,
+              fontSize: 'var(--fs-xs)',
               color: 'var(--ink-faint)',
             }}
           >
@@ -643,7 +643,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
       <p
         style={{
           fontFamily: 'var(--font-display, "Space Grotesk")',
-          fontSize: 11,
+          fontSize: 'var(--fs-xs)',
           fontWeight: 700,
           letterSpacing: '0.16em',
           textTransform: 'uppercase',
@@ -654,7 +654,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         In stock
       </p>
       {brands.length === 0 && (
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '0 4px' }}>No active inventory.</p>
+        <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: '0 4px' }}>No active inventory.</p>
       )}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
         {brands.map((b) => {
@@ -663,8 +663,8 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
             <div key={b.brand} className="glass-card" style={{ padding: '12px 14px' }}>
               <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12 }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
-                  <p style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 14, fontWeight: 600, margin: 0 }}>{b.brand}</p>
-                  <p style={{ fontSize: 11, color: 'var(--text-secondary)', display: 'flex', gap: 6, alignItems: 'center', margin: 0 }}>
+                  <p style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 'var(--fs-md)', fontWeight: 600, margin: 0 }}>{b.brand}</p>
+                  <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', display: 'flex', gap: 6, alignItems: 'center', margin: 0 }}>
                     {b.speed !== null && <>spd {b.speed}</>}
                     {b.speed !== null && b.quality !== null && ' · '}
                     {b.quality !== null && <Stars n={b.quality} />}
@@ -673,10 +673,10 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
                   <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 18, fontWeight: 700, letterSpacing: '-0.02em' }}>
                     {b.remaining}
-                    <span style={{ color: 'var(--ink-faint)', fontSize: 12, fontWeight: 500 }}>/{b.bought}</span>
+                    <span style={{ color: 'var(--ink-faint)', fontSize: 'var(--fs-sm)', fontWeight: 500 }}>/{b.bought}</span>
                   </span>
                   {b.weeksLeft !== null && (
-                    <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 10, color: 'var(--ink-faint)' }}>
+                    <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)' }}>
                       ~{b.weeksLeft}w
                     </span>
                   )}
@@ -701,7 +701,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
       <p
         style={{
           fontFamily: 'var(--font-display, "Space Grotesk")',
-          fontSize: 11,
+          fontSize: 'var(--fs-xs)',
           fontWeight: 700,
           letterSpacing: '0.16em',
           textTransform: 'uppercase',
@@ -713,12 +713,12 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         }}
       >
         Purchase history
-        <span style={{ textTransform: 'none', letterSpacing: 0, color: 'var(--text-secondary)', fontWeight: 500, fontSize: 11 }}>
+        <span style={{ textTransform: 'none', letterSpacing: 0, color: 'var(--text-secondary)', fontWeight: 500, fontSize: 'var(--fs-xs)' }}>
           last 60d
         </span>
       </p>
       {recentPurchases.length === 0 ? (
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '0 4px' }}>No purchases in the last 60 days.</p>
+        <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: '0 4px' }}>No purchases in the last 60 days.</p>
       ) : (
         <div className="glass-card" style={{ padding: '4px 0' }}>
           {recentPurchases.map((p, i) => (
@@ -733,7 +733,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
           <p
             style={{
               fontFamily: 'var(--font-display, "Space Grotesk")',
-              fontSize: 11,
+              fontSize: 'var(--fs-xs)',
               fontWeight: 700,
               letterSpacing: '0.16em',
               textTransform: 'uppercase',
@@ -760,7 +760,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         className="max-w-sm mx-auto"
       >
         <BottomSheetHeader className="flex items-center justify-between p-4">
-          <span style={{ fontSize: 16, fontWeight: 600 }}>{editingId ? 'Edit purchase' : 'Log purchase'}</span>
+          <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{editingId ? 'Edit purchase' : 'Log purchase'}</span>
           <button
             type="button"
             onClick={() => setSheetOpen(false)}
@@ -776,7 +776,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
               justifyContent: 'center',
             }}
           >
-            <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
           </button>
         </BottomSheetHeader>
         <BottomSheetBody className="p-5 pb-8">
@@ -868,7 +868,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
             </Field>
 
             {formError && (
-              <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: 0 }}>
                 {formError}
               </p>
             )}
@@ -886,7 +886,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
                   className="cc-btn cc-btn-secondary"
                   style={{ alignSelf: 'flex-start' }}
                 >
-                  <span className="material-icons" style={{ fontSize: 16 }}>event</span>
+                  <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>event</span>
                   Assign tubes to sessions
                 </button>
               );
@@ -964,19 +964,19 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
         className="max-w-sm mx-auto"
       >
         <BottomSheetHeader className="flex items-center justify-between p-4">
-          <span style={{ fontSize: 16, fontWeight: 600 }}>Reconcile count</span>
+          <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>Reconcile count</span>
           <button
             type="button"
             onClick={() => setReconcileOpen(false)}
             aria-label="Close"
             style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           >
-            <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
           </button>
         </BottomSheetHeader>
         <BottomSheetBody className="p-5 pb-8">
           <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
+            <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
               The app counts <strong style={{ color: 'var(--text-primary)' }}>{currentStock} tubes</strong> on hand
               (purchased − used). If your physical count differs — broken tubes, gifts, miscounts — enter the real
               number and we&apos;ll log the difference.
@@ -992,7 +992,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
               />
             </Field>
             {typeof reconcileCount === 'number' && reconcileCount !== currentStock && (
-              <p style={{ fontSize: 12, color: 'var(--ink-faint)', margin: 0, fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
+              <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--ink-faint)', margin: 0, fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
                 adjustment: {reconcileCount - currentStock > 0 ? '+' : '−'}{Math.abs(Math.round((reconcileCount - currentStock) * 100) / 100)} tubes
               </p>
             )}
@@ -1006,7 +1006,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
               />
             </Field>
             {reconcileError && (
-              <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: 0 }}>
                 {reconcileError}
               </p>
             )}
@@ -1047,7 +1047,7 @@ export default function BirdsPage({ onBack }: BirdsPageProps) {
 function Field({ label, children, style }: { label: string; children: React.ReactNode; style?: React.CSSProperties }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6, ...style }}>
-      <label style={{ fontSize: 12, color: 'var(--text-muted)' }}>{label}</label>
+      <label style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>{label}</label>
       {children}
     </div>
   );

--- a/components/admin/CommandCenter/CommandCenter.tsx
+++ b/components/admin/CommandCenter/CommandCenter.tsx
@@ -169,7 +169,7 @@ export default function CommandCenter({ refreshKey, setView, onExit }: CommandCe
                   border: 'none',
                   cursor: 'pointer',
                   color: 'var(--text-primary)',
-                  fontSize: 15,
+                  fontSize: 'var(--fs-lg)',
                   textAlign: 'left',
                 }}
               >

--- a/components/admin/CommandCenter/CommandCenter.tsx
+++ b/components/admin/CommandCenter/CommandCenter.tsx
@@ -176,7 +176,7 @@ export default function CommandCenter({ refreshKey, setView, onExit }: CommandCe
                 <span
                   className="material-icons"
                   aria-hidden="true"
-                  style={{ fontSize: 20, color: 'var(--text-secondary)' }}
+                  style={{ fontSize: 'var(--fs-stat)', color: 'var(--text-secondary)' }}
                 >
                   {row.icon}
                 </span>

--- a/components/admin/CommandCenter/ETransferRecipientEditor.tsx
+++ b/components/admin/CommandCenter/ETransferRecipientEditor.tsx
@@ -146,7 +146,7 @@ export default function ETransferRecipientEditor() {
               maxLength={100}
               placeholder="Your name (as shown to senders)"
               className="w-full text-sm rounded-lg p-2"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+              style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             />
           </Field>
           <Field label="Email">
@@ -157,7 +157,7 @@ export default function ETransferRecipientEditor() {
               maxLength={200}
               placeholder="e-transfer recipient address"
               className="w-full text-sm rounded-lg p-2 font-mono"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+              style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             />
           </Field>
           <Field label="Memo template (optional)">
@@ -168,7 +168,7 @@ export default function ETransferRecipientEditor() {
               maxLength={200}
               placeholder={DEFAULT_MEMO}
               className="w-full text-sm rounded-lg p-2 font-mono"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+              style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             />
             <p className="text-xs text-gray-500 mt-1">
               Use <code>{'{date}'}</code> for the session date and <code>{'{name}'}</code> for the player name.

--- a/components/admin/CommandCenter/ETransferRecipientEditor.tsx
+++ b/components/admin/CommandCenter/ETransferRecipientEditor.tsx
@@ -175,7 +175,7 @@ export default function ETransferRecipientEditor() {
             </p>
           </Field>
 
-          {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
+          {error && <p className="field-error" role="alert">{error}</p>}
 
           <div className="flex flex-wrap gap-2 justify-end">
             <button

--- a/components/admin/CommandCenter/ETransferRecipientEditor.tsx
+++ b/components/admin/CommandCenter/ETransferRecipientEditor.tsx
@@ -99,7 +99,7 @@ export default function ETransferRecipientEditor() {
     <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="E-transfer recipient">
       <header>
         <h3 className="bpm-h3">E-transfer recipient</h3>
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="fs-sm text-gray-400 mt-0.5">
           Used by the Share cost button on the Next Session card.
         </p>
       </header>
@@ -107,22 +107,22 @@ export default function ETransferRecipientEditor() {
       {!editing && (
         <>
           {recipient ? (
-            <div className="text-sm space-y-1">
+            <div className="fs-md space-y-1">
               <p>
-                <span className="text-gray-400 text-xs">Name </span>
+                <span className="text-gray-400 fs-sm">Name </span>
                 <span>{recipient.name}</span>
               </p>
               <p>
-                <span className="text-gray-400 text-xs">Email </span>
-                <span className="font-mono text-xs">{recipient.email}</span>
+                <span className="text-gray-400 fs-sm">Email </span>
+                <span className="font-mono fs-sm">{recipient.email}</span>
               </p>
               <p>
-                <span className="text-gray-400 text-xs">Memo </span>
-                <span className="font-mono text-xs">{recipient.memo ?? DEFAULT_MEMO}</span>
+                <span className="text-gray-400 fs-sm">Memo </span>
+                <span className="font-mono fs-sm">{recipient.memo ?? DEFAULT_MEMO}</span>
               </p>
             </div>
           ) : (
-            <p className="text-sm text-gray-400">
+            <p className="fs-md text-gray-400">
               Not set — add one to enable cost sharing.
             </p>
           )}
@@ -145,7 +145,7 @@ export default function ETransferRecipientEditor() {
               onChange={(e) => setDraftName(e.target.value)}
               maxLength={100}
               placeholder="Your name (as shown to senders)"
-              className="w-full text-sm rounded-lg p-2"
+              className="w-full fs-md rounded-lg p-2"
               style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             />
           </Field>
@@ -156,7 +156,7 @@ export default function ETransferRecipientEditor() {
               onChange={(e) => setDraftEmail(e.target.value)}
               maxLength={200}
               placeholder="e-transfer recipient address"
-              className="w-full text-sm rounded-lg p-2 font-mono"
+              className="w-full fs-md rounded-lg p-2 font-mono"
               style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             />
           </Field>
@@ -167,10 +167,10 @@ export default function ETransferRecipientEditor() {
               onChange={(e) => setDraftMemo(e.target.value)}
               maxLength={200}
               placeholder={DEFAULT_MEMO}
-              className="w-full text-sm rounded-lg p-2 font-mono"
+              className="w-full fs-md rounded-lg p-2 font-mono"
               style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             />
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="fs-sm text-gray-500 mt-1">
               Use <code>{'{date}'}</code> for the session date and <code>{'{name}'}</code> for the player name.
             </p>
           </Field>
@@ -204,7 +204,7 @@ export default function ETransferRecipientEditor() {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="space-y-1">
-      <label className="text-xs text-gray-400">{label}</label>
+      <label className="fs-sm text-gray-400">{label}</label>
       {children}
     </div>
   );

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -187,7 +187,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
     return (
       <section className="glass-card p-4 space-y-1 opacity-60" aria-label="Next session">
         <h3 className="bpm-h3">Next session</h3>
-        <p className="text-xs text-gray-400">No active session.</p>
+        <p className="fs-sm text-gray-400">No active session.</p>
       </section>
     );
   }
@@ -203,7 +203,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
       <header className="flex items-center justify-between gap-3">
         <div>
           <h3 className="bpm-h3">{fmtDate(session.datetime)}</h3>
-          <p className="text-xs text-gray-400 mt-0.5">{session.title ?? 'Session'}</p>
+          <p className="fs-sm text-gray-400 mt-0.5">{session.title ?? 'Session'}</p>
         </div>
         <div className="flex items-center gap-2">
           {isSettled && (
@@ -230,10 +230,10 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
       </header>
 
       <div className="space-y-2">
-        <div className="flex items-baseline justify-between text-sm">
+        <div className="flex items-baseline justify-between fs-md">
           <span className="text-gray-300">{activeCount} / {cap} signed up</span>
           {waitlistCount > 0 && (
-            <span className="text-xs text-gray-400">+{waitlistCount} waitlist</span>
+            <span className="fs-sm text-gray-400">+{waitlistCount} waitlist</span>
           )}
         </div>
         <div className="h-1.5 rounded-full overflow-hidden cc-progress-track">
@@ -248,7 +248,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
       </div>
 
       {countdown && (
-        <p className="text-xs text-gray-400">
+        <p className="fs-sm text-gray-400">
           Sign up deadline: <span className="text-gray-200">
             {fmtDeadline(session.deadline)}{countdown === 'closed' ? ' (Passed)' : ` (${countdown} left)`}
           </span>
@@ -265,7 +265,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
               onClick={onShareCost}
               className="cc-btn cc-btn-primary"
             >
-              <span className="material-icons text-base align-middle">share</span>
+              <span className="material-icons fs-lg align-middle">share</span>
               Share again — ${session.settled?.costPerPerson} each
             </button>
           ) : null
@@ -273,7 +273,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
           // Pre-flag stable users keep the simple "Share cost" affordance.
           onShareCost && (
             <button type="button" onClick={onShareCost} className="cc-btn cc-btn-primary">
-              <span className="material-icons text-base align-middle">request_quote</span>
+              <span className="material-icons fs-lg align-middle">request_quote</span>
               Share cost
             </button>
           )
@@ -289,7 +289,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
           className="cc-btn cc-btn-secondary"
           title="Copy/share a sign-up invite link for the group chat."
         >
-          <span className="material-icons text-base align-middle">share</span>
+          <span className="material-icons fs-lg align-middle">share</span>
           {shareCopied ? 'Copied ✓' : 'Share sign-up'}
         </button>
         {isSettled && (
@@ -297,7 +297,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
             type="button"
             onClick={editBill}
             disabled={settling}
-            className="cc-btn cc-btn-ghost text-xs"
+            className="cc-btn cc-btn-ghost fs-sm"
             title="Made a typo? Clears the bill so you can re-send. Paid checkmarks stay."
           >
             {settling ? 'Editing…' : 'Edit bill'}
@@ -321,7 +321,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
               className="cc-btn cc-btn-primary"
               title="Locks tonight's cost and opens the share sheet for the group chat."
             >
-              <span className="material-icons text-base align-middle">send</span>
+              <span className="material-icons fs-lg align-middle">send</span>
               {settling ? 'Finalizing…' : 'Finalize cost'}
             </button>
           )}
@@ -329,7 +329,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
             <button
               type="button"
               onClick={() => setConfirmingAdvance(true)}
-              className="cc-btn cc-btn-ghost text-xs"
+              className="cc-btn cc-btn-ghost fs-sm"
             >
               Advance to next week
             </button>
@@ -338,7 +338,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
       )}
 
       {settleError && (
-        <p role="alert" className="text-xs" style={{ color: 'var(--color-red)' }}>
+        <p role="alert" className="fs-sm" style={{ color: 'var(--color-red)' }}>
           {settleError}
         </p>
       )}

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -338,7 +338,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
       )}
 
       {settleError && (
-        <p role="alert" className="text-xs" style={{ color: 'var(--color-red, #ef4444)' }}>
+        <p role="alert" className="text-xs" style={{ color: 'var(--color-red)' }}>
           {settleError}
         </p>
       )}
@@ -353,14 +353,14 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
           className="max-w-sm mx-auto"
         >
           <BottomSheetHeader className="flex items-center justify-between p-4">
-            <span style={{ fontSize: 16, fontWeight: 600 }}>Advance to next week</span>
+            <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>Advance to next week</span>
             <button
               type="button"
               onClick={() => setConfirmingAdvance(false)}
               aria-label="Close"
               style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
             >
-              <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+              <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
             </button>
           </BottomSheetHeader>
           <BottomSheetBody className="p-5 pb-8">

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -687,7 +687,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           </button>
         </form>
       )}
-      {addError && <p role="alert" className="text-xs text-red-400">{addError}</p>}
+      {addError && <p role="alert" className="field-error">{addError}</p>}
 
       {/* Waitlist */}
       {lists.waitlisted.length > 0 && (

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -697,7 +697,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           </p>
           <ul role="list" style={{ display: 'flex', flexDirection: 'column' }}>
             {lists.waitlisted.map((p) => (
-              <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.04)', fontSize: 13.5 }}>
+              <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(var(--glass-tint), 0.04)', fontSize: 13.5 }}>
                 <span style={{ flex: 1, color: 'var(--text-secondary)' }}>{p.name}</span>
                 {isCurrentSession && (
                   <button
@@ -735,7 +735,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           {!removedCollapsed && (
             <ul role="list">
               {lists.removed.map((p) => (
-                <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.04)', fontSize: 13.5 }}>
+                <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(var(--glass-tint), 0.04)', fontSize: 13.5 }}>
                   <span style={{ flex: 1, color: 'var(--text-muted)', textDecoration: 'line-through' }}>{p.name}</span>
                   {p.removedAt && (
                     <span style={{ fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)', fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
@@ -891,8 +891,8 @@ function ActionRow({
         gap: 12,
         padding: '12px 14px',
         borderRadius: 'var(--radius-lg)',
-        background: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(255,255,255,0.10)',
+        background: 'rgba(var(--glass-tint), 0.04)',
+        border: '1px solid rgba(var(--glass-tint), 0.10)',
         cursor: disabled ? 'not-allowed' : 'pointer',
         textAlign: 'left',
         opacity: disabled ? 0.5 : 1,

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -472,7 +472,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                 onClick={() => setViewedSessionId(s.id)}
                 className="cc-session-chip flex-shrink-0"
               >
-                <span style={{ fontSize: 13, fontWeight: 600, display: 'block' }}>
+                <span style={{ fontSize: 'var(--fs-base)', fontWeight: 600, display: 'block' }}>
                   {fmtSessionLabel(s.datetime)}
                 </span>
                 <span style={{ fontSize: 10.5, display: 'block', marginTop: 2, opacity: 0.7 }}>
@@ -487,7 +487,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
       {/* Load-error affordance preserved from the removed header (the
           lying-empty-state rule forbids dropping it). */}
       {(loadError || playersError) && (
-        <p role="alert" className="text-xs" style={{ color: 'var(--color-red, #ef4444)', margin: 0 }}>
+        <p role="alert" className="text-xs" style={{ color: 'var(--color-red)', margin: 0 }}>
           Couldn&apos;t load — refresh to retry
         </p>
       )}
@@ -506,8 +506,8 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
         <p
           role="alert"
           style={{
-            fontSize: 12,
-            color: 'var(--color-red, #ef4444)',
+            fontSize: 'var(--fs-sm)',
+            color: 'var(--color-red)',
             margin: 0,
             padding: '8px 12px',
             background: 'rgba(239,68,68,0.06)',
@@ -548,7 +548,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                 onClick={() => openReceiptSheet('group')}
                 disabled={receiptBuild?.costPerPerson == null}
                 className="cc-btn cc-btn-secondary"
-                style={{ fontSize: 12, padding: '4px 12px' }}
+                style={{ fontSize: 'var(--fs-sm)', padding: '4px 12px' }}
               >
                 Share receipt
               </button>
@@ -610,7 +610,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                       ? "You're covering this — split across the others"
                       : "You're covering this — it's on you"}
                   >
-                    <span className="material-icons" style={{ fontSize: 14 }} aria-hidden="true">
+                    <span className="material-icons" style={{ fontSize: 'var(--fs-md)' }} aria-hidden="true">
                       volunteer_activism
                     </span>
                     Covered
@@ -627,7 +627,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                       '…'
                     ) : player.paid ? (
                       <>
-                        <span className="material-icons" style={{ fontSize: 14 }} aria-hidden="true">
+                        <span className="material-icons" style={{ fontSize: 'var(--fs-md)' }} aria-hidden="true">
                           check_circle
                         </span>
                         Paid
@@ -692,7 +692,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
       {/* Waitlist */}
       {lists.waitlisted.length > 0 && (
         <div style={{ marginTop: 4 }}>
-          <p style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--amber)', margin: '14px 2px 6px' }}>
+          <p style={{ fontSize: 'var(--fs-xs)', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--amber)', margin: '14px 2px 6px' }}>
             {lists.waitlisted.length} waitlisted
           </p>
           <ul role="list" style={{ display: 'flex', flexDirection: 'column' }}>
@@ -705,7 +705,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                     onClick={() => handlePromote(p)}
                     disabled={busyId === p.id}
                     className="cc-btn cc-btn-secondary"
-                    style={{ fontSize: 11, padding: '4px 10px' }}
+                    style={{ fontSize: 'var(--fs-xs)', padding: '4px 10px' }}
                   >
                     {busyId === p.id ? '…' : 'Promote'}
                   </button>
@@ -725,7 +725,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
             style={{ background: 'transparent', border: 0, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%', padding: '8px 2px', color: 'var(--text-secondary)' }}
             aria-expanded={!removedCollapsed}
           >
-            <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
+            <span style={{ fontSize: 'var(--fs-xs)', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
               {lists.removed.length} removed
             </span>
             <span className="material-icons" style={{ fontSize: 18, color: 'var(--text-muted)' }}>
@@ -738,7 +738,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                 <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(255,255,255,0.04)', fontSize: 13.5 }}>
                   <span style={{ flex: 1, color: 'var(--text-muted)', textDecoration: 'line-through' }}>{p.name}</span>
                   {p.removedAt && (
-                    <span style={{ fontSize: 10, color: 'var(--ink-faint)', fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
+                    <span style={{ fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)', fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
                       {p.cancelledBySelf ? 'cancelled' : 'removed'} {fmtSessionLabel(p.removedAt)}
                     </span>
                   )}
@@ -748,7 +748,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                       onClick={() => handleRestore(p)}
                       disabled={busyId === p.id}
                       className="cc-btn cc-btn-secondary"
-                      style={{ fontSize: 11, padding: '4px 10px' }}
+                      style={{ fontSize: 'var(--fs-xs)', padding: '4px 10px' }}
                     >
                       {busyId === p.id ? '…' : 'Restore'}
                     </button>
@@ -769,20 +769,20 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
         className="max-w-sm mx-auto"
       >
         <BottomSheetHeader className="flex items-center justify-between p-4">
-          <span style={{ fontSize: 16, fontWeight: 600 }}>{actionTarget?.name ?? 'Player'}</span>
+          <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{actionTarget?.name ?? 'Player'}</span>
           <button
             type="button"
             onClick={() => { setActionTarget(null); setActionError(''); }}
             aria-label="Close"
             style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           >
-            <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
           </button>
         </BottomSheetHeader>
         <BottomSheetBody className="p-5 pb-8">
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             {actionError && (
-              <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: 0 }}>
                 {actionError}
               </p>
             )}
@@ -901,7 +901,7 @@ function ActionRow({
     >
       <span
         className="material-icons"
-        style={{ fontSize: 20, color: destructive ? 'var(--red-soft)' : 'var(--text-secondary)' }}
+        style={{ fontSize: 'var(--fs-stat)', color: destructive ? 'var(--red-soft)' : 'var(--text-secondary)' }}
       >
         {icon}
       </span>
@@ -910,7 +910,7 @@ function ActionRow({
           {label}
         </span>
         {hint && (
-          <span style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{hint}</span>
+          <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', marginTop: 2 }}>{hint}</span>
         )}
       </span>
     </button>

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -487,7 +487,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
       {/* Load-error affordance preserved from the removed header (the
           lying-empty-state rule forbids dropping it). */}
       {(loadError || playersError) && (
-        <p role="alert" className="text-xs" style={{ color: 'var(--color-red)', margin: 0 }}>
+        <p role="alert" className="fs-sm" style={{ color: 'var(--color-red)', margin: 0 }}>
           Couldn&apos;t load — refresh to retry
         </p>
       )}
@@ -497,7 +497,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           rule). The "X of Y paid" count was removed by design; this is
           the no-roster case, not the count. */}
       {!loadError && !playersError && total === 0 && (
-        <p className="text-xs" style={{ color: 'var(--text-muted)', margin: 0 }}>
+        <p className="fs-sm" style={{ color: 'var(--text-muted)', margin: 0 }}>
           No active players
         </p>
       )}
@@ -524,7 +524,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           is gated on settleFlagOn like the other dollar surfaces below. */}
       {!loadError && !playersError && viewedSession && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <p className="text-xs" style={{ color: 'var(--text-muted)', margin: 0 }}>
+          <p className="fs-sm" style={{ color: 'var(--text-muted)', margin: 0 }}>
             {[
               fmtSessionLabel(viewedSession.datetime),
               `${total} player${total === 1 ? '' : 's'}`,
@@ -560,7 +560,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
       {/* What the admin absorbed by covering players this session. */}
       {ledgerFlagOn && settleFlagOn && !!viewedSession?.settled?.coveredTotal && (
         <p
-          className="text-xs"
+          className="fs-sm"
           style={{ color: '#d8b4fe', margin: 0, display: 'flex', alignItems: 'center', gap: 6 }}
         >
           <span className="material-icons" style={{ fontSize: 'var(--icon-sm)' }} aria-hidden="true">volunteer_activism</span>
@@ -573,7 +573,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
         <ul className="space-y-1" role="list">
           {lists.active.map((player) => (
             <li key={player.id} className="flex items-center justify-between gap-3 py-2">
-              <span className="text-sm flex items-center gap-2 flex-1 min-w-0">
+              <span className="fs-md flex items-center gap-2 flex-1 min-w-0">
                 {onOpenPlayer && player.memberId ? (
                   <button
                     type="button"
@@ -586,13 +586,13 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                   <span className="truncate">{player.name}</span>
                 )}
                 {player.selfReportedPaid && !player.paid && (
-                  <span className="text-xs flex-shrink-0" style={{ color: '#fcd34d' }}>self-reported</span>
+                  <span className="fs-sm flex-shrink-0" style={{ color: '#fcd34d' }}>self-reported</span>
                 )}
               </span>
               <div className="flex items-center gap-1 flex-shrink-0">
                 {settleFlagOn && typeof player.owedAmount === 'number' && !player.writtenOff && (
                   <span
-                    className="text-xs font-medium px-2"
+                    className="fs-sm font-medium px-2"
                     style={{
                       color: '#d8b4fe',
                       fontFamily: 'var(--font-mono), ui-monospace, monospace',
@@ -604,7 +604,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                 )}
                 {ledgerFlagOn && player.writtenOff ? (
                   <span
-                    className="text-xs font-medium px-3 py-1.5 rounded-full inline-flex items-center gap-1"
+                    className="fs-sm font-medium px-3 py-1.5 rounded-full inline-flex items-center gap-1"
                     style={{ background: 'rgba(216,180,254,0.12)', color: '#d8b4fe' }}
                     title={player.coverMode === 'resplit'
                       ? "You're covering this — split across the others"
@@ -620,7 +620,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                     type="button"
                     onClick={() => togglePaid(player)}
                     disabled={togglingId === player.id}
-                    className={`text-xs font-medium px-3 py-1.5 rounded-full transition-colors inline-flex items-center gap-1 ${player.paid ? 'pill-paid' : 'pill-unpaid'} disabled:opacity-50`}
+                    className={`fs-sm font-medium px-3 py-1.5 rounded-full transition-colors inline-flex items-center gap-1 ${player.paid ? 'pill-paid' : 'pill-unpaid'} disabled:opacity-50`}
                     aria-pressed={player.paid === true}
                   >
                     {togglingId === player.id ? (
@@ -641,21 +641,21 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                   <button
                     type="button"
                     onClick={() => openReceiptSheet('individual', player.name)}
-                    className="text-xs text-gray-400 hover:text-gray-200 px-2 py-1"
+                    className="fs-sm text-gray-400 hover:text-gray-200 px-2 py-1"
                     aria-label={`Send receipt to ${player.name}`}
                     title="Send individual receipt"
                   >
-                    <span className="material-icons text-base align-middle">receipt_long</span>
+                    <span className="material-icons fs-lg align-middle">receipt_long</span>
                   </button>
                 )}
                 <button
                   type="button"
                   onClick={() => { setActionTarget(player); setActionError(''); }}
-                  className="text-xs text-gray-400 hover:text-gray-200 px-1 py-1"
+                  className="fs-sm text-gray-400 hover:text-gray-200 px-1 py-1"
                   aria-label={`More actions for ${player.name}`}
                   title="More"
                 >
-                  <span className="material-icons text-base align-middle">more_vert</span>
+                  <span className="material-icons fs-lg align-middle">more_vert</span>
                 </button>
               </div>
             </li>

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -475,7 +475,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                 <span style={{ fontSize: 'var(--fs-base)', fontWeight: 600, display: 'block' }}>
                   {fmtSessionLabel(s.datetime)}
                 </span>
-                <span style={{ fontSize: 10.5, display: 'block', marginTop: 2, opacity: 0.7 }}>
+                <span style={{ fontSize: 'var(--fs-xs)', display: 'block', marginTop: 2, opacity: 0.7 }}>
                   {isActive ? 'Current' : sent ? 'Sent' : 'Past'}
                 </span>
               </button>
@@ -563,7 +563,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           className="text-xs"
           style={{ color: '#d8b4fe', margin: 0, display: 'flex', alignItems: 'center', gap: 6 }}
         >
-          <span className="material-icons" style={{ fontSize: 15 }} aria-hidden="true">volunteer_activism</span>
+          <span className="material-icons" style={{ fontSize: 'var(--icon-sm)' }} aria-hidden="true">volunteer_activism</span>
           You&apos;ve covered ${viewedSession.settled.coveredTotal} this session
         </p>
       )}
@@ -697,7 +697,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
           </p>
           <ul role="list" style={{ display: 'flex', flexDirection: 'column' }}>
             {lists.waitlisted.map((p) => (
-              <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(var(--glass-tint), 0.04)', fontSize: 13.5 }}>
+              <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(var(--glass-tint), 0.04)', fontSize: 'var(--fs-md)' }}>
                 <span style={{ flex: 1, color: 'var(--text-secondary)' }}>{p.name}</span>
                 {isCurrentSession && (
                   <button
@@ -728,14 +728,14 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
             <span style={{ fontSize: 'var(--fs-xs)', fontWeight: 700, letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--text-muted)' }}>
               {lists.removed.length} removed
             </span>
-            <span className="material-icons" style={{ fontSize: 18, color: 'var(--text-muted)' }}>
+            <span className="material-icons" style={{ fontSize: 'var(--icon-md)', color: 'var(--text-muted)' }}>
               {removedCollapsed ? 'expand_more' : 'expand_less'}
             </span>
           </button>
           {!removedCollapsed && (
             <ul role="list">
               {lists.removed.map((p) => (
-                <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(var(--glass-tint), 0.04)', fontSize: 13.5 }}>
+                <li key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 0', borderBottom: '1px solid rgba(var(--glass-tint), 0.04)', fontSize: 'var(--fs-md)' }}>
                   <span style={{ flex: 1, color: 'var(--text-muted)', textDecoration: 'line-through' }}>{p.name}</span>
                   {p.removedAt && (
                     <span style={{ fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)', fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
@@ -906,7 +906,7 @@ function ActionRow({
         {icon}
       </span>
       <span style={{ display: 'flex', flexDirection: 'column', flex: 1, minWidth: 0 }}>
-        <span style={{ fontSize: 13.5, fontWeight: 500, color: destructive ? 'var(--red-soft)' : 'var(--text-primary)' }}>
+        <span style={{ fontSize: 'var(--fs-md)', fontWeight: 500, color: destructive ? 'var(--red-soft)' : 'var(--text-primary)' }}>
           {label}
         </span>
         {hint && (

--- a/components/admin/CommandCenter/PlayerProfileSheet.tsx
+++ b/components/admin/CommandCenter/PlayerProfileSheet.tsx
@@ -268,7 +268,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                               type="button"
                               onClick={() => handleTogglePaid(s)}
                               disabled={updatingSession === s.sessionId}
-                              className={`text-xs font-medium px-3 py-1.5 rounded-full ${s.paid ? 'pill-paid' : 'pill-unpaid'} disabled:opacity-50`}
+                              className={`fs-sm font-medium px-3 py-1.5 rounded-full ${s.paid ? 'pill-paid' : 'pill-unpaid'} disabled:opacity-50`}
                               aria-pressed={s.paid}
                               aria-label={`Mark ${s.paid ? 'unpaid' : 'paid'} for ${fmtDate(s.date)}`}
                               title="Tap to toggle paid status"

--- a/components/admin/CommandCenter/PlayerProfileSheet.tsx
+++ b/components/admin/CommandCenter/PlayerProfileSheet.tsx
@@ -190,7 +190,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel="Player profile" maxHeight="85vh" className="max-w-sm mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>
           {history?.member.name ?? initialName ?? 'Player'}
         </span>
         <button
@@ -208,15 +208,15 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
             justifyContent: 'center',
           }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
 
       <BottomSheetBody className="p-5 pb-8">
         <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-          {loading && <p style={{ fontSize: 14, color: 'var(--text-muted)', margin: 0 }}>Loading…</p>}
+          {loading && <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-muted)', margin: 0 }}>Loading…</p>}
           {error && (
-            <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+            <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: 0 }}>
               {error}
             </p>
           )}
@@ -230,7 +230,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
 
               <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 <p style={{
-                  fontSize: 11,
+                  fontSize: 'var(--fs-xs)',
                   letterSpacing: '0.06em',
                   textTransform: 'uppercase',
                   color: 'var(--text-muted)',
@@ -240,7 +240,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                   Recent sessions
                 </p>
                 {history.sessions.length === 0 ? (
-                  <p style={{ fontSize: 14, color: 'var(--text-muted)', margin: 0 }}>
+                  <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-muted)', margin: 0 }}>
                     No sessions on record yet.
                   </p>
                 ) : (
@@ -254,14 +254,14 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                           justifyContent: 'space-between',
                           gap: 12,
                           padding: '12px 0',
-                          borderBottom: i < arr.length - 1 ? '1px solid var(--border-subtle, rgba(255,255,255,0.06))' : 'none',
-                          fontSize: 14,
+                          borderBottom: i < arr.length - 1 ? '1px solid var(--border-subtle))' : 'none',
+                          fontSize: 'var(--fs-md)',
                         }}
                       >
                         <span style={{ color: 'var(--text-primary)' }}>{fmtDate(s.date)}</span>
                         <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                           {!s.attended && (
-                            <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>Missed</span>
+                            <span style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>Missed</span>
                           )}
                           {s.attended && (
                             <button
@@ -282,7 +282,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                   </ul>
                 )}
                 {history.sessions.length > 12 && (
-                  <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '4px 0 0 0' }}>
+                  <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: '4px 0 0 0' }}>
                     +{history.sessions.length - 12} more older sessions
                   </p>
                 )}
@@ -291,7 +291,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
               <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
                   <p style={{
-                    fontSize: 11,
+                    fontSize: 'var(--fs-xs)',
                     letterSpacing: '0.06em',
                     textTransform: 'uppercase',
                     color: 'var(--text-muted)',
@@ -301,24 +301,24 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                     Owed breakdown
                   </p>
                   {audit && (
-                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 14, fontWeight: 700, color: 'var(--text-primary)' }}>
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-md)', fontWeight: 700, color: 'var(--text-primary)' }}>
                       {fmtMoney(audit.totalOwed)}
                     </span>
                   )}
                 </div>
 
                 {auditError ? (
-                  <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+                  <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: 0 }}>
                     Couldn’t load owed breakdown.
                   </p>
                 ) : !audit ? (
-                  <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>Loading…</p>
+                  <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: 0 }}>Loading…</p>
                 ) : audit.sessions.length === 0 ? (
-                  <p style={{ fontSize: 14, color: 'var(--text-muted)', margin: 0 }}>No billable sessions on record.</p>
+                  <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-muted)', margin: 0 }}>No billable sessions on record.</p>
                 ) : (
                   <>
                     {audit.names.length > 1 && (
-                      <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>
+                      <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: 0 }}>
                         Linked names: {audit.names.join(', ')}
                       </p>
                     )}
@@ -332,8 +332,8 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                             justifyContent: 'space-between',
                             gap: 12,
                             padding: '10px 0',
-                            borderBottom: i < arr.length - 1 ? '1px solid var(--border-subtle, rgba(255,255,255,0.06))' : 'none',
-                            fontSize: 14,
+                            borderBottom: i < arr.length - 1 ? '1px solid var(--border-subtle))' : 'none',
+                            fontSize: 'var(--fs-md)',
                           }}
                         >
                           <span style={{ color: s.counted ? 'var(--text-primary)' : 'var(--text-muted)' }}>
@@ -344,7 +344,7 @@ export default function PlayerProfileSheet({ open, onClose, memberId, initialNam
                               {fmtMoney(s.owedAmount)}
                             </span>
                           ) : (
-                            <span style={{ fontSize: 12, color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>
+                            <span style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', whiteSpace: 'nowrap' }}>
                               {REASON_LABEL[s.reason]}
                             </span>
                           )}
@@ -369,11 +369,11 @@ function Stat({ label, value }: { label: string; value: number }) {
         padding: 12,
         borderRadius: 'var(--radius-lg)',
         background: 'var(--input-bg)',
-        border: '1px solid var(--border-subtle, rgba(255,255,255,0.06))',
+        border: '1px solid var(--border-subtle))',
       }}
     >
       <p style={{ fontSize: 28, fontWeight: 600, lineHeight: 1.1, margin: 0, color: 'var(--text-primary)' }}>{value}</p>
-      <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '4px 0 0 0' }}>{label}</p>
+      <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: '4px 0 0 0' }}>{label}</p>
     </div>
   );
 }

--- a/components/admin/CommandCenter/ReceiptSheet.tsx
+++ b/components/admin/CommandCenter/ReceiptSheet.tsx
@@ -126,7 +126,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
             justifyContent: 'center',
           }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
 
@@ -136,7 +136,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
             <p
               role="alert"
               style={{
-                color: 'var(--color-red, #ef4444)',
+                color: 'var(--color-red)',
                 fontSize: 'var(--fs-base)',
                 lineHeight: 1.5,
                 margin: 0,
@@ -222,7 +222,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
                         alignItems: 'center',
                         justifyContent: 'center',
                         color: 'var(--text-muted)',
-                        fontSize: 12,
+                        fontSize: 'var(--fs-sm)',
                       }}
                     >
                       Rendering preview…
@@ -236,7 +236,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
                 <pre
                   style={{
                     fontFamily: 'var(--font-mono), ui-monospace, monospace',
-                    fontSize: 12,
+                    fontSize: 'var(--fs-sm)',
                     lineHeight: 1.55,
                     whiteSpace: 'pre-wrap',
                     margin: 0,
@@ -252,7 +252,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
               </div>
 
               {actionError && (
-                <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+                <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
                   {actionError}
                 </p>
               )}

--- a/components/admin/CommandCenter/ReceiptSheet.tsx
+++ b/components/admin/CommandCenter/ReceiptSheet.tsx
@@ -156,7 +156,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
                   type="button"
                   role="tab"
                   aria-selected={mode === 'group'}
-                  className={`flex-1 flex items-center justify-center text-xs ${mode === 'group' ? 'segment-tab-active' : 'segment-tab-inactive'}`}
+                  className={`flex-1 flex items-center justify-center fs-sm ${mode === 'group' ? 'segment-tab-active' : 'segment-tab-inactive'}`}
                   onClick={() => setMode('group')}
                 >
                   Group
@@ -165,7 +165,7 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
                   type="button"
                   role="tab"
                   aria-selected={mode === 'individual'}
-                  className={`flex-1 flex items-center justify-center text-xs ${mode === 'individual' ? 'segment-tab-active' : 'segment-tab-inactive'}`}
+                  className={`flex-1 flex items-center justify-center fs-sm ${mode === 'individual' ? 'segment-tab-active' : 'segment-tab-inactive'}`}
                   onClick={() => setMode('individual')}
                   disabled={input.playerNames.length === 0}
                 >

--- a/components/admin/CommandCenter/RosterHealthCard.tsx
+++ b/components/admin/CommandCenter/RosterHealthCard.tsx
@@ -68,7 +68,7 @@ export default function RosterHealthCard({ onOpen }: RosterHealthCardProps = {})
     return (
       <section className="glass-card p-4 space-y-1 opacity-60" aria-label="Roster health">
         <h3 className="bpm-h3">Roster health</h3>
-        <p className="text-xs text-gray-400">No data.</p>
+        <p className="fs-sm text-gray-400">No data.</p>
       </section>
     );
   }
@@ -108,7 +108,7 @@ function RosterStat({
       <p className="bpm-h2" style={{ color: tone === 'warning' ? '#fcd34d' : 'inherit' }}>
         {value}
       </p>
-      <p className="text-xs text-gray-400 mt-0.5">{label}</p>
+      <p className="fs-sm text-gray-400 mt-0.5">{label}</p>
     </div>
   );
 }

--- a/components/admin/CommandCenter/RosterHealthCard.tsx
+++ b/components/admin/CommandCenter/RosterHealthCard.tsx
@@ -104,7 +104,7 @@ function RosterStat({
   tone?: 'neutral' | 'warning';
 }) {
   return (
-    <div className="rounded-lg p-3" style={{ background: 'rgba(255, 255, 255, 0.04)' }}>
+    <div className="rounded-lg p-3" style={{ background: 'rgba(var(--glass-tint), 0.04)' }}>
       <p className="bpm-h2" style={{ color: tone === 'warning' ? '#fcd34d' : 'inherit' }}>
         {value}
       </p>

--- a/components/admin/CommandCenter/RosterPage.tsx
+++ b/components/admin/CommandCenter/RosterPage.tsx
@@ -429,7 +429,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
           color: 'var(--text-muted)',
         }}
       >
-        <span className="material-icons" style={{ fontSize: 18 }}>search</span>
+        <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>search</span>
         <input
           type="text"
           value={search}
@@ -441,7 +441,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
             border: 0,
             outline: 0,
             color: 'var(--text-primary)',
-            fontSize: 13.5,
+            fontSize: 'var(--fs-md)',
           }}
         />
       </div>
@@ -464,7 +464,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                 background: on ? 'rgba(74,222,128,0.13)' : 'rgba(var(--glass-tint), 0.04)',
                 border: `1px solid ${on ? 'rgba(74,222,128,0.35)' : 'rgba(var(--glass-tint), 0.12)'}`,
                 fontFamily: 'var(--font-display, "Space Grotesk")',
-                fontSize: 11.5,
+                fontSize: 'var(--fs-sm)',
                 fontWeight: 500,
                 color: on ? '#c5f5d3' : 'var(--text-secondary)',
                 cursor: 'pointer',
@@ -551,7 +551,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                           border: '1px solid rgba(74,222,128,0.25)',
                           padding: '1px 6px',
                           borderRadius: 'var(--radius-pill)',
-                          fontSize: 9,
+                          fontSize: 'var(--fs-2xs)',
                           fontWeight: 600,
                           letterSpacing: '0.04em',
                         }}
@@ -567,7 +567,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                           border: '1px solid rgba(167,139,250,0.28)',
                           padding: '1px 6px',
                           borderRadius: 'var(--radius-pill)',
-                          fontSize: 9,
+                          fontSize: 'var(--fs-2xs)',
                           fontWeight: 600,
                           letterSpacing: '0.04em',
                         }}
@@ -601,7 +601,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                     )}
                   </div>
                 </div>
-                <span className="material-icons" style={{ fontSize: 18, color: 'var(--ink-faint)' }}>more_vert</span>
+                <span className="material-icons" style={{ fontSize: 'var(--icon-md)', color: 'var(--ink-faint)' }}>more_vert</span>
               </button>
             ))}
           </div>
@@ -637,7 +637,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
             zIndex: 6,
           }}
         >
-          <span className="material-icons" style={{ fontSize: 26 }}>person_add</span>
+          <span className="material-icons" style={{ fontSize: 'var(--icon-lg)' }}>person_add</span>
         </button>,
         document.body,
       )}

--- a/components/admin/CommandCenter/RosterPage.tsx
+++ b/components/admin/CommandCenter/RosterPage.tsx
@@ -474,7 +474,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
               <span
                 style={{
                   fontFamily: 'var(--font-mono, "JetBrains Mono")',
-                  fontSize: 10,
+                  fontSize: 'var(--fs-2xs)',
                   marginLeft: 2,
                   color: on ? '#86efac' : 'var(--ink-faint)',
                 }}
@@ -489,7 +489,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
       {/* Groups */}
       <div style={{ margin: '12px -16px 0' }}>
         {groups.length === 0 && (
-          <p style={{ padding: '24px 16px', textAlign: 'center', fontSize: 13, color: 'var(--text-muted)' }}>
+          <p style={{ padding: '24px 16px', textAlign: 'center', fontSize: 'var(--fs-base)', color: 'var(--text-muted)' }}>
             No matches.
           </p>
         )}
@@ -508,8 +508,8 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                 zIndex: 1,
               }}
             >
-              <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 13, fontWeight: 700 }}>{letter}</span>
-              <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 10, color: 'var(--ink-faint)' }}>{people.length}</span>
+              <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 'var(--fs-base)', fontWeight: 700 }}>{letter}</span>
+              <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)' }}>{people.length}</span>
             </div>
             {people.map((r) => (
               <button
@@ -536,7 +536,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                     <span
                       style={{
                         fontFamily: 'var(--font-display, "Space Grotesk")',
-                        fontSize: 14,
+                        fontSize: 'var(--fs-md)',
                         fontWeight: 600,
                         color: r.status === 'dormant' ? 'var(--text-muted)' : 'var(--text-primary)',
                       }}
@@ -576,7 +576,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                       </span>
                     )}
                     {r.hasAlias && (
-                      <span className="material-icons" style={{ fontSize: 12, color: 'var(--ink-faint)' }} title="E-transfer alias linked">
+                      <span className="material-icons" style={{ fontSize: 'var(--fs-sm)', color: 'var(--ink-faint)' }} title="E-transfer alias linked">
                         article_person
                       </span>
                     )}
@@ -587,7 +587,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                       alignItems: 'center',
                       gap: 8,
                       fontFamily: 'var(--font-mono, "JetBrains Mono")',
-                      fontSize: 10,
+                      fontSize: 'var(--fs-2xs)',
                       color: 'var(--ink-faint)',
                     }}
                   >
@@ -651,7 +651,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
         className="max-w-sm mx-auto"
       >
         <BottomSheetHeader className="flex items-center justify-between p-4">
-          <span style={{ fontSize: 16, fontWeight: 600 }}>{editingId ? 'Edit member' : 'Add member'}</span>
+          <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{editingId ? 'Edit member' : 'Add member'}</span>
           <button
             type="button"
             onClick={() => setSheetOpen(false)}
@@ -667,7 +667,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
               justifyContent: 'center',
             }}
           >
-            <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+            <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
           </button>
         </BottomSheetHeader>
 
@@ -691,7 +691,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                 maxLength={100}
                 placeholder="Name on e-transfers, if different"
               />
-              <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 0' }}>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: '4px 0 0' }}>
                 Used to match incoming payments when the e-transfer name doesn&apos;t match the in-app name.
               </p>
             </Field>
@@ -732,7 +732,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                   >
                     {resettingPin ? 'Generating…' : 'Generate reset code'}
                   </button>
-                  <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 0' }}>
+                  <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: '4px 0 0' }}>
                     For a player who forgot their PIN. Give them the code — they enter it under
                     Profile → &ldquo;Have a recovery code?&rdquo; to set a new PIN. No signup needed.
                   </p>
@@ -741,7 +741,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
             )}
 
             {formError && (
-              <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+              <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: 0 }}>
                 {formError}
               </p>
             )}
@@ -795,7 +795,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-      <label style={{ fontSize: 12, color: 'var(--text-muted)' }}>{label}</label>
+      <label style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>{label}</label>
       {children}
     </div>
   );

--- a/components/admin/CommandCenter/RosterPage.tsx
+++ b/components/admin/CommandCenter/RosterPage.tsx
@@ -45,7 +45,7 @@ function Avatar({ name, size = 32 }: { name: string; size?: number }) {
         fontWeight: 600,
         fontSize: size * 0.42,
         flexShrink: 0,
-        border: '1px solid rgba(255,255,255,0.1)',
+        border: '1px solid rgba(var(--glass-tint), 0.1)',
       }}
     >
       {name.slice(0, 1).toUpperCase()}
@@ -63,7 +63,7 @@ function Sparkline({ presence }: { presence: Array<1 | null> }) {
             width: 7,
             height: 7,
             borderRadius: 2,
-            background: v === 1 ? 'var(--accent)' : 'rgba(255,255,255,0.1)',
+            background: v === 1 ? 'var(--accent)' : 'rgba(var(--glass-tint), 0.1)',
           }}
         />
       ))}
@@ -423,8 +423,8 @@ export default function RosterPage({ onBack }: RosterPageProps) {
           alignItems: 'center',
           gap: 8,
           padding: '10px 14px',
-          background: 'rgba(255,255,255,0.04)',
-          border: '1px solid rgba(255,255,255,0.12)',
+          background: 'rgba(var(--glass-tint), 0.04)',
+          border: '1px solid rgba(var(--glass-tint), 0.12)',
           borderRadius: 'var(--radius-lg)',
           color: 'var(--text-muted)',
         }}
@@ -461,8 +461,8 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                 gap: 5,
                 padding: '6px 11px',
                 borderRadius: 'var(--radius-pill)',
-                background: on ? 'rgba(74,222,128,0.13)' : 'rgba(255,255,255,0.04)',
-                border: `1px solid ${on ? 'rgba(74,222,128,0.35)' : 'rgba(255,255,255,0.12)'}`,
+                background: on ? 'rgba(74,222,128,0.13)' : 'rgba(var(--glass-tint), 0.04)',
+                border: `1px solid ${on ? 'rgba(74,222,128,0.35)' : 'rgba(var(--glass-tint), 0.12)'}`,
                 fontFamily: 'var(--font-display, "Space Grotesk")',
                 fontSize: 11.5,
                 fontWeight: 500,
@@ -526,7 +526,7 @@ export default function RosterPage({ onBack }: RosterPageProps) {
                   padding: '10px 24px',
                   alignItems: 'center',
                   gap: 12,
-                  borderBottom: '1px solid rgba(255,255,255,0.04)',
+                  borderBottom: '1px solid rgba(var(--glass-tint), 0.04)',
                 }}
                 aria-label={`Edit ${r.member.name}`}
               >

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -388,7 +388,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
           display: 'flex',
           flexDirection: 'column',
           gap: 14,
-          background: 'linear-gradient(160deg, rgba(74,222,128,0.06), rgba(255,255,255,0.02))',
+          background: 'linear-gradient(160deg, rgba(74,222,128,0.06), rgba(var(--glass-tint), 0.02))',
         }}
       >
         <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
@@ -404,7 +404,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
           </span>
         </div>
 
-        <div style={{ height: 1, background: 'rgba(255,255,255,0.06)' }} />
+        <div style={{ height: 1, background: 'rgba(var(--glass-tint), 0.06)' }} />
 
         {/* Court row */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
@@ -419,7 +419,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
             value={costPerCourt ?? ''}
             onChange={(e) => setCostPerCourt(e.target.value === '' ? null : Math.max(0, Math.min(500, Number(e.target.value))))}
             placeholder="$ per court"
-            style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 'var(--radius-sm)', padding: '8px 10px', fontSize: 'var(--fs-base)' }}
+            style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)', borderRadius: 'var(--radius-sm)', padding: '8px 10px', fontSize: 'var(--fs-base)' }}
           />
           {recentCosts.length > 0 && (
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
@@ -433,9 +433,9 @@ export default function SetupPage({ onBack }: SetupPageProps) {
                     fontSize: 'var(--fs-xs)',
                     padding: '2px 8px',
                     borderRadius: 'var(--radius-pill)',
-                    background: costPerCourt === c ? 'rgba(74,222,128,0.13)' : 'rgba(255,255,255,0.04)',
+                    background: costPerCourt === c ? 'rgba(74,222,128,0.13)' : 'rgba(var(--glass-tint), 0.04)',
                     color: costPerCourt === c ? '#86efac' : 'var(--text-secondary)',
-                    border: `1px solid ${costPerCourt === c ? 'rgba(74,222,128,0.3)' : 'rgba(255,255,255,0.12)'}`,
+                    border: `1px solid ${costPerCourt === c ? 'rgba(74,222,128,0.3)' : 'rgba(var(--glass-tint), 0.12)'}`,
                     cursor: 'pointer',
                     fontFamily: 'var(--font-mono, "JetBrains Mono")',
                   }}
@@ -603,7 +603,7 @@ function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void 
       style={{
         width: 44,
         height: 26,
-        background: on ? 'var(--accent)' : 'rgba(255,255,255,0.1)',
+        background: on ? 'var(--accent)' : 'rgba(var(--glass-tint), 0.1)',
         borderRadius: 'var(--radius-pill)',
         position: 'relative',
         border: 0,
@@ -648,8 +648,8 @@ function Stepper({
         alignItems: 'center',
         gap: 4,
         padding: 4,
-        background: 'rgba(255,255,255,0.04)',
-        border: '1px solid rgba(255,255,255,0.12)',
+        background: 'rgba(var(--glass-tint), 0.04)',
+        border: '1px solid rgba(var(--glass-tint), 0.12)',
         borderRadius: 'var(--radius-md)',
         flexShrink: 0,
       }}
@@ -662,7 +662,7 @@ function Stepper({
         style={{
           width: 28,
           height: 28,
-          background: 'rgba(255,255,255,0.04)',
+          background: 'rgba(var(--glass-tint), 0.04)',
           border: 0,
           borderRadius: 7,
           color: 'var(--text-primary)',
@@ -683,7 +683,7 @@ function Stepper({
         style={{
           width: 28,
           height: 28,
-          background: 'rgba(255,255,255,0.04)',
+          background: 'rgba(var(--glass-tint), 0.04)',
           border: 0,
           borderRadius: 7,
           color: 'var(--text-primary)',

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -409,7 +409,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         {/* Court row */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <span style={{ fontSize: 12.5, color: 'var(--text-secondary)' }}>{courts} court{courts === 1 ? '' : 's'} × cost</span>
+            <span style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)' }}>{courts} court{courts === 1 ? '' : 's'} × cost</span>
             <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-sm)' }}>${courtCost.toFixed(2)}</span>
           </div>
           <input
@@ -451,8 +451,8 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         {tubePurchase && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 1, flex: 1, minWidth: 0 }}>
-              <span style={{ fontSize: 12.5, color: 'var(--text-secondary)' }}>{tubes} tubes {tubePurchase.name}</span>
-              <span style={{ fontSize: 10.5, color: atMax ? 'var(--amber)' : 'var(--ink-faint)' }}>
+              <span style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)' }}>{tubes} tubes {tubePurchase.name}</span>
+              <span style={{ fontSize: 'var(--fs-xs)', color: atMax ? 'var(--amber)' : 'var(--ink-faint)' }}>
                 at ${tubePurchase.costPerTube.toFixed(2)}/tube
                 {remainingAfter !== null && ` · ${remainingAfter} left after`}
                 {atMax && ' · max for this purchase'}
@@ -482,7 +482,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
             style={{
               padding: '14px 16px',
               fontFamily: 'var(--font-mono, "JetBrains Mono")',
-              fontSize: 11.5,
+              fontSize: 'var(--fs-sm)',
               color: 'var(--text-secondary)',
               lineHeight: 1.6,
               whiteSpace: 'pre-wrap',

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -346,7 +346,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
             <input type="time" value={deadlineTime} onChange={(e) => setDeadlineTime(e.target.value)} style={{ flex: 1 }} />
           </div>
           {deadlineOffsetHours !== null && deadlineOffsetHours > 0 && (
-            <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '4px 0 0', fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
+            <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: '4px 0 0', fontFamily: 'var(--font-mono, "JetBrains Mono")' }}>
               {Math.round(deadlineOffsetHours)}h before session
             </p>
           )}
@@ -372,8 +372,8 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         </div>
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 6px' }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-            <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 13, fontWeight: 600 }}>Sign-ups open</span>
-            <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>Players can join now</span>
+            <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 'var(--fs-base)', fontWeight: 600 }}>Sign-ups open</span>
+            <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)' }}>Players can join now</span>
           </div>
           <Toggle on={signupOpen} onChange={setSignupOpen} />
         </div>
@@ -392,14 +392,14 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         }}
       >
         <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
-          <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 11, color: 'var(--ink-faint)', letterSpacing: '0.12em', textTransform: 'uppercase' }}>Per player</span>
-          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 10, color: 'var(--ink-faint)' }}>auto-calc</span>
+          <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 'var(--fs-xs)', color: 'var(--ink-faint)', letterSpacing: '0.12em', textTransform: 'uppercase' }}>Per player</span>
+          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)' }}>auto-calc</span>
         </div>
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
           <span style={{ fontFamily: 'var(--font-display, "Space Grotesk")', fontSize: 48, fontWeight: 700, letterSpacing: '-0.035em', lineHeight: 1, color: 'var(--accent)' }}>
             ${perPlayer}
           </span>
-          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 11, color: 'var(--ink-faint)' }}>
+          <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-xs)', color: 'var(--ink-faint)' }}>
             ${totalCost.toFixed(2)} ÷ {Math.max(1, activePlayerCount)}
           </span>
         </div>
@@ -410,7 +410,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <span style={{ fontSize: 12.5, color: 'var(--text-secondary)' }}>{courts} court{courts === 1 ? '' : 's'} × cost</span>
-            <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 12 }}>${courtCost.toFixed(2)}</span>
+            <span style={{ fontFamily: 'var(--font-mono, "JetBrains Mono")', fontSize: 'var(--fs-sm)' }}>${courtCost.toFixed(2)}</span>
           </div>
           <input
             type="number"
@@ -419,18 +419,18 @@ export default function SetupPage({ onBack }: SetupPageProps) {
             value={costPerCourt ?? ''}
             onChange={(e) => setCostPerCourt(e.target.value === '' ? null : Math.max(0, Math.min(500, Number(e.target.value))))}
             placeholder="$ per court"
-            style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 'var(--radius-sm)', padding: '8px 10px', fontSize: 13 }}
+            style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 'var(--radius-sm)', padding: '8px 10px', fontSize: 'var(--fs-base)' }}
           />
           {recentCosts.length > 0 && (
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-              <span style={{ fontSize: 10, color: 'var(--ink-faint)' }}>Recent:</span>
+              <span style={{ fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)' }}>Recent:</span>
               {recentCosts.map((c) => (
                 <button
                   key={c}
                   type="button"
                   onClick={() => setCostPerCourt(c)}
                   style={{
-                    fontSize: 11,
+                    fontSize: 'var(--fs-xs)',
                     padding: '2px 8px',
                     borderRadius: 'var(--radius-pill)',
                     background: costPerCourt === c ? 'rgba(74,222,128,0.13)' : 'rgba(255,255,255,0.04)',
@@ -468,7 +468,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         )}
 
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '2px 0' }}>
-          <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>Show cost on Home announcement</span>
+          <span style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-secondary)' }}>Show cost on Home announcement</span>
           <Toggle on={showCostBreakdown} onChange={setShowCostBreakdown} />
         </div>
       </div>
@@ -495,7 +495,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
               {copied ? 'Copied ✓' : 'Copy'}
             </button>
             <button type="button" onClick={shareImage} className="cc-btn cc-btn-primary" style={{ flex: 1, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
-              <span className="material-icons" style={{ fontSize: 16 }}>image</span>
+              <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>image</span>
               Share image
             </button>
           </div>
@@ -505,12 +505,12 @@ export default function SetupPage({ onBack }: SetupPageProps) {
 
       {/* Save bar */}
       {loadError && (
-        <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: '6px 4px 0' }}>
+        <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: '6px 4px 0' }}>
           Couldn&apos;t load the current session — saving is disabled to avoid overwriting it. Refresh to retry.
         </p>
       )}
       {saveError && (
-        <p role="alert" style={{ fontSize: 13, color: 'var(--color-red, #ef4444)', margin: '6px 4px 0' }}>
+        <p role="alert" style={{ fontSize: 'var(--fs-base)', color: 'var(--color-red)', margin: '6px 4px 0' }}>
           {saveError}
         </p>
       )}
@@ -562,7 +562,7 @@ function SecLabel({ children, right }: { children: React.ReactNode; right?: stri
     <p
       style={{
         fontFamily: 'var(--font-display, "Space Grotesk")',
-        fontSize: 11,
+        fontSize: 'var(--fs-xs)',
         fontWeight: 700,
         letterSpacing: '0.16em',
         textTransform: 'uppercase',
@@ -576,7 +576,7 @@ function SecLabel({ children, right }: { children: React.ReactNode; right?: stri
     >
       <span>{children}</span>
       {right && (
-        <span style={{ textTransform: 'none', letterSpacing: 0, color: 'var(--text-muted)', fontWeight: 500, fontSize: 11 }}>
+        <span style={{ textTransform: 'none', letterSpacing: 0, color: 'var(--text-muted)', fontWeight: 500, fontSize: 'var(--fs-xs)' }}>
           {right}
         </span>
       )}
@@ -587,7 +587,7 @@ function SecLabel({ children, right }: { children: React.ReactNode; right?: stri
 function Field({ label, children, style }: { label: string; children: React.ReactNode; style?: React.CSSProperties }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 6, ...style }}>
-      <label style={{ fontSize: 10, color: 'var(--ink-faint)', fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase' }}>{label}</label>
+      <label style={{ fontSize: 'var(--fs-2xs)', color: 'var(--ink-faint)', fontWeight: 600, letterSpacing: '0.1em', textTransform: 'uppercase' }}>{label}</label>
       {children}
     </div>
   );
@@ -670,9 +670,9 @@ function Stepper({
           opacity: decDisabled || value <= 0 ? 0.4 : 1,
         }}
       >
-        <span className="material-icons" style={{ fontSize: 14 }}>remove</span>
+        <span className="material-icons" style={{ fontSize: 'var(--fs-md)' }}>remove</span>
       </button>
-      <span style={{ minWidth: 36, textAlign: 'center', fontFamily: 'var(--font-display, "Space Grotesk")', fontWeight: 600, fontSize: 12 }}>
+      <span style={{ minWidth: 36, textAlign: 'center', fontFamily: 'var(--font-display, "Space Grotesk")', fontWeight: 600, fontSize: 'var(--fs-sm)' }}>
         {value}
       </span>
       <button
@@ -691,7 +691,7 @@ function Stepper({
           opacity: incDisabled ? 0.4 : 1,
         }}
       >
-        <span className="material-icons" style={{ fontSize: 14 }}>add</span>
+        <span className="material-icons" style={{ fontSize: 'var(--fs-md)' }}>add</span>
       </button>
     </div>
   );

--- a/components/admin/CommandCenter/SkipDatesEditor.tsx
+++ b/components/admin/CommandCenter/SkipDatesEditor.tsx
@@ -105,7 +105,7 @@ export default function SkipDatesEditor() {
         </button>
       </div>
 
-      {error && <p className="text-xs text-red-400" role="alert">{error}</p>}
+      {error && <p className="field-error" role="alert">{error}</p>}
 
       {dates.length > 0 && (
         <ul className="flex flex-wrap gap-2" role="list">

--- a/components/admin/CommandCenter/SkipDatesEditor.tsx
+++ b/components/admin/CommandCenter/SkipDatesEditor.tsx
@@ -93,7 +93,7 @@ export default function SkipDatesEditor() {
           value={adding}
           onChange={(e) => { setAdding(e.target.value); setError(''); }}
           className="flex-1 text-sm rounded-lg p-2"
-          style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+          style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
         />
         <button
           type="button"
@@ -113,7 +113,7 @@ export default function SkipDatesEditor() {
             <li
               key={d}
               className="text-xs px-3 py-1 rounded-full inline-flex items-center gap-1"
-              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.12)' }}
+              style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             >
               {d}
               <button

--- a/components/admin/CommandCenter/SkipDatesEditor.tsx
+++ b/components/admin/CommandCenter/SkipDatesEditor.tsx
@@ -82,7 +82,7 @@ export default function SkipDatesEditor() {
     <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Skip dates">
       <header>
         <h3 className="bpm-h3">Skip dates</h3>
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="fs-sm text-gray-400 mt-0.5">
           Dates the system will warn you about when advancing — holidays, travel, venue closures.
         </p>
       </header>
@@ -92,7 +92,7 @@ export default function SkipDatesEditor() {
           type="date"
           value={adding}
           onChange={(e) => { setAdding(e.target.value); setError(''); }}
-          className="flex-1 text-sm rounded-lg p-2"
+          className="flex-1 fs-md rounded-lg p-2"
           style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
         />
         <button
@@ -112,7 +112,7 @@ export default function SkipDatesEditor() {
           {dates.map((d) => (
             <li
               key={d}
-              className="text-xs px-3 py-1 rounded-full inline-flex items-center gap-1"
+              className="fs-sm px-3 py-1 rounded-full inline-flex items-center gap-1"
               style={{ background: 'rgba(var(--glass-tint), 0.04)', border: '1px solid rgba(var(--glass-tint), 0.12)' }}
             >
               {d}
@@ -131,7 +131,7 @@ export default function SkipDatesEditor() {
       )}
 
       {dates.length === 0 && (
-        <p className="text-xs text-gray-500">No skip dates yet.</p>
+        <p className="fs-sm text-gray-500">No skip dates yet.</p>
       )}
     </section>
   );

--- a/components/admin/CoverSheet.tsx
+++ b/components/admin/CoverSheet.tsx
@@ -144,11 +144,11 @@ export default function CoverSheet({
     >
       <BottomSheetHeader className="p-4">
         <h2 className="bpm-h3" style={{ margin: 0 }}>{title}</h2>
-        <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '4px 0 0' }}>{subtitle}</p>
+        <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: '4px 0 0' }}>{subtitle}</p>
       </BottomSheetHeader>
       <BottomSheetBody className="p-4 pb-8" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
         {error && (
-          <p role="alert" style={{ fontSize: 12, color: 'var(--color-red, #ef4444)', margin: 0 }}>
+          <p role="alert" style={{ fontSize: 'var(--fs-sm)', color: 'var(--color-red)', margin: 0 }}>
             {error}
           </p>
         )}
@@ -162,7 +162,7 @@ export default function CoverSheet({
             >
               {submitting ? '…' : "I've got it — I'll cover it"}
             </button>
-            <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '-2px 2px 4px' }}>
+            <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: '-2px 2px 4px' }}>
               You absorb their share. Everyone else pays the same.
             </p>
             <button
@@ -173,7 +173,7 @@ export default function CoverSheet({
             >
               {submitting ? '…' : 'Split it across everyone else'}
             </button>
-            <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '-2px 2px 4px' }}>
+            <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: '-2px 2px 4px' }}>
               Their share is spread over the other players — you pay nothing extra.
             </p>
             <button

--- a/components/admin/DateTimeEditor.tsx
+++ b/components/admin/DateTimeEditor.tsx
@@ -180,7 +180,7 @@ export default function DateTimeEditor({ onBack }: { onBack: () => void }) {
               </div>
             </div>
           </Label>
-          {error && <p className="text-red-400 text-xs" role="alert">{error}</p>}
+          {error && <p className="field-error" role="alert">{error}</p>}
           <button
             type="submit"
             disabled={saving || !dirty}

--- a/components/admin/DateTimeEditor.tsx
+++ b/components/admin/DateTimeEditor.tsx
@@ -10,7 +10,7 @@ const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 function Label({ text, children }: { text: string; children: React.ReactNode }) {
   return (
     <label className="block space-y-1">
-      <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
+      <span className="fs-sm font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
       {children}
     </label>
   );

--- a/components/admin/LedgerPage.tsx
+++ b/components/admin/LedgerPage.tsx
@@ -113,7 +113,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
           style={{ padding: '40px 24px', textAlign: 'center', color: 'var(--text-muted)' }}
         >
           <p style={{ fontWeight: 600, color: 'var(--text)' }}>Couldn&apos;t load the ledger</p>
-          <p style={{ fontSize: 13, marginTop: 6 }}>
+          <p style={{ fontSize: 'var(--fs-base)', marginTop: 6 }}>
             Backend may be cold-starting. Reconnect, then retry.
           </p>
           <button
@@ -143,7 +143,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
     <div className="animate-slideInRight space-y-3">
       <AdminBackHeader onBack={onBack} title="Ledger" />
 
-      <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: '0 4px' }}>
+      <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', margin: '0 4px' }}>
         Who owes what. Cover anyone you don&apos;t want to chase.
       </p>
 
@@ -171,7 +171,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
             padding: '48px 24px',
             textAlign: 'center',
             color: 'var(--text-muted)',
-            fontSize: 14,
+            fontSize: 'var(--fs-md)',
           }}
         >
           Nothing settled in this window. Try widening the range.
@@ -197,7 +197,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
           {/* Honest-headline sub-line — always shown, even at $0 covered. */}
           <p
             style={{
-              fontSize: 12,
+              fontSize: 'var(--fs-sm)',
               color: 'var(--ink-faint)',
               margin: '0 4px',
               fontFamily: 'var(--font-mono, "JetBrains Mono")',
@@ -210,7 +210,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
           {!showPlayerTab && (
             <p
               style={{
-                fontSize: 13,
+                fontSize: 'var(--fs-base)',
                 color: 'var(--accent)',
                 fontWeight: 600,
                 margin: '4px 4px 0',
@@ -282,14 +282,14 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
                       <p
                         style={{
                           fontFamily: 'var(--font-display, "Space Grotesk")',
-                          fontSize: 14,
+                          fontSize: 'var(--fs-md)',
                           fontWeight: 600,
                           margin: 0,
                         }}
                       >
                         {fmtSessionLabel(s.date)}
                       </p>
-                      <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: '2px 0 0' }}>
+                      <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: '2px 0 0' }}>
                         {money(s.totalCost)} · {s.attendanceCount} player
                         {s.attendanceCount === 1 ? '' : 's'}
                       </p>
@@ -341,14 +341,14 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
                       <p
                         style={{
                           fontFamily: 'var(--font-display, "Space Grotesk")',
-                          fontSize: 14,
+                          fontSize: 'var(--fs-md)',
                           fontWeight: 600,
                           margin: 0,
                         }}
                       >
                         {p.name}
                       </p>
-                      <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: '2px 0 0' }}>
+                      <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: '2px 0 0' }}>
                         {p.sessionCount} unpaid session{p.sessionCount === 1 ? '' : 's'}
                       </p>
                     </div>

--- a/components/admin/LedgerPage.tsx
+++ b/components/admin/LedgerPage.tsx
@@ -156,7 +156,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
             role="tab"
             aria-selected={range === r.key}
             onClick={() => setRange(r.key)}
-            className={`flex-1 text-xs rounded-full ${
+            className={`flex-1 fs-sm rounded-full ${
               range === r.key ? 'segment-tab-active' : 'segment-tab-inactive'
             }`}
           >
@@ -227,7 +227,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
               role="tab"
               aria-selected={activeTab === 'session'}
               onClick={() => setTab('session')}
-              className={`flex-1 text-xs rounded-full ${
+              className={`flex-1 fs-sm rounded-full ${
                 activeTab === 'session' ? 'segment-tab-active' : 'segment-tab-inactive'
               }`}
             >
@@ -239,7 +239,7 @@ export default function LedgerPage({ onBack, onOpenSession }: LedgerPageProps) {
                 role="tab"
                 aria-selected={activeTab === 'player'}
                 onClick={() => setTab('player')}
-                className={`flex-1 text-xs rounded-full ${
+                className={`flex-1 fs-sm rounded-full ${
                   activeTab === 'player' ? 'segment-tab-active' : 'segment-tab-inactive'
                 }`}
               >

--- a/components/admin/MembersView.tsx
+++ b/components/admin/MembersView.tsx
@@ -178,7 +178,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
         <div className="flex items-center justify-between">
           <div>
             <p className="section-label">INVITE LIST</p>
-            {inviteCollapsed && <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>{members.length} member{members.length !== 1 ? 's' : ''}</p>}
+            {inviteCollapsed && <p className="fs-sm mt-0.5" style={{ color: 'var(--text-muted)' }}>{members.length} member{members.length !== 1 ? 's' : ''}</p>}
           </div>
           <button
             type="button"
@@ -190,7 +190,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
             <span className="material-icons icon-md">{inviteCollapsed ? 'expand_more' : 'expand_less'}</span>
           </button>
         </div>
-        {!inviteCollapsed && <p className="text-xs" style={{ color: 'var(--text-muted)' }}>Only people on this list can sign up. Leave empty to allow anyone.</p>}
+        {!inviteCollapsed && <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>Only people on this list can sign up. Leave empty to allow anyone.</p>}
         {!inviteCollapsed && (<>
           <div className="flex gap-2">
             <input
@@ -223,9 +223,9 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
               {members.map((member) => (
                 <div key={member.id} className="flex items-center justify-between py-1.5 px-3 rounded-xl bg-white/5">
                   <div className="flex-1 min-w-0">
-                    <span className="text-sm" style={{ color: 'var(--text-primary)' }}>{member.name}</span>
+                    <span className="fs-md" style={{ color: 'var(--text-primary)' }}>{member.name}</span>
                     {member.sessionCount > 0 && (
-                      <span className="text-xs ml-2" style={{ color: 'var(--text-muted)' }}>{member.sessionCount} session{member.sessionCount !== 1 ? 's' : ''}</span>
+                      <span className="fs-sm ml-2" style={{ color: 'var(--text-muted)' }}>{member.sessionCount} session{member.sessionCount !== 1 ? 's' : ''}</span>
                     )}
                   </div>
                   <button
@@ -274,7 +274,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
                       onChange={(e) => setEditAppName(e.target.value)}
                       maxLength={50}
                       autoComplete="off"
-                      className="flex-1 text-sm"
+                      className="flex-1 fs-md"
                     />
                     <input
                       name="editEtransferName"
@@ -283,23 +283,23 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
                       onChange={(e) => setEditEtransferName(e.target.value)}
                       maxLength={50}
                       autoComplete="off"
-                      className="flex-1 text-sm"
+                      className="flex-1 fs-md"
                     />
                   </div>
                   {editError && <p className="field-error" role="alert">{editError}</p>}
                   <div className="flex gap-2">
-                    <button onClick={() => handleSaveEdit(alias.id)} className="cc-btn cc-btn-primary text-xs" style={{ minHeight: 44 }}>Save</button>
-                    <button onClick={() => setEditingId(null)} className="btn-ghost text-xs px-3 py-1.5" style={{ minHeight: 44 }}>Cancel</button>
+                    <button onClick={() => handleSaveEdit(alias.id)} className="cc-btn cc-btn-primary fs-sm" style={{ minHeight: 44 }}>Save</button>
+                    <button onClick={() => setEditingId(null)} className="btn-ghost fs-sm px-3 py-1.5" style={{ minHeight: 44 }}>Cancel</button>
                   </div>
                 </div>
               ) : (
                 <div key={alias.id} className="flex items-center gap-3 px-4 py-3">
-                  <span className="text-sm font-medium flex-1" style={{ color: 'var(--text-primary)' }}>{alias.appName}</span>
+                  <span className="fs-md font-medium flex-1" style={{ color: 'var(--text-primary)' }}>{alias.appName}</span>
                   <span className="material-icons icon-sm" style={{ color: 'var(--text-muted)' }}>arrow_back</span>
-                  <span className="text-sm flex-1" style={{ color: 'var(--text-secondary)' }}>{alias.etransferName}</span>
-                  <button onClick={() => startEdit(alias)} className="text-xs text-blue-400 hover:text-blue-300 transition-colors" style={{ minHeight: 44, display: 'flex', alignItems: 'center' }}>Edit</button>
+                  <span className="fs-md flex-1" style={{ color: 'var(--text-secondary)' }}>{alias.etransferName}</span>
+                  <button onClick={() => startEdit(alias)} className="fs-sm text-blue-400 hover:text-blue-300 transition-colors" style={{ minHeight: 44, display: 'flex', alignItems: 'center' }}>Edit</button>
                   {confirmingDeleteId === alias.id ? (
-                    <div className="flex items-center gap-2 text-xs">
+                    <div className="flex items-center gap-2 fs-sm">
                       <span style={{ color: 'var(--text-muted)' }}>Delete?</span>
                       <button
                         onClick={() => { handleDeleteAlias(alias.id); setConfirmingDeleteId(null); }}
@@ -320,7 +320,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
                   ) : (
                     <button
                       onClick={() => setConfirmingDeleteId(alias.id)}
-                      className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                      className="fs-sm text-red-400 hover:text-red-300 transition-colors"
                       style={{ minHeight: 44, display: 'flex', alignItems: 'center' }}
                     >
                       Delete
@@ -332,14 +332,14 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
           </div>
         </div>
       ) : (
-        <p className="text-sm text-center py-4" style={{ color: 'var(--text-muted)' }}>No aliases yet — add one to map names for e-transfer.</p>
+        <p className="fs-md text-center py-4" style={{ color: 'var(--text-muted)' }}>No aliases yet — add one to map names for e-transfer.</p>
       )}
 
       {/* Add alias form — below the list so the submit button is in the
           thumb zone for one-handed use. */}
       <div className="glass-card p-5 space-y-3">
         <p className="section-label">ADD ALIAS</p>
-        <p className="text-xs" style={{ color: 'var(--text-muted)' }}>Link each player&apos;s app name to their e-transfer name for payment tracking.</p>
+        <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>Link each player&apos;s app name to their e-transfer name for payment tracking.</p>
         <form onSubmit={handleAddAlias} className="space-y-3">
           <div className="flex gap-2">
             <input

--- a/components/admin/MembersView.tsx
+++ b/components/admin/MembersView.tsx
@@ -236,7 +236,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
                     aria-label={`${(member.role ?? 'member') === 'admin' ? 'Remove admin role from' : 'Make admin'} ${member.name}`}
                     title={(member.role ?? 'member') === 'admin' ? 'Admin' : 'Make admin'}
                   >
-                    <span className="material-icons" style={{ fontSize: 16 }}>shield</span>
+                    <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>shield</span>
                   </button>
                   <button
                     type="button"
@@ -245,7 +245,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
                     style={{ color: 'var(--text-muted)', minHeight: 44, minWidth: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                     aria-label={`Remove ${member.name}`}
                   >
-                    <span className="material-icons" style={{ fontSize: 16 }}>close</span>
+                    <span className="material-icons" style={{ fontSize: 'var(--fs-lg)' }}>close</span>
                   </button>
                 </div>
               ))}

--- a/components/admin/MembersView.tsx
+++ b/components/admin/MembersView.tsx
@@ -215,7 +215,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
               {adding ? '...' : 'Add'}
             </button>
           </div>
-          {addError && <p className="text-red-400 text-xs" role="alert">{addError}</p>}
+          {addError && <p className="field-error" role="alert">{addError}</p>}
           {membersLoading ? (
             <ShimmerLoader lines={3} />
           ) : members.length > 0 ? (
@@ -286,7 +286,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
                       className="flex-1 text-sm"
                     />
                   </div>
-                  {editError && <p className="text-red-400 text-xs" role="alert">{editError}</p>}
+                  {editError && <p className="field-error" role="alert">{editError}</p>}
                   <div className="flex gap-2">
                     <button onClick={() => handleSaveEdit(alias.id)} className="cc-btn cc-btn-primary text-xs" style={{ minHeight: 44 }}>Save</button>
                     <button onClick={() => setEditingId(null)} className="btn-ghost text-xs px-3 py-1.5" style={{ minHeight: 44 }}>Cancel</button>
@@ -367,7 +367,7 @@ export default function MembersView({ onBack }: { onBack: () => void }) {
               className="flex-1"
             />
           </div>
-          {aliasAddError && <p className="text-red-400 text-xs" role="alert">{aliasAddError}</p>}
+          {aliasAddError && <p className="field-error" role="alert">{aliasAddError}</p>}
           <button type="submit" disabled={aliasAdding} className="cc-btn cc-btn-primary cc-btn-lg" style={{ minHeight: 44 }}>
             {aliasAdding ? 'Adding...' : 'Add Alias'}
           </button>

--- a/components/admin/ReleaseForm.tsx
+++ b/components/admin/ReleaseForm.tsx
@@ -160,12 +160,12 @@ ${rawNotes}`;
   return (
     <div className="space-y-4">
       {!isEdit && (
-        <p className="text-xs leading-relaxed" style={{ color: 'var(--text-muted)' }}>
+        <p className="fs-sm leading-relaxed" style={{ color: 'var(--text-muted)' }}>
           {t('howItWorks')}
         </p>
       )}
       <div>
-        <label htmlFor="release-version" className="block text-xs text-gray-400 mb-1">Version</label>
+        <label htmlFor="release-version" className="block fs-sm text-gray-400 mb-1">Version</label>
         <input
           id="release-version"
           name="version"
@@ -179,7 +179,7 @@ ${rawNotes}`;
       {!isEdit && (
         <div>
           <div className="flex items-center justify-between mb-1">
-            <label htmlFor="release-raw-notes" className="block text-xs text-gray-400">Raw notes</label>
+            <label htmlFor="release-raw-notes" className="block fs-sm text-gray-400">Raw notes</label>
             <button
               type="button"
               onClick={loadFromChangelog}
@@ -222,22 +222,22 @@ ${rawNotes}`;
 
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label htmlFor="release-title-en" className="block text-xs text-gray-400 mb-1">Title (EN)</label>
+          <label htmlFor="release-title-en" className="block fs-sm text-gray-400 mb-1">Title (EN)</label>
           <input id="release-title-en" name="titleEn" type="text" value={titleEn} onChange={(e) => setTitleEn(e.target.value)} className="input w-full" />
         </div>
         <div>
-          <label htmlFor="release-title-zh" className="block text-xs text-gray-400 mb-1">Title (中文)</label>
+          <label htmlFor="release-title-zh" className="block fs-sm text-gray-400 mb-1">Title (中文)</label>
           <input id="release-title-zh" name="titleZh" type="text" value={titleZh} onChange={(e) => setTitleZh(e.target.value)} className="input w-full" />
         </div>
       </div>
 
       <div>
-        <label htmlFor="release-body-en" className="block text-xs text-gray-400 mb-1">Body (EN)</label>
+        <label htmlFor="release-body-en" className="block fs-sm text-gray-400 mb-1">Body (EN)</label>
         <textarea id="release-body-en" name="bodyEn" value={bodyEn} onChange={(e) => setBodyEn(e.target.value)} className="input w-full min-h-[100px]" />
       </div>
 
       <div>
-        <label htmlFor="release-body-zh" className="block text-xs text-gray-400 mb-1">Body (中文)</label>
+        <label htmlFor="release-body-zh" className="block fs-sm text-gray-400 mb-1">Body (中文)</label>
         <textarea id="release-body-zh" name="bodyZh" value={bodyZh} onChange={(e) => setBodyZh(e.target.value)} className="input w-full min-h-[100px]" />
       </div>
 

--- a/components/admin/ReleaseForm.tsx
+++ b/components/admin/ReleaseForm.tsx
@@ -241,7 +241,7 @@ ${rawNotes}`;
         <textarea id="release-body-zh" name="bodyZh" value={bodyZh} onChange={(e) => setBodyZh(e.target.value)} className="input w-full min-h-[100px]" />
       </div>
 
-      {error && <p className="text-red-400 text-xs" role="alert">{error}</p>}
+      {error && <p className="field-error" role="alert">{error}</p>}
 
       <div className="flex gap-2">
         <button type="button" onClick={onCancel} className="btn-ghost flex-1">Cancel</button>

--- a/components/admin/ReleasesView.tsx
+++ b/components/admin/ReleasesView.tsx
@@ -94,7 +94,7 @@ export default function ReleasesView({ onBack }: Props) {
                       aria-label={`Edit ${r.version}`}
                       title="Edit"
                     >
-                      <span className="material-icons" style={{ fontSize: 18 }}>edit</span>
+                      <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>edit</span>
                     </button>
                     <button
                       type="button"
@@ -104,7 +104,7 @@ export default function ReleasesView({ onBack }: Props) {
                       aria-label={`Delete ${r.version}`}
                       title="Delete"
                     >
-                      <span className="material-icons" style={{ fontSize: 18 }}>delete</span>
+                      <span className="material-icons" style={{ fontSize: 'var(--icon-md)' }}>delete</span>
                     </button>
                   </div>
                 </li>

--- a/components/admin/ReleasesView.tsx
+++ b/components/admin/ReleasesView.tsx
@@ -71,16 +71,16 @@ export default function ReleasesView({ onBack }: Props) {
 
           {error && <p className="field-error" role="alert">{error}</p>}
           {loading ? (
-            <p className="text-sm text-gray-400">Loading…</p>
+            <p className="fs-md text-gray-400">Loading…</p>
           ) : releases.length === 0 ? (
-            <p className="text-sm text-gray-400">No releases yet.</p>
+            <p className="fs-md text-gray-400">No releases yet.</p>
           ) : (
             <ul className="space-y-2">
               {releases.map((r) => (
                 <li key={r.id} className="glass-card p-3 flex justify-between items-start">
                   <div>
-                    <p className="text-sm font-semibold text-white">{r.version} · {r.title.en}</p>
-                    <p className="text-xs text-gray-400">
+                    <p className="fs-md font-semibold text-white">{r.version} · {r.title.en}</p>
+                    <p className="fs-sm text-gray-400">
                       {new Date(r.publishedAt).toLocaleDateString()}
                       {r.editedAt && <> · edited {new Date(r.editedAt).toLocaleDateString()}</>}
                     </p>

--- a/components/admin/ReleasesView.tsx
+++ b/components/admin/ReleasesView.tsx
@@ -69,7 +69,7 @@ export default function ReleasesView({ onBack }: Props) {
             {t('newButton')}
           </button>
 
-          {error && <p className="text-red-400 text-xs" role="alert">{error}</p>}
+          {error && <p className="field-error" role="alert">{error}</p>}
           {loading ? (
             <p className="text-sm text-gray-400">Loading…</p>
           ) : releases.length === 0 ? (

--- a/components/admin/ResetAccessSheet.tsx
+++ b/components/admin/ResetAccessSheet.tsx
@@ -36,14 +36,14 @@ export default function ResetAccessSheet({ open, onClose, playerName, code, expi
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={titleText} className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{titleText}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{titleText}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={t('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
@@ -60,7 +60,7 @@ export default function ResetAccessSheet({ open, onClose, playerName, code, expi
           >
             {code}
           </p>
-          <p style={{ fontSize: 13, color: 'var(--text-secondary)', marginBottom: 20 }}>
+          <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', marginBottom: 20 }}>
             {t('expiresIn', { time: `${mm}:${ss}` })}
           </p>
           <div style={{ display: 'flex', gap: 8 }}>

--- a/components/admin/SessionContextBar.tsx
+++ b/components/admin/SessionContextBar.tsx
@@ -27,7 +27,7 @@ export default function SessionContextBar({ session, onEditDates }: Props) {
     >
       <div className="text-left">
         <p className="text-[10px] font-medium" style={{ color: 'var(--text-muted)' }}>Editing</p>
-        <p className="text-sm font-semibold" style={{ color: 'var(--accent)' }}>
+        <p className="fs-md font-semibold" style={{ color: 'var(--accent)' }}>
           {session?.datetime ? fmtSessionDate(session.datetime) : 'No session'}
         </p>
       </div>

--- a/components/admin/SessionContextBar.tsx
+++ b/components/admin/SessionContextBar.tsx
@@ -31,7 +31,7 @@ export default function SessionContextBar({ session, onEditDates }: Props) {
           {session?.datetime ? fmtSessionDate(session.datetime) : 'No session'}
         </p>
       </div>
-      <span className="material-icons" style={{ fontSize: 16, color: 'var(--text-muted)' }}>edit</span>
+      <span className="material-icons" style={{ fontSize: 'var(--fs-lg)', color: 'var(--text-muted)' }}>edit</span>
     </button>
   );
 }

--- a/components/admin/SessionDetailsEditor.tsx
+++ b/components/admin/SessionDetailsEditor.tsx
@@ -582,7 +582,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
         </div>
 
         {/* ── Error + Update ── */}
-        {error && <p className="text-red-400 text-xs px-1" role="alert">{error}</p>}
+        {error && <p className="field-error px-1" role="alert">{error}</p>}
         <button
           type="submit"
           disabled={saving || !dirty}

--- a/components/admin/SessionDetailsEditor.tsx
+++ b/components/admin/SessionDetailsEditor.tsx
@@ -10,7 +10,7 @@ const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 function Label({ text, children }: { text: string; children: React.ReactNode }) {
   return (
     <label className="block space-y-1">
-      <span className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
+      <span className="fs-sm font-medium" style={{ color: 'var(--text-muted)' }}>{text}</span>
       {children}
     </label>
   );
@@ -18,7 +18,7 @@ function Label({ text, children }: { text: string; children: React.ReactNode }) 
 
 function CardDescription({ children }: { children: React.ReactNode }) {
   return (
-    <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+    <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
       {children}
     </p>
   );
@@ -58,7 +58,7 @@ function TubeStepper({ value, onChange }: { value: number; onChange: (next: numb
         <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat)' }}>remove</span>
       </button>
       <span
-        className="text-base font-semibold tabular-nums"
+        className="fs-lg font-semibold tabular-nums"
         style={{ color: 'var(--text-primary)', minWidth: 48, textAlign: 'center' }}
         aria-live="polite"
       >
@@ -286,7 +286,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
         {/* ── Card 1: Session Details ── */}
         <div className="glass-card p-5 space-y-4">
           <div className="space-y-1">
-            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            <h3 className="fs-md font-semibold" style={{ color: 'var(--text-primary)' }}>
               Session Details
             </h3>
             <CardDescription>Venue, capacity, and sign-up controls.</CardDescription>
@@ -312,8 +312,8 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
             return (
               <div className="flex items-center justify-between pt-1">
                 <div>
-                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>Sign-ups</p>
-                  <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+                  <p className="fs-md font-medium" style={{ color: 'var(--text-primary)' }}>Sign-ups</p>
+                  <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
                     {isSessionFinished
                       ? 'This session has ended — advance to start a new one'
                       : form.signupOpen ? 'Open — players can sign up' : 'Closed — players cannot sign up'}
@@ -338,7 +338,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
         {/* ── Card 2: Cost Details ── */}
         <div className="glass-card p-5 space-y-4">
           <div className="space-y-1">
-            <h3 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            <h3 className="fs-md font-semibold" style={{ color: 'var(--text-primary)' }}>
               Cost Details
             </h3>
             <CardDescription>How much each player pays per session.</CardDescription>
@@ -347,7 +347,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
           <Label text="Cost per court">
             <div className="relative">
               {form.costPerCourt !== null && form.costPerCourt > 0 && (
-                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm pointer-events-none" style={{ color: 'var(--text-muted)' }}>$</span>
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 fs-md pointer-events-none" style={{ color: 'var(--text-muted)' }}>$</span>
               )}
               <input
                 id="session-cost-per-court"
@@ -372,7 +372,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
             style={{ borderTop: '1px solid var(--glass-border)' }}
           >
             <div className="flex items-center justify-between">
-              <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+              <span className="fs-md font-semibold" style={{ color: 'var(--text-primary)' }}>
                 Bird usage
               </span>
               <button
@@ -383,7 +383,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                     birdUsages: [...f.birdUsages, { purchaseId: '', tubes: 0 }],
                   }))
                 }
-                className="text-xs font-medium px-2 py-1 rounded-md"
+                className="fs-sm font-medium px-2 py-1 rounded-md"
                 style={{ color: 'var(--accent)', background: 'var(--inner-card-bg)' }}
               >
                 + Add from inventory
@@ -391,7 +391,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
             </div>
 
             {form.birdUsages.length === 0 && (
-              <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
                 No bird usage recorded.
               </p>
             )}
@@ -485,7 +485,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                         return (
                           <div className="flex items-center justify-between gap-2 min-h-8">
                             <p
-                              className="text-xs"
+                              className="fs-sm"
                               style={{ color: complete ? 'var(--accent)' : 'var(--text-muted)' }}
                             >
                               {tubesSlot} × {costSlot} = {totalSlot}
@@ -522,10 +522,10 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                 className="flex items-center justify-between pt-3"
                 style={{ borderTop: '1px solid var(--glass-border)' }}
               >
-                <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
+                <span className="fs-sm font-medium" style={{ color: 'var(--text-secondary)' }}>
                   Total bird cost
                 </span>
-                <span className="text-sm font-bold" style={{ color: 'var(--accent)' }}>
+                <span className="fs-md font-bold" style={{ color: 'var(--accent)' }}>
                   ${birdTotal.toFixed(2)}
                 </span>
               </div>
@@ -538,20 +538,20 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
               className="pt-3 space-y-1"
               style={{ borderTop: '1px solid var(--glass-border)' }}
             >
-              <p className="text-xs font-medium" style={{ color: 'var(--text-muted)' }}>
+              <p className="fs-sm font-medium" style={{ color: 'var(--text-muted)' }}>
                 Per person preview
               </p>
               {activePlayerCount > 0 && perPerson !== null ? (
                 <>
-                  <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                  <p className="fs-sm" style={{ color: 'var(--text-secondary)' }}>
                     (${courtTotal.toFixed(2)} courts + ${birdTotal.toFixed(2)} birds) ÷ {activePlayerCount}
                   </p>
-                  <p className="text-sm font-bold" style={{ color: 'var(--accent)' }}>
+                  <p className="fs-md font-bold" style={{ color: 'var(--accent)' }}>
                     ${perPerson.toFixed(2)} per player
                   </p>
                 </>
               ) : (
-                <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                <p className="fs-sm" style={{ color: 'var(--text-secondary)' }}>
                   No players signed up yet.
                 </p>
               )}
@@ -561,10 +561,10 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
           {/* ── Show cost toggle (now a real switch) ── */}
           <div className="flex items-center justify-between pt-1">
             <div>
-              <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+              <p className="fs-md font-medium" style={{ color: 'var(--text-primary)' }}>
                 Show cost to players
               </p>
-              <p className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              <p className="fs-sm" style={{ color: 'var(--text-muted)' }}>
                 {form.showCostBreakdown ? 'Visible on the Home announcement' : 'Hidden from players'}
               </p>
             </div>

--- a/components/admin/SessionDetailsEditor.tsx
+++ b/components/admin/SessionDetailsEditor.tsx
@@ -55,7 +55,7 @@ function TubeStepper({ value, onChange }: { value: number; onChange: (next: numb
           cursor: canDec ? 'pointer' : 'not-allowed',
         }}
       >
-        <span className="material-icons" aria-hidden="true" style={{ fontSize: 20 }}>remove</span>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat)' }}>remove</span>
       </button>
       <span
         className="text-base font-semibold tabular-nums"
@@ -71,7 +71,7 @@ function TubeStepper({ value, onChange }: { value: number; onChange: (next: numb
         className="flex items-center justify-center"
         style={{ ...btn, color: 'var(--text-primary)', cursor: 'pointer' }}
       >
-        <span className="material-icons" aria-hidden="true" style={{ fontSize: 20 }}>add</span>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat)' }}>add</span>
       </button>
     </div>
   );
@@ -449,7 +449,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                             style={{
                               right: 10,
                               transform: 'translateY(-50%)',
-                              fontSize: 20,
+                              fontSize: 'var(--fs-stat)',
                               color: 'var(--text-muted)',
                             }}
                           >
@@ -506,7 +506,7 @@ export default function SessionDetailsEditor({ onBack }: { onBack: () => void })
                             width: 32,
                           }}
                         >
-                          <span className="material-icons" aria-hidden="true" style={{ fontSize: 20 }}>delete_outline</span>
+                          <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat)' }}>delete_outline</span>
                         </button>
                       </div>
                         );

--- a/components/admin/VenueSummary.tsx
+++ b/components/admin/VenueSummary.tsx
@@ -31,7 +31,7 @@ export default function VenueSummary({ session, onEdit }: Props) {
           {details}
         </p>
       </div>
-      <span className="material-icons ml-2 shrink-0" style={{ fontSize: 16, color: 'var(--text-muted)' }}>edit</span>
+      <span className="material-icons ml-2 shrink-0" style={{ fontSize: 'var(--fs-lg)', color: 'var(--text-muted)' }}>edit</span>
     </button>
   );
 }

--- a/components/admin/VenueSummary.tsx
+++ b/components/admin/VenueSummary.tsx
@@ -24,10 +24,10 @@ export default function VenueSummary({ session, onEdit }: Props) {
       style={{ minHeight: 44 }}
     >
       <div className="min-w-0">
-        <p className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+        <p className="fs-md font-medium truncate" style={{ color: 'var(--text-primary)' }}>
           {session.locationName || 'No venue set'}
         </p>
-        <p className="text-xs mt-0.5 truncate" style={{ color: 'var(--text-muted)' }}>
+        <p className="fs-sm mt-0.5 truncate" style={{ color: 'var(--text-muted)' }}>
           {details}
         </p>
       </div>

--- a/components/home/NameAutocompleteInput.tsx
+++ b/components/home/NameAutocompleteInput.tsx
@@ -131,7 +131,7 @@ export default function NameAutocompleteInput({
               aria-selected={i === active}
               onMouseDown={() => selectSuggestion(s)}
               onMouseEnter={() => setActiveIndex(i)}
-              className="w-full text-left px-4 py-2.5 text-sm transition-colors cursor-pointer"
+              className="w-full text-left px-4 py-2.5 fs-md transition-colors cursor-pointer"
               style={{
                 color: 'var(--text-primary)',
                 background: i === active ? 'rgba(var(--glass-tint), 0.06)' : 'transparent',

--- a/components/home/NameAutocompleteInput.tsx
+++ b/components/home/NameAutocompleteInput.tsx
@@ -134,7 +134,7 @@ export default function NameAutocompleteInput({
               className="w-full text-left px-4 py-2.5 text-sm transition-colors cursor-pointer"
               style={{
                 color: 'var(--text-primary)',
-                background: i === active ? 'rgba(255,255,255,0.06)' : 'transparent',
+                background: i === active ? 'rgba(var(--glass-tint), 0.06)' : 'transparent',
               }}
             >
               {s}

--- a/components/home/SkillDiscoveryCard.tsx
+++ b/components/home/SkillDiscoveryCard.tsx
@@ -64,10 +64,10 @@ export default function SkillDiscoveryCard({
         onClick={onOpen}
         style={{ flex: 1, textAlign: 'left', background: 'transparent', border: 'none', cursor: 'pointer', padding: 0 }}
       >
-        <p style={{ fontSize: 14, color: 'var(--text-primary)', margin: 0, fontWeight: 600, lineHeight: 1.3 }}>
+        <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-primary)', margin: 0, fontWeight: 600, lineHeight: 1.3 }}>
           {signedUp ? t('skillDiscovery.titleSignedUp') : t('skillDiscovery.title')}
         </p>
-        <p style={{ fontSize: 13, color: 'var(--accent, #22c55e)', margin: '2px 0 0', fontWeight: 600 }}>
+        <p style={{ fontSize: 'var(--fs-base)', color: 'var(--accent, #22c55e)', margin: '2px 0 0', fontWeight: 600 }}>
           {t('skillDiscovery.cta')} →
         </p>
       </button>
@@ -78,7 +78,7 @@ export default function SkillDiscoveryCard({
         className="flex items-center justify-center rounded-full"
         style={{ width: 28, height: 28, background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)', flexShrink: 0 }}
       >
-        <span className="material-icons" style={{ fontSize: 16, color: 'var(--text-muted)' }}>close</span>
+        <span className="material-icons" style={{ fontSize: 'var(--fs-lg)', color: 'var(--text-muted)' }}>close</span>
       </button>
     </div>
   );

--- a/components/home/SkillDiscoveryCard.tsx
+++ b/components/home/SkillDiscoveryCard.tsx
@@ -56,7 +56,7 @@ export default function SkillDiscoveryCard({
 
   return (
     <div className="glass-card p-4" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-      <span className="material-icons" aria-hidden="true" style={{ fontSize: 24, color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
+      <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-lg)', color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
         trending_up
       </span>
       <button

--- a/components/primitives/CardHeader.tsx
+++ b/components/primitives/CardHeader.tsx
@@ -18,10 +18,10 @@ import type { ReactNode } from 'react';
  * Replaces e.g.:
  *
  *   <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
- *     <span className="material-icons" style={{ fontSize: 22 }}>trending_up</span>
+ *     <span className="material-icons" style={{ fontSize: 'var(--fs-stat-lg)' }}>trending_up</span>
  *     <div>
  *       <h3 className="bpm-h3 m-0">{title}</h3>
- *       <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, marginTop: 2 }}>{sub}</p>
+ *       <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: 0, marginTop: 2 }}>{sub}</p>
  *     </div>
  *   </div>
  *
@@ -60,7 +60,7 @@ export default function CardHeader({
         <span
           className="material-icons"
           aria-hidden="true"
-          style={{ fontSize: 22, color: iconColor, ...(subtitle ? { marginTop: 1 } : null) }}
+          style={{ fontSize: 'var(--fs-stat-lg)', color: iconColor, ...(subtitle ? { marginTop: 1 } : null) }}
         >
           {icon}
         </span>

--- a/components/primitives/ConfirmInline.tsx
+++ b/components/primitives/ConfirmInline.tsx
@@ -4,7 +4,7 @@
  * twice (active row + waitlist row) with subtly different styling
  * each time:
  *
- *   <div className="flex items-center gap-2 text-xs">
+ *   <div className="flex items-center gap-2 fs-sm">
  *     <span className="text-gray-400">{message}</span>
  *     <button onClick={onYes} className="text-red-400 …">{yesLabel}</button>
  *     <button onClick={onNo} className="text-gray-400 …">{noLabel}</button>
@@ -40,7 +40,7 @@ export default function ConfirmInline({
       ? 'text-red-400 hover:text-red-300'
       : 'text-green-400 hover:text-green-300';
   return (
-    <div className="flex items-center gap-2 text-xs">
+    <div className="flex items-center gap-2 fs-sm">
       <span className="text-gray-400">{message}</span>
       <button
         type="button"

--- a/components/primitives/EmptyState.tsx
+++ b/components/primitives/EmptyState.tsx
@@ -4,10 +4,10 @@ import type { ReactNode } from 'react';
  * Empty-state copy — the muted "nothing here yet" line shown when a card
  * loaded successfully but has no data (distinct from <ErrorState>, which is
  * a load failure). Standardizes the recurring inline
- * `{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }` text on the
+ * `{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: 0 }` text on the
  * `--fs-base` token.
  *
- * Replaces:  <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>{msg}</p>
+ * Replaces:  <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: 0 }}>{msg}</p>
  * With:      <EmptyState>{msg}</EmptyState>
  */
 export interface EmptyStateProps {

--- a/components/primitives/ErrorState.tsx
+++ b/components/primitives/ErrorState.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
  * across stats/admin cards (the "legible-fail" rule: a failed fetch must NOT
  * render as a confident empty state). One place to restyle the error tone.
  *
- * Replaces:  <p className="text-red-400 text-xs" role="alert">{msg}</p>
+ * Replaces:  <p className="field-error" role="alert">{msg}</p>
  * With:      <ErrorState message={msg} />
  */
 export interface ErrorStateProps {
@@ -15,7 +15,7 @@ export interface ErrorStateProps {
 
 export default function ErrorState({ message }: ErrorStateProps) {
   return (
-    <p className="text-red-400 text-xs" role="alert" style={{ margin: 0 }}>
+    <p className="field-error" role="alert" style={{ margin: 0 }}>
       {message}
     </p>
   );

--- a/components/primitives/StatusBadge.tsx
+++ b/components/primitives/StatusBadge.tsx
@@ -36,7 +36,7 @@ const BASE: CSSProperties = {
 export default function StatusBadge({ children, variant = 'accent', tone = 'accent' }: StatusBadgeProps) {
   let style: CSSProperties;
   if (variant === 'muted') {
-    style = { ...BASE, fontSize: 9, padding: '2px 7px', border: '1px solid var(--inner-card-border)', color: 'var(--text-muted)' };
+    style = { ...BASE, fontSize: 'var(--fs-2xs)', padding: '2px 7px', border: '1px solid var(--inner-card-border)', color: 'var(--text-muted)' };
   } else if (variant === 'phase') {
     const c = tone === 'amber' ? 'var(--accent-amber)' : 'var(--accent)';
     style = { ...BASE, fontSize: 'var(--fs-xs)', padding: '3px 10px', border: `1px solid ${c}`, color: c };

--- a/components/primitives/StatusBanner.tsx
+++ b/components/primitives/StatusBanner.tsx
@@ -12,8 +12,8 @@ import type { ReactNode } from 'react';
  *   <div className="status-banner-orange">
  *     <span className="material-icons icon-status text-amber-400">{icon}</span>
  *     <div>
- *       <p className="font-semibold text-amber-300 text-sm">{title}</p>
- *       <p className="text-xs text-gray-400 mt-0.5">{body}</p>
+ *       <p className="font-semibold text-amber-300 fs-md">{title}</p>
+ *       <p className="fs-sm text-gray-400 mt-0.5">{body}</p>
  *     </div>
  *   </div>
  *
@@ -65,8 +65,8 @@ export default function StatusBanner({ tone, icon, title, body, celebrate }: Sta
         {icon}
       </span>
       <div>
-        <p className={`font-semibold text-sm ${TITLE_TONE_CLASS[tone]}`}>{title}</p>
-        {body && <p className="text-xs text-gray-400 mt-0.5">{body}</p>}
+        <p className={`font-semibold fs-md ${TITLE_TONE_CLASS[tone]}`}>{title}</p>
+        {body && <p className="fs-sm text-gray-400 mt-0.5">{body}</p>}
       </div>
     </div>
   );

--- a/components/stats/CheckInSheet.tsx
+++ b/components/stats/CheckInSheet.tsx
@@ -146,9 +146,9 @@ export default function CheckInSheet({
           {skill && (
             <div style={{ marginTop: 12 }}>
               <div className="cc-progress-track" style={{ height: 4, borderRadius: 'var(--radius-pill)', overflow: 'hidden' }}>
-                <div style={{ width: `${((step + 1) / total) * 100}%`, height: '100%', background: 'var(--accent)', transition: 'width 180ms var(--ease-out-quart, ease-out)' }} />
+                <div style={{ width: `${((step + 1) / total) * 100}%`, height: '100%', background: 'var(--accent)', transition: 'width 180ms var(--ease-out-quart)' }} />
               </div>
-              <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: '6px 0 0' }}>{t('assess.step', { n: step + 1, total })}</p>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: '6px 0 0' }}>{t('assess.step', { n: step + 1, total })}</p>
             </div>
           )}
         </BottomSheetHeader>
@@ -159,7 +159,7 @@ export default function CheckInSheet({
             <div className="space-y-4">
               {mirror && mirror.played > 0 ? (
                 <div className="p-4 rounded-xl" style={{ background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)' }}>
-                  <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>{t('assess.mirrorTitle')}</p>
+                  <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>{t('assess.mirrorTitle')}</p>
                   <p style={{ fontSize: 15, color: 'var(--text-primary)', margin: '6px 0 0', lineHeight: 1.4 }}>
                     {t('assess.mirrorRecord', { won: mirror.won, played: mirror.played })}
                     {mirror.topPartner ? ` ${t('assess.mirrorPartner', { name: mirror.topPartner })}` : ''}
@@ -168,7 +168,7 @@ export default function CheckInSheet({
               ) : (
                 <EmptyState>{t('assess.noGames')}</EmptyState>
               )}
-              <p style={{ fontSize: 14, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>{t('assess.ratePrompt')}</p>
+              <p style={{ fontSize: 'var(--fs-md)', color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>{t('assess.ratePrompt')}</p>
               <button type="button" onClick={() => setStep(0)} className="cc-btn cc-btn-primary cc-btn-lg" style={{ width: '100%' }}>
                 {t('assess.start')}
               </button>
@@ -179,7 +179,7 @@ export default function CheckInSheet({
           {skill && (
             <div className="space-y-3">
               <div>
-                <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+                <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>
                   {t(`assess.dim.${skill.dimension}`)}
                 </p>
                 <h3 className="bpm-h3 m-0" style={{ marginTop: 2 }}>{skill.label}</h3>
@@ -202,10 +202,10 @@ export default function CheckInSheet({
                     }}
                   >
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
-                      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 13, fontWeight: 700, color: isActive ? 'var(--accent)' : 'var(--text-muted)' }}>{level}</span>
+                      <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-base)', fontWeight: 700, color: isActive ? 'var(--accent)' : 'var(--text-muted)' }}>{level}</span>
                       {isActive && <span className="material-icons" aria-hidden="true" style={{ fontSize: 15, color: 'var(--accent)' }}>check_circle</span>}
                     </div>
-                    <p style={{ fontSize: 13, lineHeight: 1.45, color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)', margin: 0 }}>{anchor}</p>
+                    <p style={{ fontSize: 'var(--fs-base)', lineHeight: 1.45, color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)', margin: 0 }}>{anchor}</p>
                   </button>
                 );
               })}

--- a/components/stats/CheckInSheet.tsx
+++ b/components/stats/CheckInSheet.tsx
@@ -139,7 +139,7 @@ export default function CheckInSheet({
               className="flex items-center justify-center rounded-full"
               style={{ width: 32, height: 32, background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)' }}
             >
-              <span className="material-icons" style={{ fontSize: 18, color: 'var(--text-muted)' }}>close</span>
+              <span className="material-icons" style={{ fontSize: 'var(--icon-md)', color: 'var(--text-muted)' }}>close</span>
             </button>
           </div>
           {/* Progress track — only during the quiz steps. */}
@@ -160,7 +160,7 @@ export default function CheckInSheet({
               {mirror && mirror.played > 0 ? (
                 <div className="p-4 rounded-xl" style={{ background: 'var(--inner-card-bg)', border: '1px solid var(--inner-card-border)' }}>
                   <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>{t('assess.mirrorTitle')}</p>
-                  <p style={{ fontSize: 15, color: 'var(--text-primary)', margin: '6px 0 0', lineHeight: 1.4 }}>
+                  <p style={{ fontSize: 'var(--fs-lg)', color: 'var(--text-primary)', margin: '6px 0 0', lineHeight: 1.4 }}>
                     {t('assess.mirrorRecord', { won: mirror.won, played: mirror.played })}
                     {mirror.topPartner ? ` ${t('assess.mirrorPartner', { name: mirror.topPartner })}` : ''}
                   </p>
@@ -203,7 +203,7 @@ export default function CheckInSheet({
                   >
                     <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
                       <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-base)', fontWeight: 700, color: isActive ? 'var(--accent)' : 'var(--text-muted)' }}>{level}</span>
-                      {isActive && <span className="material-icons" aria-hidden="true" style={{ fontSize: 15, color: 'var(--accent)' }}>check_circle</span>}
+                      {isActive && <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-sm)', color: 'var(--accent)' }}>check_circle</span>}
                     </div>
                     <p style={{ fontSize: 'var(--fs-base)', lineHeight: 1.45, color: isActive ? 'var(--text-primary)' : 'var(--text-secondary)', margin: 0 }}>{anchor}</p>
                   </button>
@@ -223,7 +223,7 @@ export default function CheckInSheet({
           {/* Review + save */}
           {step === total && (
             <div className="space-y-4">
-              <p style={{ fontSize: 15, color: 'var(--text-primary)', margin: 0, lineHeight: 1.4 }}>{t('assess.reviewCount', { rated: ratedCount, total })}</p>
+              <p style={{ fontSize: 'var(--fs-lg)', color: 'var(--text-primary)', margin: 0, lineHeight: 1.4 }}>{t('assess.reviewCount', { rated: ratedCount, total })}</p>
               <EmptyState>{t('assess.reviewPrompt')}</EmptyState>
               {error && <ErrorState message={error} />}
               <div style={{ display: 'flex', gap: 10 }}>

--- a/components/stats/DrillsCard.tsx
+++ b/components/stats/DrillsCard.tsx
@@ -103,13 +103,13 @@ export default function DrillsCard() {
         {state.drills.map((d) => (
           <li key={d.id} style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
             <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 8 }}>
-              <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>{d.title}</span>
-              <span style={{ fontSize: 11, color: 'var(--text-muted)', whiteSpace: 'nowrap', fontFamily: 'var(--font-mono)' }}>
+              <span style={{ fontSize: 'var(--fs-md)', fontWeight: 600, color: 'var(--text-primary)' }}>{d.title}</span>
+              <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', whiteSpace: 'nowrap', fontFamily: 'var(--font-mono)' }}>
                 {t('drills.minutes', { n: d.minutes })} · {t(`drills.setting.${d.setting}`)}
               </span>
             </div>
-            <span style={{ fontSize: 12, lineHeight: 1.45, color: 'var(--text-secondary)' }}>{d.description}</span>
-            <span style={{ fontSize: 11, color: 'var(--text-muted)', fontStyle: 'italic' }}>{d.reason}</span>
+            <span style={{ fontSize: 'var(--fs-sm)', lineHeight: 1.45, color: 'var(--text-secondary)' }}>{d.description}</span>
+            <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', fontStyle: 'italic' }}>{d.reason}</span>
           </li>
         ))}
       </ul>

--- a/components/stats/GameLoggerCard.tsx
+++ b/components/stats/GameLoggerCard.tsx
@@ -74,7 +74,7 @@ export default function GameLoggerCard() {
   if (status === 'error') {
     return (
       <div className="glass-card p-5">
-        <p className="text-xs" role="alert" style={{ color: 'var(--text-muted)', margin: 0, lineHeight: 1.4 }}>
+        <p className="fs-sm" role="alert" style={{ color: 'var(--text-muted)', margin: 0, lineHeight: 1.4 }}>
           {t('logGameError')}
         </p>
       </div>

--- a/components/stats/GameLoggerSheet.tsx
+++ b/components/stats/GameLoggerSheet.tsx
@@ -69,28 +69,28 @@ export default function GameLoggerSheet({ you, sessionId, open, onClose, onLogge
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={t('logGameTitle')} maxHeight="80vh" className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('logGameTitle')}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{t('logGameTitle')}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={tRecovery('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
         {done ? (
-          <p style={{ textAlign: 'center', fontSize: 16, color: 'var(--text-primary)' }}>{t('logGameThanks')}</p>
+          <p style={{ textAlign: 'center', fontSize: 'var(--fs-lg)', color: 'var(--text-primary)' }}>{t('logGameThanks')}</p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>{t('logGameHint')}</p>
+            <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', margin: 0 }}>{t('logGameHint')}</p>
             <div>
-              <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('partner')}</p>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('partner')}</p>
               <input type="text" aria-label={t('partner')} value={partner} onChange={(e) => setPartner(e.target.value)} maxLength={50} />
             </div>
             <div>
-              <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('opponents')}</p>
+              <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('opponents')}</p>
               <div style={{ display: 'flex', gap: 8 }}>
                 <input type="text" aria-label={`${t('opponents')} 1`} value={opp1} onChange={(e) => setOpp1(e.target.value)} maxLength={50} style={{ flex: 1 }} />
                 <input type="text" aria-label={`${t('opponents')} 2`} value={opp2} onChange={(e) => setOpp2(e.target.value)} maxLength={50} style={{ flex: 1 }} />
@@ -98,11 +98,11 @@ export default function GameLoggerSheet({ you, sessionId, open, onClose, onLogge
             </div>
             <div style={{ display: 'flex', gap: 8 }}>
               <div style={{ flex: 1 }}>
-                <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('yourScore')}</p>
+                <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('yourScore')}</p>
                 <input inputMode="numeric" aria-label={t('yourScore')} value={scoreA} onChange={(e) => setScoreA(onlyDigits(e.target.value))} />
               </div>
               <div style={{ flex: 1 }}>
-                <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('theirScore')}</p>
+                <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: '0 0 4px' }}>{t('theirScore')}</p>
                 <input inputMode="numeric" aria-label={t('theirScore')} value={scoreB} onChange={(e) => setScoreB(onlyDigits(e.target.value))} />
               </div>
             </div>

--- a/components/stats/GearSheet.tsx
+++ b/components/stats/GearSheet.tsx
@@ -71,24 +71,24 @@ export default function GearSheet({ name, open, onClose, onSaved }: Props) {
   return (
     <BottomSheet open={open} onClose={onClose} ariaLabel={t('racketSheetTitle')} maxHeight="75vh" className="max-w-lg mx-auto">
       <BottomSheetHeader className="flex items-center justify-between p-4">
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{t('racketSheetTitle')}</span>
+        <span style={{ fontSize: 'var(--fs-lg)', fontWeight: 600 }}>{t('racketSheetTitle')}</span>
         <button
           type="button"
           onClick={onClose}
           aria-label={tRecovery('close')}
           style={{ background: 'transparent', border: 'none', cursor: 'pointer', minWidth: 44, minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
         >
-          <span className="material-icons" style={{ fontSize: 20 }}>close</span>
+          <span className="material-icons" style={{ fontSize: 'var(--fs-stat)' }}>close</span>
         </button>
       </BottomSheetHeader>
       <BottomSheetBody className="p-5 pb-8">
         {savedLabel ? (
-          <p style={{ textAlign: 'center', fontSize: 16, color: 'var(--text-primary)' }}>
+          <p style={{ textAlign: 'center', fontSize: 'var(--fs-lg)', color: 'var(--text-primary)' }}>
             {t('gearSaved')} {savedLabel}
           </p>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <p style={{ fontSize: 13, color: 'var(--text-secondary)', margin: 0 }}>{t('racketSheetHint')}</p>
+            <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-secondary)', margin: 0 }}>{t('racketSheetHint')}</p>
             <input
               type="text"
               aria-label={t('racketSheetTitle')}

--- a/components/stats/GiveKudosCard.tsx
+++ b/components/stats/GiveKudosCard.tsx
@@ -105,12 +105,12 @@ export default function GiveKudosCard() {
     <div className="glass-card p-5 space-y-3">
       <CardHeader icon="volunteer_activism" title={t('kudos.giveTitle')} subtitle={t('kudos.giveHint')} />
       {!online && (
-        <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>{t('kudos.offline')}</p>
+        <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: 0 }}>{t('kudos.offline')}</p>
       )}
       <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 12 }}>
         {coPlayers.map((name) => (
           <li key={name} style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>{name}</span>
+            <span style={{ fontSize: 'var(--fs-md)', fontWeight: 600, color: 'var(--text-primary)' }}>{name}</span>
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
               {KUDOS_TAGS.map((tag) => {
                 const st = status[`${name}:${tag}`];
@@ -124,7 +124,7 @@ export default function GiveKudosCard() {
                     aria-pressed={sent}
                     className="cc-btn cc-btn-ghost"
                     style={{
-                      fontSize: 12, padding: '4px 10px',
+                      fontSize: 'var(--fs-sm)', padding: '4px 10px',
                       opacity: sent ? 0.55 : 1,
                       borderColor: sent ? 'var(--accent)' : undefined,
                       color: sent ? 'var(--accent)' : undefined,

--- a/components/stats/InsightChip.tsx
+++ b/components/stats/InsightChip.tsx
@@ -41,8 +41,8 @@ export default function InsightChip({ headline, support, kind }: CardSlice) {
         {icon}
       </span>
       <div style={{ minWidth: 0, flex: 1 }}>
-        <p style={{ margin: 0, fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1.35 }}>{headline}</p>
-        {support && <p style={{ margin: '2px 0 0', fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.4 }}>{support}</p>}
+        <p style={{ margin: 0, fontSize: 'var(--fs-base)', fontWeight: 600, color: 'var(--text-primary)', lineHeight: 1.35 }}>{headline}</p>
+        {support && <p style={{ margin: '2px 0 0', fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', lineHeight: 1.4 }}>{support}</p>}
       </div>
       <span
         aria-label="AI generated"

--- a/components/stats/InsightChip.tsx
+++ b/components/stats/InsightChip.tsx
@@ -37,7 +37,7 @@ export default function InsightChip({ headline, support, kind }: CardSlice) {
         border: '1px solid var(--inner-card-border)',
       }}
     >
-      <span className="material-icons" aria-hidden="true" style={{ fontSize: 18, color: ACCENT, marginTop: 1, flexShrink: 0 }}>
+      <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-md)', color: ACCENT, marginTop: 1, flexShrink: 0 }}>
         {icon}
       </span>
       <div style={{ minWidth: 0, flex: 1 }}>
@@ -48,7 +48,7 @@ export default function InsightChip({ headline, support, kind }: CardSlice) {
         aria-label="AI generated"
         title="AI generated"
         style={{
-          fontSize: 9,
+          fontSize: 'var(--fs-2xs)',
           padding: '2px 6px',
           borderRadius: 'var(--radius-pill)',
           whiteSpace: 'nowrap',

--- a/components/stats/KudosReceivedCard.tsx
+++ b/components/stats/KudosReceivedCard.tsx
@@ -93,7 +93,7 @@ export default function KudosReceivedCard() {
           return (
             <li key={tag} style={{
               display: 'flex', alignItems: 'center', gap: 6, padding: '6px 12px', borderRadius: 'var(--radius-pill)',
-              border: '1px solid var(--border, rgba(255,255,255,0.12))', fontSize: 13, color: 'var(--text-secondary)',
+              border: '1px solid var(--border))', fontSize: 'var(--fs-base)', color: 'var(--text-secondary)',
             }}>
               <span aria-hidden="true">{TAG_EMOJI[tag]}</span>
               <span>{t(`kudos.tag.${tag}`)}</span>

--- a/components/stats/LevelCard.tsx
+++ b/components/stats/LevelCard.tsx
@@ -121,7 +121,7 @@ export default function LevelCard() {
   if (level.level === null) {
     return (
       <Frame>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0 }}>
+        <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: 0 }}>
           {level.explanation[0] ?? t('level.empty')}
         </p>
       </Frame>
@@ -140,10 +140,10 @@ export default function LevelCard() {
           </StatusBadge>
         )}
         <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, marginLeft: 'auto' }}>
-          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 20, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>
+          <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-stat)', fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1 }}>
             {level.level.toFixed(1)}
           </span>
-          <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>{t('level.ofFive')}</span>
+          <span style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)' }}>{t('level.ofFive')}</span>
         </div>
       </div>
 
@@ -152,7 +152,7 @@ export default function LevelCard() {
           aria-hidden="true"
           style={{ width: 8, height: 8, borderRadius: 'var(--radius-pill)', background: CONF_COLOR[level.confidence], flexShrink: 0 }}
         />
-        <span style={{ fontSize: 11, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
+        <span style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
           {t(`level.confidence.${level.confidence}`)}
         </span>
       </div>
@@ -162,12 +162,12 @@ export default function LevelCard() {
       {level.pendingPromotion && (
         <p
           style={{
-            fontSize: 12, lineHeight: 1.45, margin: 0,
+            fontSize: 'var(--fs-sm)', lineHeight: 1.45, margin: 0,
             color: 'var(--accent-amber, #f59e0b)',
             display: 'flex', alignItems: 'center', gap: 6,
           }}
         >
-          <span className="material-icons" aria-hidden="true" style={{ fontSize: 16 }}>trending_up</span>
+          <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-lg)' }}>trending_up</span>
           {t('level.onTrack', { phase: t(`assess.phase.${level.pendingPromotion}`) })}
         </p>
       )}
@@ -187,7 +187,7 @@ export default function LevelCard() {
             {showCompare ? t('level.compare.hide') : t('level.compare.cta')}
           </button>
           {showCompare && (
-            <p style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--text-secondary)', margin: 0 }}>
+            <p style={{ fontSize: 'var(--fs-sm)', lineHeight: 1.5, color: 'var(--text-secondary)', margin: 0 }}>
               {t(`level.compare.${level.blindSpot.direction}`)}
             </p>
           )}
@@ -210,7 +210,7 @@ export default function LevelCard() {
           {showHow && (
             <ul style={{ margin: 0, paddingLeft: 18, display: 'flex', flexDirection: 'column', gap: 4 }}>
               {level.explanation.map((line, i) => (
-                <li key={i} style={{ fontSize: 12, lineHeight: 1.45, color: 'var(--text-secondary)' }}>{line}</li>
+                <li key={i} style={{ fontSize: 'var(--fs-sm)', lineHeight: 1.45, color: 'var(--text-secondary)' }}>{line}</li>
               ))}
             </ul>
           )}

--- a/components/stats/RacketRow.tsx
+++ b/components/stats/RacketRow.tsx
@@ -67,7 +67,7 @@ export default function RacketRow() {
           className="glass-card"
           style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 112, textAlign: 'left', cursor: 'pointer' }}
         >
-          <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('yourRacket')}</p>
+          <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: 0 }}>{t('yourRacket')}</p>
           {loadError ? (
             <span className="text-red-400 text-xs" role="alert">{t('recError')}</span>
           ) : !loaded ? (
@@ -75,7 +75,7 @@ export default function RacketRow() {
           ) : racketLabel ? (
             <span style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, lineHeight: 1.25 }}>{racketLabel}</span>
           ) : (
-            <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>{t('noRacketYet')}</span>
+            <span style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)' }}>{t('noRacketYet')}</span>
           )}
         </button>
 

--- a/components/stats/RacketRow.tsx
+++ b/components/stats/RacketRow.tsx
@@ -73,7 +73,7 @@ export default function RacketRow() {
           ) : !loaded ? (
             <span className="shimmer-line rounded-lg" style={{ height: 15, width: '70%' }} aria-hidden="true" />
           ) : racketLabel ? (
-            <span style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, lineHeight: 1.25 }}>{racketLabel}</span>
+            <span style={{ fontFamily: 'var(--font-display)', fontSize: 'var(--fs-lg)', fontWeight: 600, lineHeight: 1.25 }}>{racketLabel}</span>
           ) : (
             <span style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)' }}>{t('noRacketYet')}</span>
           )}

--- a/components/stats/RacketRow.tsx
+++ b/components/stats/RacketRow.tsx
@@ -69,7 +69,7 @@ export default function RacketRow() {
         >
           <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: 0 }}>{t('yourRacket')}</p>
           {loadError ? (
-            <span className="text-red-400 text-xs" role="alert">{t('recError')}</span>
+            <span className="field-error" role="alert">{t('recError')}</span>
           ) : !loaded ? (
             <span className="shimmer-line rounded-lg" style={{ height: 15, width: '70%' }} aria-hidden="true" />
           ) : racketLabel ? (

--- a/components/stats/StatsPlaceholder.tsx
+++ b/components/stats/StatsPlaceholder.tsx
@@ -37,7 +37,7 @@ function CompactComingSoonCard({ icon, title, subtitle, comingSoon }: CompactCar
         <StatusBadge variant="muted">{comingSoon}</StatusBadge>
       </div>
       <h3
-        className="text-xs font-semibold m-0"
+        className="fs-sm font-semibold m-0"
         style={{ color: 'var(--text-primary)', lineHeight: 1.25 }}
       >
         {title}
@@ -238,7 +238,7 @@ export default function StatsPlaceholder({
           short wrapper would un-stick it). Subhead is a sibling pinned tight
           to the title via inline marginTop (beats the space-y-5 gap). */}
       <PageHeader>{t('heading')}</PageHeader>
-      <p className="text-sm text-gray-400 px-2" style={{ marginTop: 4 }}>{t('subhead')}</p>
+      <p className="fs-md text-gray-400 px-2" style={{ marginTop: 4 }}>{t('subhead')}</p>
 
       {useTabs && (
         <div className="flex justify-center">
@@ -248,7 +248,7 @@ export default function StatsPlaceholder({
                 key={tab.id}
                 type="button"
                 onClick={() => setView(tab.id)}
-                className={`flex-1 flex items-center justify-center text-xs transition-all ${
+                className={`flex-1 flex items-center justify-center fs-sm transition-all ${
                   view === tab.id ? 'segment-tab-active' : 'segment-tab-inactive'
                 }`}
               >

--- a/components/stats/StatsPlaceholder.tsx
+++ b/components/stats/StatsPlaceholder.tsx
@@ -30,7 +30,7 @@ function CompactComingSoonCard({ icon, title, subtitle, comingSoon }: CompactCar
         <span
           className="material-icons"
           aria-hidden="true"
-          style={{ fontSize: 20, color: 'var(--accent, #22c55e)' }}
+          style={{ fontSize: 'var(--fs-stat)', color: 'var(--accent, #22c55e)' }}
         >
           {icon}
         </span>
@@ -42,7 +42,7 @@ function CompactComingSoonCard({ icon, title, subtitle, comingSoon }: CompactCar
       >
         {title}
       </h3>
-      <p style={{ fontSize: 11, color: 'var(--text-muted)', margin: 0, lineHeight: 1.35 }}>{subtitle}</p>
+      <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-muted)', margin: 0, lineHeight: 1.35 }}>{subtitle}</p>
     </div>
   );
 }
@@ -96,7 +96,7 @@ interface Props {
 }
 
 const sectionLabelStyle: React.CSSProperties = {
-  fontSize: 10,
+  fontSize: 'var(--fs-2xs)',
   letterSpacing: '0.08em',
   color: 'var(--text-muted)',
   textTransform: 'none',

--- a/components/stats/StatsSignedOut.tsx
+++ b/components/stats/StatsSignedOut.tsx
@@ -30,7 +30,7 @@ export default function StatsSignedOut({ onSignIn }: { onSignIn?: () => void }) 
         <p style={{ fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', margin: 0 }}>
           {t('assess.signedOutTitle')}
         </p>
-        <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: 0, maxWidth: 280, lineHeight: 1.5 }}>
+        <p style={{ fontSize: 'var(--fs-base)', color: 'var(--text-muted)', margin: 0, maxWidth: 280, lineHeight: 1.5 }}>
           {t('assess.signedOutBody')}
         </p>
         {onSignIn && (

--- a/components/stats/StatsSignedOut.tsx
+++ b/components/stats/StatsSignedOut.tsx
@@ -24,7 +24,7 @@ export default function StatsSignedOut({ onSignIn }: { onSignIn?: () => void }) 
           gap: 12,
         }}
       >
-        <span className="material-icons" aria-hidden="true" style={{ fontSize: 40, color: 'var(--text-muted)', opacity: 0.7 }}>
+        <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--icon-xl)', color: 'var(--text-muted)', opacity: 0.7 }}>
           trending_up
         </span>
         <p style={{ fontFamily: 'var(--font-display)', fontSize: 18, fontWeight: 600, color: 'var(--text-primary)', margin: 0 }}>

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -145,18 +145,18 @@ export default function StreakSummaryCard() {
               display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
             }}
           >
-            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 22, fontWeight: 700, color: onPersonalBest ? 'white' : ACCENT, lineHeight: 1 }}>
+            <span style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--fs-stat-lg)', fontWeight: 700, color: onPersonalBest ? 'white' : ACCENT, lineHeight: 1 }}>
               {streak}
             </span>
           </div>
           <div style={{ minWidth: 0, flex: 1 }}>
-            <p style={{ margin: 0, fontSize: 11, color: MUTED, fontWeight: 500, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+            <p style={{ margin: 0, fontSize: 'var(--fs-xs)', color: MUTED, fontWeight: 500, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
               {onPersonalBest ? `${name} — Personal Best` : `${name}'s Streak`}
             </p>
-            <p style={{ margin: 0, fontSize: 16, fontWeight: 600, color: PRIMARY, lineHeight: 1.25, marginTop: 2 }}>
+            <p style={{ margin: 0, fontSize: 'var(--fs-lg)', fontWeight: 600, color: PRIMARY, lineHeight: 1.25, marginTop: 2 }}>
               {streak === 1 ? "You're on a 1-week streak" : `You're on a ${streak}-week streak`}
             </p>
-            <p style={{ margin: 0, fontSize: 12, color: MUTED, marginTop: 2 }}>
+            <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED, marginTop: 2 }}>
               {onPersonalBest
                 ? `Tied or beating your longest run of ${longestStreak}.`
                 : `Longest run: ${longestStreak} week${longestStreak === 1 ? '' : 's'}. Keep showing up.`}
@@ -174,7 +174,7 @@ export default function StreakSummaryCard() {
             <div aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               <div className="animate-pulse" style={{ height: 12, borderRadius: 'var(--radius-xs)', background: 'var(--inner-card-bg)', width: '90%' }} />
               <div className="animate-pulse" style={{ height: 12, borderRadius: 'var(--radius-xs)', background: 'var(--inner-card-bg)', width: '70%' }} />
-              <p style={{ margin: 0, fontSize: 11, color: MUTED }}>Reading the dots…</p>
+              <p style={{ margin: 0, fontSize: 'var(--fs-xs)', color: MUTED }}>Reading the dots…</p>
             </div>
           ) : hasInsight ? (
             <div className="animate-fadeIn" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -182,7 +182,7 @@ export default function StreakSummaryCard() {
               {insight?.focus && <InsightSection label="This week · Focus" body={insight.focus} accent />}
             </div>
           ) : (
-            <p role="alert" style={{ margin: 0, fontSize: 12, color: MUTED }}>
+            <p role="alert" style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED }}>
               Couldn’t load your read — refresh to retry.
             </p>
           )}
@@ -195,7 +195,7 @@ export default function StreakSummaryCard() {
 function InsightSection({ label, body, accent }: { label: string; body: string; accent?: boolean }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <p style={{ margin: 0, fontSize: 10, fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: accent ? ACCENT : MUTED }}>
+      <p style={{ margin: 0, fontSize: 'var(--fs-2xs)', fontWeight: 700, letterSpacing: '0.08em', textTransform: 'uppercase', color: accent ? ACCENT : MUTED }}>
         {label}
       </p>
       <p style={{ margin: 0, fontSize: 'var(--fs-md)', lineHeight: 1.5, color: PRIMARY }}>{body}</p>

--- a/components/stats/SummaryGreeting.tsx
+++ b/components/stats/SummaryGreeting.tsx
@@ -23,13 +23,13 @@ export default function SummaryGreeting() {
       style={{ padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 12 }}
       aria-label="Your AI summary"
     >
-      <span className="material-icons" aria-hidden="true" style={{ fontSize: 22, color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
+      <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat-lg)', color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
         auto_fix_high
       </span>
       <p style={{ margin: 0, fontSize: 15, lineHeight: 1.45, color: 'var(--text-primary)', flex: 1, minWidth: 0 }}>{greeting}</p>
       <span
         style={{
-          fontSize: 10,
+          fontSize: 'var(--fs-2xs)',
           padding: '3px 8px',
           borderRadius: 'var(--radius-pill)',
           whiteSpace: 'nowrap',

--- a/components/stats/SummaryGreeting.tsx
+++ b/components/stats/SummaryGreeting.tsx
@@ -26,7 +26,7 @@ export default function SummaryGreeting() {
       <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat-lg)', color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
         auto_fix_high
       </span>
-      <p style={{ margin: 0, fontSize: 15, lineHeight: 1.45, color: 'var(--text-primary)', flex: 1, minWidth: 0 }}>{greeting}</p>
+      <p style={{ margin: 0, fontSize: 'var(--fs-lg)', lineHeight: 1.45, color: 'var(--text-primary)', flex: 1, minWidth: 0 }}>{greeting}</p>
       <span
         style={{
           fontSize: 'var(--fs-2xs)',

--- a/components/stats/cards/AttendanceCardLive.tsx
+++ b/components/stats/cards/AttendanceCardLive.tsx
@@ -98,10 +98,10 @@ export default function AttendanceCardLive() {
   if (!activeName) {
     return (
       <div style={{ display: 'grid', gap: 10 }}>
-        <p style={{ margin: 0, fontSize: 13, color: PRIMARY, fontWeight: 600 }}>
+        <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: PRIMARY, fontWeight: 600 }}>
           Your stats
         </p>
-        <p style={{ margin: 0, fontSize: 12, color: MUTED, lineHeight: 1.45 }}>
+        <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED, lineHeight: 1.45 }}>
           Sign in or create an account to see your personalized stats.
         </p>
       </div>
@@ -111,7 +111,7 @@ export default function AttendanceCardLive() {
   if (loading && !data) return <LoadingStrip weeks={weeks} />;
   if (!data) {
     return (
-      <p style={{ margin: 0, fontSize: 12, color: MUTED }} role="alert">
+      <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED }} role="alert">
         Couldn’t load that — refresh to try again.
       </p>
     );
@@ -129,16 +129,16 @@ export default function AttendanceCardLive() {
   return (
     <div style={{ display: 'grid', gap: 10 }}>
       <div style={{ display: 'flex', gap: 14, alignItems: 'baseline', justifyContent: 'space-between', flexWrap: 'wrap' }}>
-        <p style={{ margin: 0, fontSize: 12, color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
+        <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
           Your recent form
         </p>
         {isPreviewPick && (
-          <span style={{ fontSize: 11, color: MUTED }}>
+          <span style={{ fontSize: 'var(--fs-xs)', color: MUTED }}>
             viewing as <strong style={{ color: PRIMARY }}>{activeName}</strong>{' '}
             <button
               type="button"
               onClick={clearPickedName}
-              style={{ background: 'transparent', border: 'none', color: ACCENT, cursor: 'pointer', padding: 0, fontSize: 11 }}
+              style={{ background: 'transparent', border: 'none', color: ACCENT, cursor: 'pointer', padding: 0, fontSize: 'var(--fs-xs)' }}
             >
               change
             </button>
@@ -147,7 +147,7 @@ export default function AttendanceCardLive() {
       </div>
       <AttendanceSessionStrip history={data.history} limit={RECENT} />
       {recent.length > 0 && (
-        <p style={{ margin: 0, fontSize: 13, color: PRIMARY }}>
+        <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: PRIMARY }}>
           <strong>{recentAttended}</strong> of your last {recent.length}
           {streak >= 2 ? <span style={{ color: MUTED }}> · {streak}-session streak</span> : null}
         </p>

--- a/components/stats/cards/AttendanceSessionStrip.tsx
+++ b/components/stats/cards/AttendanceSessionStrip.tsx
@@ -45,7 +45,7 @@ export default function AttendanceSessionStrip({ history, limit = 8 }: Props) {
 
   if (sessions.length === 0) {
     return (
-      <p style={{ margin: 0, fontSize: 12, color: MUTED }}>
+      <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED }}>
         No sessions in this window yet.
       </p>
     );

--- a/components/stats/cards/PartnerFrequencyCard.tsx
+++ b/components/stats/cards/PartnerFrequencyCard.tsx
@@ -99,7 +99,7 @@ export default function PartnerFrequencyCard() {
                     fontWeight: 600,
                     fontSize: 19,
                     flexShrink: 0,
-                    border: '1px solid rgba(255,255,255,0.10)',
+                    border: '1px solid rgba(var(--glass-tint), 0.10)',
                   }}
                 >
                   {top.name.slice(0, 1).toUpperCase()}

--- a/components/stats/cards/PartnerFrequencyCard.tsx
+++ b/components/stats/cards/PartnerFrequencyCard.tsx
@@ -109,7 +109,7 @@ export default function PartnerFrequencyCard() {
                   <p style={{ margin: 0, fontSize: 19, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.2 }}>
                     {top.name}
                   </p>
-                  <p style={{ margin: 0, fontSize: 12.5, color: 'var(--text-secondary)' }}>
+                  <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: 'var(--text-secondary)' }}>
                     {t('partnersTogether', { count: top.count })}
                   </p>
                 </div>
@@ -117,7 +117,7 @@ export default function PartnerFrequencyCard() {
             );
           })()}
           {partners.length > 1 && (
-            <p style={{ margin: 0, fontSize: 12.5, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+            <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: 'var(--text-muted)', lineHeight: 1.5 }}>
               {partners.slice(1).map((p) => `${p.name} ${p.count}`).join('  ·  ')}
             </p>
           )}

--- a/components/stats/cards/PartnerFrequencyCard.tsx
+++ b/components/stats/cards/PartnerFrequencyCard.tsx
@@ -73,7 +73,7 @@ export default function PartnerFrequencyCard() {
           </div>
         </div>
       ) : partners.length === 0 ? (
-        <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: 0 }}>{t('partnersEmpty')}</p>
+        <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: 0 }}>{t('partnersEmpty')}</p>
       ) : (
         // Hero the #1 partner — in doubles your most-frequent partner is the
         // meaningful relationship, so lead with "who you play most with" rather
@@ -105,7 +105,7 @@ export default function PartnerFrequencyCard() {
                   {top.name.slice(0, 1).toUpperCase()}
                 </span>
                 <div style={{ minWidth: 0 }}>
-                  <p style={{ margin: 0, fontSize: 12, color: 'var(--text-muted)' }}>{t('partnersMostWith')}</p>
+                  <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: 'var(--text-muted)' }}>{t('partnersMostWith')}</p>
                   <p style={{ margin: 0, fontSize: 19, fontWeight: 700, color: 'var(--text-primary)', lineHeight: 1.2 }}>
                     {top.name}
                   </p>

--- a/components/stats/cards/RacketRecCard.tsx
+++ b/components/stats/cards/RacketRecCard.tsx
@@ -32,7 +32,7 @@ export default function RacketRecCard({ name }: { name: string }) {
 
   return (
     <div className="glass-card" style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 4, minHeight: 112 }}>
-      <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0 }}>{t('weRecommend')}</p>
+      <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--text-secondary)', margin: 0 }}>{t('weRecommend')}</p>
       {loadError ? (
         <ErrorState message={t('recError')} />
       ) : !loaded ? (

--- a/components/stats/cards/RacketRecCard.tsx
+++ b/components/stats/cards/RacketRecCard.tsx
@@ -40,7 +40,7 @@ export default function RacketRecCard({ name }: { name: string }) {
       ) : !item ? (
         <EmptyState>{t('recEmpty')}</EmptyState>
       ) : (
-        <p style={{ fontFamily: 'var(--font-display)', fontSize: 15, fontWeight: 600, margin: 0, lineHeight: 1.25 }}>
+        <p style={{ fontFamily: 'var(--font-display)', fontSize: 'var(--fs-lg)', fontWeight: 600, margin: 0, lineHeight: 1.25 }}>
           {item.brand} {item.model}
         </p>
       )}

--- a/components/stats/skeletons/PartnerChips.tsx
+++ b/components/stats/skeletons/PartnerChips.tsx
@@ -16,10 +16,10 @@ export default function PartnerChips() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: 11,
+              fontSize: 'var(--fs-xs)',
               fontWeight: 600,
               letterSpacing: '0.02em',
-              border: '1.5px solid var(--bg-surface, #1a1a1a)',
+              border: '1.5px solid var(--bg-surface)',
               marginLeft: i === 0 ? 0 : -10,
             }}
           >

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,6 +35,15 @@ const EXTRA_TOKEN_SELECTORS = [
     message:
       'Bare rgba() literal — use a design token (var(--glass-border), --divider, --text-*, --sev-*, etc.) so the value is theme-aware.',
   },
+  {
+    // Bare Tailwind text-size classes (space/edge-delimited so responsive/state
+    // variants like `md:text-sm` and unrelated classes like `text-gray-300` are
+    // NOT matched). Steers to the design type-scale utilities. All bare uses were
+    // migrated in the audit, so this adds ~0 warnings today and just guards regressions.
+    selector: 'Literal[value=/(^|\\s)text-(xs|sm|base)(\\s|$)/]',
+    message:
+      'Raw Tailwind text-size class — use the design type-scale utility instead (text-xs→fs-sm, text-sm→fs-md, text-base→fs-lg).',
+  },
 ];
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -115,6 +124,20 @@ const config = [
     files: ['components/stats/**/*.{ts,tsx}'],
     rules: {
       'no-restricted-syntax': ['error', ...DESIGN_TOKEN_SELECTORS],
+    },
+  },
+  {
+    // Fully-swept areas (design-audit item #5). These have ZERO hex / raw radius /
+    // numeric fontSize / bare rgba / bare Tailwind text-size, so they graduate to
+    // ERROR on the FULL selector set — any re-introduced drift fails CI, locking in
+    // the cleanup. Add areas here as each reaches zero drift.
+    files: [
+      'components/primitives/**/*.{ts,tsx}',
+      'components/home/**/*.{ts,tsx}',
+      'components/BottomSheet/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-syntax': ['error', ...DESIGN_TOKEN_SELECTORS, ...EXTRA_TOKEN_SELECTORS],
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,27 @@ const DESIGN_TOKEN_SELECTORS = [
   },
 ];
 
+// Extended guardrail (design-audit P0). These cover the two largest UNGUARDED
+// drift categories from the audit: hand-typed numeric `fontSize` and bare
+// `rgba()` literals. Kept SEPARATE from DESIGN_TOKEN_SELECTORS and wired only
+// into the app-wide `warn` rule — NOT the per-area `error` overrides — because
+// there is still a backlog (odd sizes like 15/18/19 with no scale token, and
+// legitimate rgba in a few spots). Area sweeps tokenize these, after which the
+// area can graduate to `error` by switching to [...DESIGN_TOKEN_SELECTORS,
+// ...EXTRA_TOKEN_SELECTORS] in its override.
+const EXTRA_TOKEN_SELECTORS = [
+  {
+    selector: "Property[key.name='fontSize'] > Literal[raw=/^[0-9]/]",
+    message:
+      'Raw font-size — use the type scale token (var(--fs-2xs|xs|sm|base|md|lg|stat|stat-lg)) or a .fs-* utility class instead of a hand-typed pixel number.',
+  },
+  {
+    selector: 'Literal[value=/rgba\\(\\s*\\d/]',
+    message:
+      'Bare rgba() literal — use a design token (var(--glass-border), --divider, --text-*, --sev-*, etc.) so the value is theme-aware.',
+  },
+];
+
 /** @type {import('eslint').Linter.Config[]} */
 const config = [
   {
@@ -83,7 +104,7 @@ const config = [
     // flagged — the hex there is inside the var() string, not a bare literal.
     files: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}', 'lib/**/*.{ts,tsx}'],
     rules: {
-      'no-restricted-syntax': ['warn', ...DESIGN_TOKEN_SELECTORS],
+      'no-restricted-syntax': ['warn', ...DESIGN_TOKEN_SELECTORS, ...EXTRA_TOKEN_SELECTORS],
     },
   },
   {


### PR DESCRIPTION
## What & why

Cross-referenced the app against the `app/globals.css` design-system contract and closed the highest-value token/consistency drift. Every commit kept the gate green (`npm run lint && npm test && npm run build`): **0 lint errors · 1078 tests · build ok**.

> **Base note:** stacked on `test/birds-purchase-grouping` (PR #216) so this diff is **only** the 8 design commits. Retarget to `main` once #216 merges.

## Commits (8)

| Scope | Commit | Summary |
|---|---|---|
| P0–P2 | `3bb8920` | Define **10 phantom tokens** (incl. the live `--font-mono` defect where mono/data numbers were inheriting the sans body font) + light overrides; extend ESLint guardrail (numeric `fontSize` + bare `rgba()`); tokenize 293 exact-match inline `fontSize`; strip 51 dead hex fallbacks; pin the contract in `design-canary`. |
| #1 | `478c24e` | Adopt `.field-error` for the 32 sanctioned `text-red-400 text-xs` error messages (theme-aware; interactive red buttons excluded). |
| #2 | `17e2dfe` + `c459792` | Tokenize 53 white-tint `rgba(255,255,255,X)` → `rgba(var(--glass-tint), X)` (dark no-op, light-correct). Visually verified in light + dark. |
| #3 | `4850212` | Add `--icon-*` ladder; snap 30 icon sizes → `--icon-*` and 28 off-scale text sizes → `--fs-*` (all ≤1px, line-scoped, no crossover). |
| #4a | `1cc5b27` | Migrate 225 exact-value Tailwind `text-xs/sm/base` → `.fs-sm/md/lg` (font-size identical). |
| #4b | `f961b2a` | Palette classes were already theme-aware via `[data-theme=light]` overrides — closed the 4 real `hover:` override gaps (CSS-only). |
| #5 | `8ef219e` | Add a bare-text-size guardrail selector; graduate `components/{primitives,home,BottomSheet}` to **error** on the full selector set (locks in zero drift). |

## Deliberately NOT done (with reasons)
- **Palette → token conversion:** classes are already theme-aware via the override convention (DESIGN.md §8) — conversion would be visual churn for zero benefit.
- **#6 button/primitive consolidation:** `.btn-primary` (prominent filled CTA) and `.cc-btn` (compact admin action) are distinct visual roles — bulk-migrating the 104 legacy buttons would regress CTAs, not improve consistency. `CardHeader`/`ListRow` adoption is per-component structural work needing visual review.
- **CommandCenter colored/black `rgba`:** needs per-color semantic judgment (owner pass).

## Verification
- Gate green at every commit. Final: 0 lint errors (405 warnings — the extended guardrail now surfaces the remaining backlog by design), 1078 tests, production build ok.
- rgba change verified in light + dark via a scripted admin screenshot; dark mode is provably pixel-identical (`--glass-tint` = `255,255,255` dark / `0,0,0` light, matching 21 existing globals.css uses).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
