### PR TITLE
fix(tests): clear pre-existing TypeScript errors in test files (#69)

### DIFF
--- a/__tests__/components/PageHeaders.test.tsx
+++ b/__tests__/components/PageHeaders.test.tsx
@@ -53,7 +53,7 @@ describe('PageHeaders', () => {
   it('AdminTab renders "Admin" as an h1', () => {
     render(
       <NextIntlClientProvider locale="en" messages={enMessages}>
-        <AdminTab />
+        <AdminTab onExit={() => {}} />
       </NextIntlClientProvider>
     );
     const heading = screen.getByRole('heading', { level: 1 });

--- a/__tests__/components/SkillsRadar.test.tsx
+++ b/__tests__/components/SkillsRadar.test.tsx
@@ -153,7 +153,7 @@ describe('SkillsRadar — sheet lifecycle (characterization, M1 mitigation)', ()
     // Characterization: clicking a level triggers a PATCH to /api/skills
     // with the new level for the active dimension.
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toContain('/api/skills');
     expect(init.method).toBe('PATCH');
     const body = JSON.parse(init.body as string);

--- a/__tests__/players-delete.test.ts
+++ b/__tests__/players-delete.test.ts
@@ -47,7 +47,7 @@ describe('DELETE /api/players', () => {
       expect(data.success).toBe(true);
 
       // ASSERT: player is soft-deleted in the store — removed flag is set
-      const store = global._mockStore as Record<string, Record<string, unknown>[]>;
+      const store = (global as typeof globalThis & { _mockStore?: Record<string, Record<string, unknown>[]> })._mockStore!;
       const stored = store['players'].find((p) => p.id === player.id);
       expect(stored?.removed).toBe(true);
       expect(stored?.cancelledBySelf).toBe(true);
@@ -128,7 +128,7 @@ describe('DELETE /api/players', () => {
       expect(data.count).toBe(3);
 
       // ASSERT: store has no remaining player records for the session
-      const store = global._mockStore as Record<string, Record<string, unknown>[]>;
+      const store = (global as typeof globalThis & { _mockStore?: Record<string, Record<string, unknown>[]> })._mockStore!;
       const remaining = (store['players'] ?? []).filter((p) => p.sessionId === SESSION_ID);
       expect(remaining).toHaveLength(0);
     });
@@ -154,7 +154,7 @@ describe('DELETE /api/players', () => {
       expect(data.count).toBe(2);
 
       // ASSERT: every player in the store now has removed: true
-      const store = global._mockStore as Record<string, Record<string, unknown>[]>;
+      const store = (global as typeof globalThis & { _mockStore?: Record<string, Record<string, unknown>[]> })._mockStore!;
       const players = (store['players'] ?? []).filter((p) => p.sessionId === SESSION_ID);
       expect(players.every((p) => p.removed === true)).toBe(true);
     });

--- a/__tests__/players-signup-with-pin.test.ts
+++ b/__tests__/players-signup-with-pin.test.ts
@@ -93,7 +93,7 @@ describe('POST /api/players with PIN (v1.4 unified Home sign-in fix)', () => {
     // with a new salt. Verify the stored pinHash is unchanged by reading
     // the mock store directly.
     const { getStore } = await import('./helpers');
-    const storedBefore = (getStore().members?.find((m: { name?: string }) => m.name === 'Lin') as { pinHash?: string })?.pinHash;
+    const storedBefore = ((getStore().members as { name?: string; pinHash?: string }[] | undefined)?.find((m) => m.name === 'Lin') as { pinHash?: string })?.pinHash;
     expect(storedBefore).toBeTruthy();
 
     const req = makeRequest('POST', 'http://localhost:3000/api/players', {
@@ -103,7 +103,7 @@ describe('POST /api/players with PIN (v1.4 unified Home sign-in fix)', () => {
     const res = await POST(req);
     expect(res.status).toBe(201);
 
-    const storedAfter = (getStore().members?.find((m: { name?: string }) => m.name === 'Lin') as { pinHash?: string })?.pinHash;
+    const storedAfter = ((getStore().members as { name?: string; pinHash?: string }[] | undefined)?.find((m) => m.name === 'Lin') as { pinHash?: string })?.pinHash;
     expect(storedAfter).toBe(storedBefore);
   });
 });


### PR DESCRIPTION
## What & why

Closes #69. `npx tsc --noEmit` reported **7 errors across 4 test files** — all pre-existing, all in tests, none affecting runtime (vitest doesn't strict-typecheck the way `next build` does). The baseline noise masked real signature drift and made the "run `tsc` before a refactor PR" workflow noisy.

The current error set had **drifted from the issue's original audit list**: `session.test.ts:32` is already fixed, while `PageHeaders.test.tsx` and `players-signup-with-pin.test.ts` are newer errors not in the issue.

## Fixes (all mechanical)

- **`PageHeaders.test.tsx`** — `<AdminTab/>` requires an `onExit` prop; pass `onExit={() => {}}` (TS2741).
- **`SkillsRadar.test.tsx`** — cast the mock-call tuple through `unknown` first (TS2352).
- **`players-delete.test.ts`** (×3) — type the `global._mockStore` access instead of indexing `typeof globalThis`, which has no index signature (TS7017).
- **`players-signup-with-pin.test.ts`** (×2) — cast `getStore().members` to the element type so the `.find(...)` predicate overload resolves (TS2769).

## Verification

- `npx tsc --noEmit` — **now clean (0 errors)**.
- Full vitest suite — **1044 passing** (133 files).
- No source/runtime files touched — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_