### PR TITLE
Fix Stats streak window, insight cache, and partners default window

### DIFF
--- a/__tests__/stats-attendance.test.ts
+++ b/__tests__/stats-attendance.test.ts
@@ -137,4 +137,24 @@ describe('GET /api/stats/attendance', () => {
     const data = await res.json();
     expect(data.weeks).toBeLessThanOrEqual(52);
   });
+
+  it('excludes a not-yet-played future session from history and streak', async () => {
+    // Three past sessions, all attended → a real 3-session streak.
+    const past = makeSessionIds(3);
+    past.forEach((id, i) => seedSession(id, { datetime: isoForDaysAgo(i * 7 + 7) }));
+    past.forEach((id) => seedPlayer(id, 'Grant'));
+    // Upcoming session next week — nobody has played it yet (no player row).
+    const future = new Date();
+    future.setDate(future.getDate() + 7);
+    const futureId = `session-${future.toISOString().slice(0, 10)}`;
+    seedSession(futureId, { datetime: future.toISOString() });
+
+    const res = await GET(
+      makeRequest('GET', 'http://localhost:3000/api/stats/attendance?name=Grant&weeks=12'),
+    );
+    const data = await res.json();
+    // The future session must neither appear in history nor reset the streak to 0.
+    expect(data.history.some((h: { sessionId: string }) => h.sessionId === futureId)).toBe(false);
+    expect(data.streak).toBe(3);
+  });
 });

--- a/__tests__/stats-partners.test.ts
+++ b/__tests__/stats-partners.test.ts
@@ -31,6 +31,23 @@ describe('GET /api/stats/partners', () => {
     expect(body.partners.find((p: { name: string }) => p.name === 'Carolina').count).toBe(1);
   });
 
+  it('defaults to a 12-week window when weeks is omitted (not a 1-week window)', async () => {
+    // A session 4 weeks ago — inside a 12-week window, outside a 1-week one.
+    // Guards the `Number(null) === 0` trap that made an omitted `weeks` resolve
+    // to a 1-week window and silently drop older partners.
+    const players = getContainer('players');
+    const d = new Date();
+    d.setDate(d.getDate() - 28);
+    const sid = `session-${d.toISOString().slice(0, 10)}`;
+    await players.items.upsert({ id: 'pd1', sessionId: sid, name: 'Lin' });
+    await players.items.upsert({ id: 'pd2', sessionId: sid, name: 'Akane' });
+
+    const res = await GET(get('/api/stats/partners?name=Lin'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.partners.find((p: { name: string }) => p.name === 'Akane')?.count).toBe(1);
+  });
+
   it('404s when the flag is off', async () => {
     process.env.NEXT_PUBLIC_FLAG_VALUE_HUB_SLICE = 'false';
     const res = await GET(get('/api/stats/partners?name=Lin'));

--- a/app/api/stats/attendance/route.ts
+++ b/app/api/stats/attendance/route.ts
@@ -61,7 +61,14 @@ export async function GET(req: NextRequest) {
       return db.localeCompare(da);
     });
 
-    const windowSessions = sorted.slice(0, weeks);
+    // Exclude sessions that haven't happened yet. Advancing to a new week
+    // creates a future-dated session that nobody has attended — leaving it in
+    // would sort to history[0] and break the current streak to 0 (or, once the
+    // player signs up, over-count a not-yet-played session). The streak must be
+    // computed over played sessions only.
+    const now = Date.now();
+    const played = sorted.filter((s) => !s.datetime || new Date(s.datetime).getTime() <= now);
+    const windowSessions = played.slice(0, weeks);
     if (windowSessions.length === 0) {
       return NextResponse.json({
         name,

--- a/app/api/stats/insight/route.ts
+++ b/app/api/stats/insight/route.ts
@@ -190,8 +190,13 @@ export async function GET(req: NextRequest) {
   const cacheFresh = !!existing && existing.sessionId === activeSessionId && assessmentMatches;
   // The cache is keyed by the shape the current flag wants: a flag flip leaves a
   // doc with the wrong field set, which misses here and regenerates once.
-  if (cacheFresh && cardsOn && existing!.greeting) {
-    return NextResponse.json({ account: true, greeting: existing!.greeting, level: existing!.level ?? null, trend: existing!.trend ?? null, generatedAt: existing!.generatedAt, cached: true });
+  // A persisted cards-doc always has at least one non-null slice (the generator
+  // bails without writing when all three are null), so "any slice present" is
+  // the correct freshness test. Keying on `greeting` alone made a legitimately
+  // null greeting (with a level/trend chip) miss the cache on every view and
+  // re-call Claude — breaking the one-call-per-member-per-session guarantee.
+  if (cacheFresh && cardsOn && (existing!.greeting || existing!.level || existing!.trend)) {
+    return NextResponse.json({ account: true, greeting: existing!.greeting ?? null, level: existing!.level ?? null, trend: existing!.trend ?? null, generatedAt: existing!.generatedAt, cached: true });
   }
   if (cacheFresh && !cardsOn && existing!.recap) {
     return NextResponse.json({ account: true, recap: existing!.recap, focus: existing!.focus, generatedAt: existing!.generatedAt, cached: true });
@@ -335,8 +340,12 @@ async function buildSnapshot({
     (playerHits.resources as { sessionId?: string }[]).map((p) => p.sessionId).filter((id): id is string => typeof id === 'string'),
   );
 
+  // Exclude not-yet-played (future-dated) sessions so the streak/attendance
+  // snapshot matches the attendance route — an upcoming session must not break
+  // or inflate the current streak. (See app/api/stats/attendance/route.ts.)
+  const nowMs = Date.now();
   const recentSessions = (sessionHits.resources as { id: string; datetime: string | null }[])
-    .filter((s) => s.datetime)
+    .filter((s) => s.datetime && new Date(s.datetime).getTime() <= nowMs)
     .sort((a, b) => (a.datetime ?? '').localeCompare(b.datetime ?? ''));
 
   const history = recentSessions.map((s) => ({ id: s.id, datetime: s.datetime as string, attended: attendedSessionIds.has(s.id) }));

--- a/app/api/stats/partners/route.ts
+++ b/app/api/stats/partners/route.ts
@@ -25,8 +25,11 @@ export async function GET(req: NextRequest) {
   try {
     const url = new URL(req.url);
     const name = url.searchParams.get('name')?.trim().slice(0, 50) ?? '';
-    const weeksRaw = Number(url.searchParams.get('weeks'));
-    const weeks = Number.isFinite(weeksRaw) ? Math.min(Math.max(weeksRaw, 1), 260) : 12;
+    // Default to 12 when absent. Note: `Number(null)` is 0 (finite), so reading
+    // the raw param directly would make an omitted `weeks` resolve to a 1-week
+    // window, not 12 — default the string before coercing.
+    const weeksParam = Number(url.searchParams.get('weeks') ?? '12');
+    const weeks = Number.isFinite(weeksParam) && weeksParam > 0 ? Math.min(Math.floor(weeksParam), 260) : 12;
     if (!name) return NextResponse.json({ partners: [] });
 
     const cutoff = cutoffSessionId(weeks);


### PR DESCRIPTION
## Why

From the broader Stats-page audit you asked for. These are the three **confirmed backend correctness bugs** (I verified each in the code), fixed as one contained PR. UI issues (i18n gap, offline gating, a11y) are tracked separately.

## Fixes

**1. 🔴 Current streak collapses to 0 whenever an upcoming session exists** — `app/api/stats/attendance/route.ts`
The attendance query had no upper date bound. Advancing to a new week creates a future-dated session nobody has played yet → it sorts to `history[0]` → the streak loop breaks on the first non-attended entry. Result: **every player reads a 0 streak until they sign up** for the next week, then over-counts a not-yet-played session. Now filters `datetime > now` before computing the window. Mirrored in the insight snapshot's streak.

**2. 🟡 Insight re-called Claude on every view when greeting was null** — `app/api/stats/insight/route.ts`
Cache-hit keyed on `existing.greeting` being truthy, but a legitimately null greeting (with a level/trend chip) is persisted, so the cache always missed → regenerated via Sonnet on every page load, breaking the one-call-per-member-per-session guarantee and inflating spend. Now keys freshness on any slice being present.

**3. 🟡 Partners defaulted to a 1-week window, not 12** — `app/api/stats/partners/route.ts`
`Number(null)` is `0` (finite), so an omitted `weeks` skipped the `: 12` fallback and resolved to 1. Latent (masked because the card always sends `weeks=12`), but a trap for any new caller. Default the string before coercing.

## Tests
Adds coverage for the future-session exclusion (attendance) and the 12-week default (partners).

## Verification
`npm run lint` → 0 errors · `npm test` → **1093 passed** · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_