### PR TITLE
Guard against finalizing the cost split while sign-ups are open

### DIFF
--- a/__tests__/components/NextSessionCard.test.tsx
+++ b/__tests__/components/NextSessionCard.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, waitFor, fireEvent } from '@testing-library/react';
 import NextSessionCard from '@/components/admin/CommandCenter/NextSessionCard';
 
@@ -214,6 +214,90 @@ describe('<NextSessionCard />', () => {
         expect(screen.getByText(/Share again — \$15 each/)).toBeTruthy();
         expect(screen.getByText(/Edit bill/)).toBeTruthy();
         expect(screen.queryByText(/Send the bill/)).toBeNull();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('warns before finalizing while sign-ups are open, and aborts if declined', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      let settlePosted = false;
+      global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        const method = init?.method ?? 'GET';
+        if (method === 'POST' && url.includes('/api/session/settle')) { settlePosted = true; return new Response('{}', { status: 200 }); }
+        if (url.includes('/api/players')) return new Response(JSON.stringify([{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }]), { status: 200 });
+        if (url.includes('/api/session')) return new Response(JSON.stringify(
+          { id: 's', title: 'X', datetime: new Date(Date.now() + 86_400_000).toISOString(), deadline: new Date(Date.now() + 3_600_000).toISOString(), courts: 2, maxPlayers: 12, signupOpen: true },
+        ), { status: 200 });
+        return new Response('nf', { status: 404 });
+      }) as typeof fetch;
+      try {
+        render(<NextSessionCard onShareCost={() => {}} />);
+        fireEvent.click(await screen.findByRole('button', { name: /Finalize cost/ }));
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(confirmSpy.mock.calls[0][0]).toMatch(/3 players/);
+        await waitFor(() => expect(confirmSpy).toHaveBeenCalled());
+        expect(settlePosted).toBe(false);
+      } finally {
+        confirmSpy.mockRestore();
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('finalizes when the open-signups warning is accepted', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      let settlePosted = false;
+      global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        const method = init?.method ?? 'GET';
+        if (method === 'POST' && url.includes('/api/session/settle')) { settlePosted = true; return new Response('{}', { status: 200 }); }
+        if (url.includes('/api/players')) return new Response(JSON.stringify([{ id: 'p1' }, { id: 'p2' }]), { status: 200 });
+        if (url.includes('/api/session')) return new Response(JSON.stringify(
+          { id: 's', title: 'X', datetime: new Date(Date.now() + 86_400_000).toISOString(), deadline: new Date(Date.now() + 3_600_000).toISOString(), courts: 2, maxPlayers: 12, signupOpen: true },
+        ), { status: 200 });
+        return new Response('nf', { status: 404 });
+      }) as typeof fetch;
+      try {
+        render(<NextSessionCard onShareCost={() => {}} />);
+        fireEvent.click(await screen.findByRole('button', { name: /Finalize cost/ }));
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(settlePosted).toBe(true));
+      } finally {
+        confirmSpy.mockRestore();
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('flags a stale split when the roster changed since finalizing', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // Frozen at 6 players; 3 active now → stale.
+        mockFetch(makeFetcher(settledSession, [{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }]));
+        render(<NextSessionCard onShareCost={() => {}} />);
+        await waitFor(() => expect(screen.getByText(/Roster changed since you finalized/)).toBeTruthy());
+        expect(screen.getByText(/3 now vs 6 when sent/)).toBeTruthy();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('does NOT flag a stale split when the roster still matches', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // 6 frozen, 6 active now → matches, no nudge.
+        mockFetch(makeFetcher(settledSession, [
+          { id: 'p1' }, { id: 'p2' }, { id: 'p3' }, { id: 'p4' }, { id: 'p5' }, { id: 'p6' },
+        ]));
+        render(<NextSessionCard onShareCost={() => {}} />);
+        await waitFor(() => expect(screen.getByText(/Sent · \$15/)).toBeTruthy());
+        expect(screen.queryByText(/Roster changed since you finalized/)).toBeNull();
       } finally {
         process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
       }

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -118,6 +118,17 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
   // (admin presses again to share to a different chat), only the
   // share-sheet step runs.
   const sendBill = useCallback(async () => {
+    // Guardrail: finalizing while sign-ups are still open freezes the split at
+    // the current headcount — anyone who signs up later won't change what's
+    // owed. This is the #1 way an admin ends up with a stale per-person amount
+    // (settle early at 9 players → everyone locked at that rate even when 11
+    // eventually play). Warn before locking.
+    if (session?.signupOpen === true) {
+      const ok = confirm(
+        `Sign-ups are still open — finalizing now locks the split at ${activeCount} player${activeCount === 1 ? '' : 's'}. Anyone who signs up later won't change what everyone owes.\n\nClose sign-ups (or wait until after the session) first if the roster isn't final.\n\nFinalize anyway?`,
+      );
+      if (!ok) return;
+    }
     setSettleError(null);
     setSettling(true);
     try {
@@ -134,7 +145,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
     } finally {
       setSettling(false);
     }
-  }, [load, onShareCost]);
+  }, [load, onShareCost, session?.signupOpen, activeCount]);
 
   const editBill = useCallback(async () => {
     if (!confirm("Edit the bill? This clears what each person owes (paid checkmarks stay).")) return;
@@ -197,6 +208,13 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
   const countdown = fmtCountdown(session.deadline);
   const open = session.signupOpen === true;
   const isSettled = settleFlagOn && !!session.settled;
+  // The active roster no longer matches what was frozen at finalize time — the
+  // per-person split is now stale. Gated on activeCount > 0 so a failed player
+  // load (0) can't false-alarm. `playerNames.length` is the raw active count
+  // captured at settle, the apples-to-apples comparison to `activeCount`.
+  const settledRosterSize = session.settled?.playerNames?.length;
+  const rosterChanged =
+    isSettled && activeCount > 0 && typeof settledRosterSize === 'number' && settledRosterSize !== activeCount;
 
   return (
     <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Next session">
@@ -335,6 +353,19 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
             </button>
           )}
         </div>
+      )}
+
+      {rosterChanged && (
+        <p
+          role="status"
+          className="fs-sm"
+          style={{ color: 'var(--amber)', margin: 0, display: 'flex', alignItems: 'flex-start', gap: 6 }}
+        >
+          <span className="material-icons" style={{ fontSize: 'var(--icon-sm)', flexShrink: 0 }} aria-hidden="true">warning</span>
+          <span>
+            Roster changed since you finalized ({activeCount} now vs {settledRosterSize} when sent) — the split is stale. Tap &ldquo;Edit bill&rdquo; to recompute.
+          </span>
+        </p>
       )}
 
       {settleError && (


### PR DESCRIPTION
## Why

Debugging a reported "total cost is inconsistent" bug (settled early at ~9 players → everyone locked at $19.28 even though 11 now play), the root cause was **finalizing the cost while sign-ups were still open**. Settle deliberately freezes the split so late signups can't change an already-sent bill — but doing it *before* the roster is final locks in a stale per-person amount. The calculation itself was correct; the workflow footgun wasn't guarded.

## Guardrails (in `NextSessionCard`)

1. **Confirm before finalizing with sign-ups open** — "Finalize cost" while `signupOpen === true` now prompts: *"Sign-ups are still open — finalizing now locks the split at N players … Finalize anyway?"* (names the exact headcount it will freeze).
2. **Stale-split nudge** — a settled session whose current active roster no longer matches the frozen snapshot shows: *"Roster changed since you finalized (N now vs M when sent) — the split is stale. Tap Edit bill to recompute."* Gated on `activeCount > 0` so a failed player-load can't false-alarm.

No math change — this prevents the premature freeze and surfaces it when it has already happened (which is exactly the current situation). Uses the `warning` glyph (already in the icon subset).

## Tests
Cover confirm-abort (no settle POST), confirm-proceed (settle fires), and both nudge states (roster changed → shown; roster matches → hidden).

## Verification
`npm run lint` → 0 errors · `npm test` → **1097 passed** · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_