### PR TITLE
fix(signup): close the capacity race with deterministic reconciliation (#79)

### DIFF
--- a/__tests__/capacity.test.ts
+++ b/__tests__/capacity.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { overCapacityIds, isOverCapacity, compareBySignup, type CapacityEntry } from '../lib/capacity';
+
+// Helper: build entries with an explicit signup order.
+const e = (id: string, timestamp?: string): CapacityEntry => ({ id, timestamp });
+
+describe('capacity resolver (#79)', () => {
+  describe('overCapacityIds', () => {
+    it('returns empty when the active set is under the cap', () => {
+      const active = [e('a', '2026-07-01T10:00:00Z'), e('b', '2026-07-01T10:01:00Z')];
+      expect(overCapacityIds(active, 12).size).toBe(0);
+    });
+
+    it('returns empty when exactly at the cap', () => {
+      const active = [e('a', '2026-07-01T10:00:00Z'), e('b', '2026-07-01T10:01:00Z')];
+      expect(overCapacityIds(active, 2).size).toBe(0);
+    });
+
+    it('flags the latest arrival when over by one (first-come-first-served)', () => {
+      const active = [
+        e('a', '2026-07-01T10:00:00Z'),
+        e('b', '2026-07-01T10:02:00Z'), // latest → loses the spot
+        e('c', '2026-07-01T10:01:00Z'),
+      ];
+      expect(overCapacityIds(active, 2)).toEqual(new Set(['b']));
+    });
+
+    it('flags the two latest arrivals when over by two', () => {
+      const active = [
+        e('a', '2026-07-01T10:00:00Z'),
+        e('b', '2026-07-01T10:01:00Z'),
+        e('c', '2026-07-01T10:02:00Z'),
+        e('d', '2026-07-01T10:03:00Z'),
+      ];
+      expect(overCapacityIds(active, 2)).toEqual(new Set(['c', 'd']));
+    });
+
+    it('breaks timestamp ties by id (stable, so every racer agrees)', () => {
+      const ts = '2026-07-01T10:00:00Z';
+      const active = [e('zzz', ts), e('aaa', ts), e('mmm', ts)];
+      // Same timestamp → id ascending: aaa, mmm, zzz. Cap 2 drops zzz.
+      expect(overCapacityIds(active, 2)).toEqual(new Set(['zzz']));
+    });
+
+    it('treats a missing timestamp as earliest (keeps its spot)', () => {
+      const active = [e('late', '2026-07-01T10:05:00Z'), e('legacy'), e('mid', '2026-07-01T10:01:00Z')];
+      // legacy (no ts) sorts first, then mid, then late → cap 2 drops late.
+      expect(overCapacityIds(active, 2)).toEqual(new Set(['late']));
+    });
+
+    it('flags everyone when the cap is zero', () => {
+      const active = [e('a', '2026-07-01T10:00:00Z'), e('b', '2026-07-01T10:01:00Z')];
+      expect(overCapacityIds(active, 0)).toEqual(new Set(['a', 'b']));
+    });
+
+    it('clamps negative / fractional caps to a floor', () => {
+      const active = [e('a', '2026-07-01T10:00:00Z'), e('b', '2026-07-01T10:01:00Z')];
+      expect(overCapacityIds(active, -3)).toEqual(new Set(['a', 'b']));
+      expect(overCapacityIds(active, 1.9)).toEqual(new Set(['b'])); // floor(1.9) = 1
+    });
+
+    it('does not mutate the input array', () => {
+      const active = [e('b', '2026-07-01T10:02:00Z'), e('a', '2026-07-01T10:00:00Z')];
+      const snapshot = active.map((p) => p.id);
+      overCapacityIds(active, 1);
+      expect(active.map((p) => p.id)).toEqual(snapshot);
+    });
+
+    it('is deterministic: two independent racers compute the same overflow set', () => {
+      const active = [
+        e('a', '2026-07-01T10:00:00Z'),
+        e('b', '2026-07-01T10:01:00Z'),
+        e('c', '2026-07-01T10:01:00Z'), // ties b on timestamp
+      ];
+      const racer1 = overCapacityIds(active, 2);
+      const racer2 = overCapacityIds([...active].reverse(), 2); // different insertion order
+      expect(racer1).toEqual(racer2);
+    });
+  });
+
+  describe('isOverCapacity', () => {
+    const active = [
+      e('a', '2026-07-01T10:00:00Z'),
+      e('b', '2026-07-01T10:01:00Z'),
+      e('c', '2026-07-01T10:02:00Z'),
+    ];
+
+    it('is true for the racer past the cap, false for the ones within it', () => {
+      expect(isOverCapacity(active, 'c', 2)).toBe(true);
+      expect(isOverCapacity(active, 'a', 2)).toBe(false);
+      expect(isOverCapacity(active, 'b', 2)).toBe(false);
+    });
+
+    it('is false for an id not in the active set', () => {
+      expect(isOverCapacity(active, 'missing', 2)).toBe(false);
+    });
+  });
+
+  describe('compareBySignup', () => {
+    it('orders by timestamp then id', () => {
+      expect(compareBySignup(e('a', '2026-01-01T00:00:00Z'), e('b', '2026-01-02T00:00:00Z'))).toBeLessThan(0);
+      expect(compareBySignup(e('a', '2026-01-01T00:00:00Z'), e('b', '2026-01-01T00:00:00Z'))).toBeLessThan(0);
+      expect(compareBySignup(e('a', '2026-01-01T00:00:00Z'), e('a', '2026-01-01T00:00:00Z'))).toBe(0);
+    });
+  });
+});

--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -5,9 +5,50 @@ import { checkRateLimit, getClientIp } from '@/lib/rateLimit';
 import { isAdminAuthed, isAdminAuthedWithMember, verifyMemberAuth, setMemberCookie } from '@/lib/auth';
 import { hashPin, verifyPin, FAKE_HASH } from '@/lib/recoveryHash';
 import { appendEvent } from '@/lib/recoveryAudit';
+import { isOverCapacity } from '@/lib/capacity';
 import type { RecoveryEvent } from '@/lib/types';
 
 const BLOCKLISTED_PINS = new Set(['0000', '1111', '1234', '4321', '1212']);
+
+// Single definition of a session's "active" (not-removed, not-waitlisted)
+// players — shared by the pre-insert capacity check and the post-insert
+// reconciliation (#79) so the two can never disagree on who counts.
+const ACTIVE_PLAYERS_QUERY =
+  'SELECT * FROM c WHERE c.sessionId = @sessionId AND (NOT IS_DEFINED(c.removed) OR c.removed != true) AND (NOT IS_DEFINED(c.waitlisted) OR c.waitlisted != true)';
+
+/**
+ * Close the signup capacity race (#79). The pre-insert count check and the
+ * insert aren't atomic, so concurrent signups can both pass the check and land
+ * active, exceeding maxPlayers. Once our own record `doc` is committed, re-derive
+ * the active set and, if `doc` is past the cap in the deterministic first-come
+ * order (see lib/capacity.ts), demote it — to the waitlist when the caller opted
+ * in, else roll the just-created record back and report the session full.
+ *
+ * Every concurrent racer runs this against the same committed rows and only
+ * demotes itself when over the line, so the active count converges to
+ * `<= maxPlayers` with no coordination. The in-memory mock store is synchronous
+ * (one request in flight at a time) so it can't reproduce the interleave — the
+ * ordering core is unit-tested (capacity.test.ts) and full concurrency proof is
+ * the real-Cosmos test in #82.
+ */
+async function reconcileCapacity(
+  container: ReturnType<typeof getContainer>,
+  sessionId: string,
+  doc: { id: string; timestamp?: string; [k: string]: unknown },
+  maxPlayers: number,
+  joinWaitlist: boolean,
+): Promise<'kept' | 'waitlisted' | 'full'> {
+  const { resources } = await container.items
+    .query({ query: ACTIVE_PLAYERS_QUERY, parameters: [{ name: '@sessionId', value: sessionId }] })
+    .fetchAll();
+  if (!isOverCapacity(resources, doc.id, maxPlayers)) return 'kept';
+  if (joinWaitlist) {
+    await container.items.upsert({ ...doc, waitlisted: true });
+    return 'waitlisted';
+  }
+  await container.item(doc.id, sessionId).delete();
+  return 'full';
+}
 
 export async function GET(req: NextRequest) {
   try {
@@ -151,10 +192,7 @@ export async function POST(req: NextRequest) {
         })
         .fetchAll(),
       container.items
-        .query({
-          query: 'SELECT * FROM c WHERE c.sessionId = @sessionId AND (NOT IS_DEFINED(c.removed) OR c.removed != true) AND (NOT IS_DEFINED(c.waitlisted) OR c.waitlisted != true)',
-          parameters: [{ name: '@sessionId', value: sessionId }],
-        })
+        .query({ query: ACTIVE_PLAYERS_QUERY, parameters: [{ name: '@sessionId', value: sessionId }] })
         .fetchAll(),
     ]);
 
@@ -315,6 +353,18 @@ export async function POST(req: NextRequest) {
 
     const { resource } = await container.items.create(player);
 
+    // Close the capacity race (#79): the pre-insert check + this create aren't
+    // atomic, so concurrent signups can both land active. Reconcile against the
+    // now-committed active set and demote ourselves if we're past the cap.
+    let waitlisted = player.waitlisted;
+    if (!player.waitlisted) {
+      const outcome = await reconcileCapacity(container, sessionId, player, maxPlayers, joinWaitlist);
+      if (outcome === 'full') {
+        return NextResponse.json({ error: 'Session is full' }, { status: 409 });
+      }
+      waitlisted = outcome === 'waitlisted';
+    }
+
     // Update member stats + mirror pinHash for unified admin auth
     if (matchedMember) {
       await membersContainer.items.upsert({
@@ -326,7 +376,9 @@ export async function POST(req: NextRequest) {
     }
 
     // Return the deleteToken once so the client can store it for self-cancellation
-    const { pinHash: _ph, ...safeResource } = resource as unknown as Record<string, unknown>;
+    // (waitlisted reflects any race-demotion above).
+    const { pinHash: _ph, ...safeResource } =
+      { ...(resource as unknown as Record<string, unknown>), waitlisted } as Record<string, unknown>;
     const out = NextResponse.json({ ...safeResource, deleteToken }, { status: 201 });
     // Trust this device for future sign-ups when this request proved (sign-in)
     // or created (first PIN) the member's PIN — the "stay logged in" model.

--- a/lib/capacity.ts
+++ b/lib/capacity.ts
@@ -1,0 +1,52 @@
+/**
+ * Signup capacity race resolver (#79).
+ *
+ * `POST /api/players` checks the active-player count and then inserts — two
+ * separate Cosmos operations. Concurrent signups can both pass the check and
+ * both land active, exceeding `maxPlayers` by 1–2 spots (the CLAUDE.md gotcha).
+ *
+ * The fix is a post-insert reconciliation: once a request's own record is
+ * committed, it re-derives the active set and demotes itself if it's past the
+ * cap. Correctness hinges on a **deterministic total order** every racer agrees
+ * on — first-come-first-served by `timestamp`, with `id` as a stable tiebreak.
+ * Because the order is derived only from committed fields, every concurrent
+ * request computes the same ranking and only the ones beyond the cap step back,
+ * so the active count converges to `<= maxPlayers` without any coordination.
+ *
+ * This module is the pure, deterministic core (no I/O) so the ranking is fully
+ * unit-testable; the handler wraps it with the re-query + demote writes.
+ */
+
+export interface CapacityEntry {
+  id: string;
+  /** ISO 8601 signup time. Missing sorts earliest (keeps its spot). */
+  timestamp?: string;
+}
+
+/** Stable total order: earliest `timestamp` first, `id` as tiebreak. */
+export function compareBySignup(a: CapacityEntry, b: CapacityEntry): number {
+  const at = a.timestamp ?? '';
+  const bt = b.timestamp ?? '';
+  if (at !== bt) return at < bt ? -1 : 1;
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+  return 0;
+}
+
+/**
+ * The ids that are OVER capacity — ranked at or beyond `maxPlayers` in the
+ * first-come order. Empty when the active set fits within the cap.
+ */
+export function overCapacityIds(active: CapacityEntry[], maxPlayers: number): Set<string> {
+  const cap = Math.max(0, Math.floor(maxPlayers));
+  if (active.length <= cap) return new Set();
+  return new Set([...active].sort(compareBySignup).slice(cap).map((p) => p.id));
+}
+
+/** Whether `playerId` is beyond the cap in the deterministic first-come order. */
+export function isOverCapacity(
+  active: CapacityEntry[],
+  playerId: string,
+  maxPlayers: number,
+): boolean {
+  return overCapacityIds(active, maxPlayers).has(playerId);
+}


### PR DESCRIPTION
## What & why

Closes #79 (P1). `POST /api/players` checked the active-player count and **then** inserted — two separate Cosmos operations. Concurrent signups could both pass the check and both land active, exceeding `maxPlayers` by 1–2 spots. The user-facing symptom is the CLAUDE.md gotcha: *"I'm 13th of 12 — am I in or out?"* — confusing, and it undermines trust in the waitlist.

## Approach — deterministic post-insert reconciliation

The truly-atomic options (a stored counter + transactional batch, or ETag `if-match`) either require a schema change on a **shared** Cosmos DB or Cosmos-only primitives the mock store can't model. Instead, this closes the race without either:

1. After a request's **own** record is committed, re-derive the active set.
2. Rank it by a **deterministic first-come total order** — `timestamp`, then `id` as a stable tiebreak.
3. If this record is past the cap, demote it — to the **waitlist** if the caller opted in, else **roll the just-created record back** and return `409 Session is full`.

Because the order is derived only from committed fields, **every concurrent racer computes the same ranking** and only the ones beyond the cap step back. The active count converges to `<= maxPlayers` with no coordination, no schema change, and identical behavior on the mock store and real Cosmos.

## Changes

- **`lib/capacity.ts`** (new) — the pure, deterministic ordering/overflow core (`overCapacityIds`, `isOverCapacity`, `compareBySignup`). No I/O, fully unit-testable.
- **`app/api/players/route.ts`** — a shared `ACTIVE_PLAYERS_QUERY` constant (so the pre-check and the reconciliation can never disagree on who counts) + a `reconcileCapacity()` helper called right after the create. The response reflects any race-demotion.
- **`__tests__/capacity.test.ts`** (new) — 13 cases pinning the ranking: under/at/over cap, timestamp ties broken by id, missing-timestamp = earliest, cap 0, negative/fractional cap, no-input-mutation, and racer determinism.

## Scope & verification

- **Scope:** the fresh-signup **create** path — the exact scenario described in #79. The **restore-after-cancel** path shares the race but has different rollback semantics (re-soft-delete vs. hard-delete); it's a documented follow-up.
- **Testability:** the in-memory mock store is synchronous (one request in flight), so it **cannot reproduce the interleave** — the ordering core is unit-tested here, and full end-to-end concurrency proof is the **real-Cosmos integration test in #82** (this PR strengthens the case for it).
- `npx tsc --noEmit` clean for the changed files; full vitest suite green (**1057 passing**, +13); `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAUzNicFw1Dxq6yakWoXDy)_