### PR TITLE
Stats: translate hardcoded strings + gate mutation sheets offline

### DIFF
--- a/components/stats/CheckInSheet.tsx
+++ b/components/stats/CheckInSheet.tsx
@@ -6,6 +6,7 @@ import ErrorState from '@/components/primitives/ErrorState';
 import EmptyState from '@/components/primitives/EmptyState';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 import { SKILLS } from '@/lib/assessment';
+import { useOnline } from '@/lib/useOnline';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -35,6 +36,7 @@ export default function CheckInSheet({
   previous?: Map<string, number>;
 }) {
   const t = useTranslations('stats');
+  const online = useOnline();
   const total = SKILLS.length;
   // step: -1 = mirror/intro, 0..total-1 = a skill, total = review/save
   const [step, setStep] = useState(-1);
@@ -226,11 +228,14 @@ export default function CheckInSheet({
               <p style={{ fontSize: 'var(--fs-lg)', color: 'var(--text-primary)', margin: 0, lineHeight: 1.4 }}>{t('assess.reviewCount', { rated: ratedCount, total })}</p>
               <EmptyState>{t('assess.reviewPrompt')}</EmptyState>
               {error && <ErrorState message={error} />}
+              {!online && (
+                <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: 0 }}>{t('offline')}</p>
+              )}
               <div style={{ display: 'flex', gap: 10 }}>
                 <button type="button" onClick={() => setStep(total - 1)} className="cc-btn cc-btn-ghost" style={{ flex: 1 }}>
                   {t('assess.back')}
                 </button>
-                <button type="button" onClick={submit} disabled={busy || ratedCount === 0} className="cc-btn cc-btn-primary" style={{ flex: 2 }}>
+                <button type="button" onClick={submit} disabled={!online || busy || ratedCount === 0} className="cc-btn cc-btn-primary" style={{ flex: 2 }}>
                   {busy ? t('assess.saving') : t('assess.save')}
                 </button>
               </div>

--- a/components/stats/GameLoggerSheet.tsx
+++ b/components/stats/GameLoggerSheet.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import ErrorState from '@/components/primitives/ErrorState';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '../BottomSheet';
+import { useOnline } from '@/lib/useOnline';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
@@ -21,6 +22,8 @@ interface Props {
 export default function GameLoggerSheet({ you, sessionId, open, onClose, onLogged }: Props) {
   const t = useTranslations('valueHub');
   const tRecovery = useTranslations('recovery');
+  const tStats = useTranslations('stats');
+  const online = useOnline();
   const [partner, setPartner] = useState('');
   const [opp1, setOpp1] = useState('');
   const [opp2, setOpp2] = useState('');
@@ -107,7 +110,10 @@ export default function GameLoggerSheet({ you, sessionId, open, onClose, onLogge
               </div>
             </div>
             {error && <ErrorState message={t('recError')} />}
-            <button type="button" disabled={!valid || busy} onClick={submit} className="cc-btn cc-btn-primary cc-btn-lg" style={{ marginTop: 4 }}>
+            {!online && (
+              <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: 0 }}>{tStats('offline')}</p>
+            )}
+            <button type="button" disabled={!online || !valid || busy} onClick={submit} className="cc-btn cc-btn-primary cc-btn-lg" style={{ marginTop: 4 }}>
               {t('logGameSubmit')}
             </button>
           </div>

--- a/components/stats/GearSheet.tsx
+++ b/components/stats/GearSheet.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import ErrorState from '@/components/primitives/ErrorState';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '../BottomSheet';
+import { useOnline } from '@/lib/useOnline';
 import type { CatalogItem } from '@/lib/types';
 
 const BASE = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
@@ -23,6 +24,8 @@ interface Props {
 export default function GearSheet({ name, open, onClose, onSaved }: Props) {
   const t = useTranslations('valueHub');
   const tRecovery = useTranslations('recovery');
+  const tStats = useTranslations('stats');
+  const online = useOnline();
   const [catalog, setCatalog] = useState<CatalogItem[]>([]);
   const [query, setQuery] = useState('');
   const [saving, setSaving] = useState(false);
@@ -100,12 +103,15 @@ export default function GearSheet({ name, open, onClose, onSaved }: Props) {
             />
             {loadError && <ErrorState message={t('recError')} />}
             {saveError && <ErrorState message={t('recError')} />}
+            {!online && (
+              <p style={{ fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', margin: 0 }}>{tStats('offline')}</p>
+            )}
             <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
               {matches.map((c) => (
                 <li key={c.id}>
                   <button
                     type="button"
-                    disabled={saving}
+                    disabled={!online || saving}
                     onClick={() => pick(c)}
                     className="cc-btn cc-btn-ghost"
                     style={{ width: '100%', justifyContent: 'flex-start' }}

--- a/components/stats/InsightChip.tsx
+++ b/components/stats/InsightChip.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import type { CardSlice } from '@/lib/useInsight';
 
 /**
@@ -23,6 +24,7 @@ const ICON_BY_KIND: Record<string, string> = {
 const ACCENT = 'var(--accent, #22c55e)';
 
 export default function InsightChip({ headline, support, kind }: CardSlice) {
+  const t = useTranslations('stats');
   const icon = ICON_BY_KIND[kind] ?? 'auto_fix_high';
   return (
     <div
@@ -45,8 +47,8 @@ export default function InsightChip({ headline, support, kind }: CardSlice) {
         {support && <p style={{ margin: '2px 0 0', fontSize: 'var(--fs-sm)', color: 'var(--text-muted)', lineHeight: 1.4 }}>{support}</p>}
       </div>
       <span
-        aria-label="AI generated"
-        title="AI generated"
+        aria-label={t('insightChip.aiGenerated')}
+        title={t('insightChip.aiGenerated')}
         style={{
           fontSize: 'var(--fs-2xs)',
           padding: '2px 6px',
@@ -60,7 +62,7 @@ export default function InsightChip({ headline, support, kind }: CardSlice) {
           flexShrink: 0,
         }}
       >
-        AI
+        {t('insightChip.aiBadge')}
       </span>
     </div>
   );

--- a/components/stats/StreakSummaryCard.tsx
+++ b/components/stats/StreakSummaryCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { getIdentity, IDENTITY_EVENT } from '@/lib/identity';
 import CardHeader from '@/components/primitives/CardHeader';
 import StatusBadge from '@/components/primitives/StatusBadge';
@@ -46,6 +47,7 @@ function resolveActiveName(): string | null {
 }
 
 export default function StreakSummaryCard() {
+  const t = useTranslations('stats');
   const [activeName, setActiveName] = useState<string | null>(null);
   const [streakData, setStreakData] = useState<StreakData | null>(null);
   const [insight, setInsight] = useState<InsightData | null>(null);
@@ -133,7 +135,7 @@ export default function StreakSummaryCard() {
       className={`glass-card${showRim ? ' insight-rim' : ''}${generating ? ' is-generating' : ''}`}
       style={{ padding: 20, display: 'flex', flexDirection: 'column', gap: 12 }}
       aria-busy={generating || undefined}
-      aria-label={hasStreak ? `${streak} week attendance streak for ${name}` : `Insight for ${name}`}
+      aria-label={hasStreak ? t('streak.ariaStreak', { count: streak, name }) : t('streak.ariaInsight', { name })}
     >
       {/* ── Headline: attendance streak ── */}
       {hasStreak && (
@@ -151,15 +153,15 @@ export default function StreakSummaryCard() {
           </div>
           <div style={{ minWidth: 0, flex: 1 }}>
             <p style={{ margin: 0, fontSize: 'var(--fs-xs)', color: MUTED, fontWeight: 500, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-              {onPersonalBest ? `${name} — Personal Best` : `${name}'s Streak`}
+              {onPersonalBest ? t('streak.personalBestLabel', { name }) : t('streak.streakLabel', { name })}
             </p>
             <p style={{ margin: 0, fontSize: 'var(--fs-lg)', fontWeight: 600, color: PRIMARY, lineHeight: 1.25, marginTop: 2 }}>
-              {streak === 1 ? "You're on a 1-week streak" : `You're on a ${streak}-week streak`}
+              {t('streak.streakLine', { count: streak })}
             </p>
             <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED, marginTop: 2 }}>
               {onPersonalBest
-                ? `Tied or beating your longest run of ${longestStreak}.`
-                : `Longest run: ${longestStreak} week${longestStreak === 1 ? '' : 's'}. Keep showing up.`}
+                ? t('streak.personalBestSub', { count: longestStreak })
+                : t('streak.longestRunSub', { count: longestStreak })}
             </p>
           </div>
         </div>
@@ -168,22 +170,22 @@ export default function StreakSummaryCard() {
       {/* ── Body: passive AI insight (recap + focus) ── */}
       {showBody && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12, ...(hasStreak ? { borderTop: '1px solid var(--inner-card-border)', paddingTop: 14 } : {}) }}>
-          <CardHeader icon="auto_fix_high" title="Your read" badge={<StatusBadge>Beta</StatusBadge>} />
+          <CardHeader icon="auto_fix_high" title={t('streak.readTitle')} badge={<StatusBadge>{t('streak.beta')}</StatusBadge>} />
 
           {insightLoading && !hasInsight ? (
             <div aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
               <div className="animate-pulse" style={{ height: 12, borderRadius: 'var(--radius-xs)', background: 'var(--inner-card-bg)', width: '90%' }} />
               <div className="animate-pulse" style={{ height: 12, borderRadius: 'var(--radius-xs)', background: 'var(--inner-card-bg)', width: '70%' }} />
-              <p style={{ margin: 0, fontSize: 'var(--fs-xs)', color: MUTED }}>Reading the dots…</p>
+              <p style={{ margin: 0, fontSize: 'var(--fs-xs)', color: MUTED }}>{t('streak.reading')}</p>
             </div>
           ) : hasInsight ? (
             <div className="animate-fadeIn" style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              {insight?.recap && <InsightSection label="Last week" body={insight.recap} />}
-              {insight?.focus && <InsightSection label="This week · Focus" body={insight.focus} accent />}
+              {insight?.recap && <InsightSection label={t('streak.lastWeek')} body={insight.recap} />}
+              {insight?.focus && <InsightSection label={t('streak.focus')} body={insight.focus} accent />}
             </div>
           ) : (
             <p role="alert" style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED }}>
-              Couldn’t load your read — refresh to retry.
+              {t('streak.readError')}
             </p>
           )}
         </div>

--- a/components/stats/SummaryGreeting.tsx
+++ b/components/stats/SummaryGreeting.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
 import { useInsight } from '@/lib/useInsight';
 import StatusBadge from '@/components/primitives/StatusBadge';
 
@@ -14,6 +15,7 @@ import StatusBadge from '@/components/primitives/StatusBadge';
  * so the AI provenance is honest.
  */
 export default function SummaryGreeting() {
+  const t = useTranslations('stats');
   const { data } = useInsight(true);
   const greeting = data?.greeting ?? null;
   if (!greeting) return null;
@@ -22,14 +24,14 @@ export default function SummaryGreeting() {
     <div
       className="glass-card insight-rim animate-fadeIn"
       style={{ padding: 'var(--space-4) var(--space-5)', display: 'flex', alignItems: 'center', gap: 12 }}
-      aria-label="Your AI summary"
+      aria-label={t('summaryGreeting.ariaLabel')}
     >
       <span className="material-icons" aria-hidden="true" style={{ fontSize: 'var(--fs-stat-lg)', color: 'var(--accent, #22c55e)', flexShrink: 0 }}>
         auto_fix_high
       </span>
       <p style={{ margin: 0, fontSize: 'var(--fs-lg)', lineHeight: 1.45, color: 'var(--text-primary)', flex: 1, minWidth: 0 }}>{greeting}</p>
       <span style={{ flexShrink: 0 }}>
-        <StatusBadge>Beta</StatusBadge>
+        <StatusBadge>{t('summaryGreeting.beta')}</StatusBadge>
       </span>
     </div>
   );

--- a/components/stats/cards/AttendanceCardLive.tsx
+++ b/components/stats/cards/AttendanceCardLive.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { getIdentity } from '@/lib/identity';
 import AttendanceSessionStrip, { recentSessions } from './AttendanceSessionStrip';
 
@@ -38,6 +39,7 @@ function resolveActiveName(): string | null {
 }
 
 export default function AttendanceCardLive() {
+  const t = useTranslations('stats');
   const [activeName, setActiveName] = useState<string | null>(null);
   const [resolved, setResolved] = useState(false);
   const [data, setData] = useState<AttendanceResponse | null>(null);
@@ -99,10 +101,10 @@ export default function AttendanceCardLive() {
     return (
       <div style={{ display: 'grid', gap: 10 }}>
         <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: PRIMARY, fontWeight: 600 }}>
-          Your stats
+          {t('attendanceLive.title')}
         </p>
         <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED, lineHeight: 1.45 }}>
-          Sign in or create an account to see your personalized stats.
+          {t('attendanceLive.prompt')}
         </p>
       </div>
     );
@@ -112,7 +114,7 @@ export default function AttendanceCardLive() {
   if (!data) {
     return (
       <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED }} role="alert">
-        Couldn’t load that — refresh to try again.
+        {t('attendanceLive.loadError')}
       </p>
     );
   }
@@ -129,17 +131,17 @@ export default function AttendanceCardLive() {
     <div style={{ display: 'grid', gap: 10 }}>
       <div style={{ display: 'flex', gap: 14, alignItems: 'baseline', justifyContent: 'space-between', flexWrap: 'wrap' }}>
         <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
-          Your recent form
+          {t('attendanceLive.recentForm')}
         </p>
         {isPreviewPick && (
           <span style={{ fontSize: 'var(--fs-xs)', color: MUTED }}>
-            viewing as <strong style={{ color: PRIMARY }}>{activeName}</strong>{' '}
+            {t('attendanceLive.viewingAs')} <strong style={{ color: PRIMARY }}>{activeName}</strong>{' '}
             <button
               type="button"
               onClick={clearPickedName}
               style={{ background: 'transparent', border: 'none', color: ACCENT, cursor: 'pointer', padding: 0, fontSize: 'var(--fs-xs)' }}
             >
-              change
+              {t('attendanceLive.change')}
             </button>
           </span>
         )}
@@ -147,8 +149,7 @@ export default function AttendanceCardLive() {
       <AttendanceSessionStrip history={data.history} limit={RECENT} />
       {recent.length > 0 && (
         <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: PRIMARY }}>
-          <strong>{recentAttended}</strong> of your last {recent.length}
-
+          <strong>{recentAttended}</strong> {t('attendanceLive.ofLast', { count: recent.length })}
         </p>
       )}
     </div>

--- a/components/stats/cards/AttendanceSessionStrip.tsx
+++ b/components/stats/cards/AttendanceSessionStrip.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
+
 /**
  * Recent-form attendance row. Shows the last N actual sessions as larger
  * played/missed dots (newest on the right) — a sports-style "form guide" that
@@ -41,12 +43,13 @@ export function recentSessions(history: HistoryEntry[], limit = 8) {
 }
 
 export default function AttendanceSessionStrip({ history, limit = 8 }: Props) {
+  const t = useTranslations('stats');
   const sessions = recentSessions(history, limit);
 
   if (sessions.length === 0) {
     return (
       <p style={{ margin: 0, fontSize: 'var(--fs-sm)', color: MUTED }}>
-        No sessions in this window yet.
+        {t('sessionStrip.empty')}
       </p>
     );
   }
@@ -54,11 +57,11 @@ export default function AttendanceSessionStrip({ history, limit = 8 }: Props) {
   return (
     <div
       role="img"
-      aria-label={`Recent form across the last ${sessions.length} session${sessions.length === 1 ? '' : 's'}`}
+      aria-label={t('sessionStrip.ariaLabel', { count: sessions.length })}
       style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}
     >
       {sessions.map((s) => {
-        const label = `${s.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} — ${s.attended ? 'played' : 'missed'}`;
+        const label = `${s.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} — ${s.attended ? t('sessionStrip.played') : t('sessionStrip.missed')}`;
         return (
           <div
             key={s.sessionId}

--- a/messages/en.json
+++ b/messages/en.json
@@ -292,6 +292,45 @@
         "nice_shot": "Nice shot"
       }
     },
+    "offline": "You're offline — reconnect to save.",
+    "streak": {
+      "personalBestLabel": "{name} — Personal Best",
+      "streakLabel": "{name}'s Streak",
+      "streakLine": "You're on a {count, plural, one {# week} other {# weeks}} streak",
+      "personalBestSub": "Tied or beating your longest run of {count}.",
+      "longestRunSub": "Longest run: {count, plural, one {# week} other {# weeks}}. Keep showing up.",
+      "ariaStreak": "{count, plural, one {# week attendance streak for {name}} other {# weeks attendance streak for {name}}}",
+      "ariaInsight": "Insight for {name}",
+      "readTitle": "Your read",
+      "beta": "Beta",
+      "reading": "Reading the dots…",
+      "lastWeek": "Last week",
+      "focus": "This week · Focus",
+      "readError": "Couldn't load your read — refresh to retry."
+    },
+    "attendanceLive": {
+      "title": "Your stats",
+      "prompt": "Sign in or create an account to see your personalized stats.",
+      "loadError": "Couldn't load that — refresh to try again.",
+      "recentForm": "Your recent form",
+      "viewingAs": "viewing as",
+      "change": "change",
+      "ofLast": "of your last {count}"
+    },
+    "sessionStrip": {
+      "empty": "No sessions in this window yet.",
+      "ariaLabel": "Recent form across the last {count, plural, one {# session} other {# sessions}}",
+      "played": "played",
+      "missed": "missed"
+    },
+    "summaryGreeting": {
+      "ariaLabel": "Your AI summary",
+      "beta": "Beta"
+    },
+    "insightChip": {
+      "aiGenerated": "AI generated",
+      "aiBadge": "AI"
+    },
     "comingSoon": "Coming soon",
     "moreComing": "other metrics in the making",
     "progression": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -292,6 +292,45 @@
         "nice_shot": "好球"
       }
     },
+    "offline": "你已离线——重新联网后再保存。",
+    "streak": {
+      "personalBestLabel": "{name} — 个人最佳",
+      "streakLabel": "{name}的连续出勤",
+      "streakLine": "你已连续出勤 {count, plural, other {# 周}}",
+      "personalBestSub": "追平或超越了你最长的 {count} 周纪录。",
+      "longestRunSub": "最长连续 {count, plural, other {# 周}}。继续保持。",
+      "ariaStreak": "{count, plural, other {{name}连续出勤 # 周}}",
+      "ariaInsight": "{name}的解读",
+      "readTitle": "为你解读",
+      "beta": "测试版",
+      "reading": "正在解读…",
+      "lastWeek": "上周",
+      "focus": "本周 · 重点",
+      "readError": "解读加载不出来 — 刷新再试一次。"
+    },
+    "attendanceLive": {
+      "title": "你的数据",
+      "prompt": "登录或创建账户，查看你的专属数据。",
+      "loadError": "暂时加载不出来 — 刷新再试一次。",
+      "recentForm": "你的近期状态",
+      "viewingAs": "正在查看",
+      "change": "更改",
+      "ofLast": "／最近 {count} 场"
+    },
+    "sessionStrip": {
+      "empty": "此时间段内还没有场次。",
+      "ariaLabel": "{count, plural, other {最近 # 场的近期状态}}",
+      "played": "已参加",
+      "missed": "缺席"
+    },
+    "summaryGreeting": {
+      "ariaLabel": "你的 AI 总结",
+      "beta": "测试版"
+    },
+    "insightChip": {
+      "aiGenerated": "AI 生成",
+      "aiBadge": "AI"
+    },
     "comingSoon": "即将推出",
     "moreComing": "更多指标制作中",
     "progression": {


### PR DESCRIPTION
## Why

Two follow-ups from the Stats-page audit — you asked for both.

## A. i18n — translate hardcoded strings (High)

Five user-facing cards rendered English string **literals** that bypassed next-intl, so zh-CN users saw ~half the Stats tab in English. The two headline reads (`StreakSummaryCard`, `AttendanceCardLive`) didn't even import `useTranslations`.

Routed every user-visible string — labels, streak lines, aria-labels, badge text — through `t()` in:
- `StreakSummaryCard`, `AttendanceCardLive`, `AttendanceSessionStrip`, `SummaryGreeting`, `InsightChip`

Added keys under the `stats` namespace in **both** `en.json` and `zh-CN.json` (real Chinese translations matching existing tone; locale parity holds at 397 leaf keys each side). Counts use ICU plural (`{count, plural, …}`); Chinese uses the single `other` branch, as it should.

## B. Offline gating — 3 mutation sheets (Med-High)

`CheckInSheet`, `GameLoggerSheet`, and `GearSheet` let users tap Save / Log / Pick while offline, then failed silently after the fetch threw — violating the repo's legible-fail rule. Now they mirror `GiveKudosCard`: the action is gated on `useOnline()` (disabled + a shared `stats.offline` notice).

## Scope note
Admin-only `SkillsRadar`/`SkillsTab` strings and the `GearSheet` example placeholder are a deliberate separate follow-up (admin surface, behind flags).

## Verification
`npm run lint` → 0 errors · `npm test` → **1093 passed** (incl. locale-parity + canary-strings + plural + fallback tests) · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_