### PR TITLE
Don't show frozen per-player owed amounts on an unsettled session

### DIFF
--- a/__tests__/components/PaymentsCard.test.tsx
+++ b/__tests__/components/PaymentsCard.test.tsx
@@ -187,6 +187,26 @@ describe('<PaymentsCard />', () => {
       }
     });
 
+    it('hides per-row $ once the session is unsettled, even if owedAmount lingers on player docs', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // ACTIVE_SESSION is unsettled, but the players still carry a frozen
+        // owedAmount from a settle that was later undone ("Edit bill"). The
+        // stale amount must NOT render — a per-person owed only means anything
+        // while the session is settled. (Regression: it used to stay on-screen.)
+        fetchPlayers([
+          { id: 'p1', name: 'Daisy', paid: true, owedAmount: 19.28 },
+          { id: 'p2', name: 'Mei', paid: false, owedAmount: 19.28 },
+        ]);
+        render(<PaymentsCard />);
+        await waitFor(() => expect(screen.getByText('Daisy')).toBeTruthy());
+        expect(screen.queryByText('$19.28')).toBeNull();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
     it('summary header: shows players · % paid · $ each for the viewed session', async () => {
       const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
       process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';

--- a/components/admin/CommandCenter/PaymentsCard.tsx
+++ b/components/admin/CommandCenter/PaymentsCard.tsx
@@ -590,7 +590,7 @@ export default function PaymentsCard({ refreshKey = 0, onOpenPlayer, initialSess
                 )}
               </span>
               <div className="flex items-center gap-1 flex-shrink-0">
-                {settleFlagOn && typeof player.owedAmount === 'number' && !player.writtenOff && (
+                {settleFlagOn && !!viewedSession?.settled && typeof player.owedAmount === 'number' && !player.writtenOff && (
                   <span
                     className="fs-sm font-medium px-2"
                     style={{


### PR DESCRIPTION
## The bug

Reported live: after unsettling a session ("Edit bill" → the Next-session card correctly flips back to "Finalize cost"), the Payments card **still shows a frozen `$19.28` tag next to every player's name**.

Root cause: the per-row owed-amount tag in `PaymentsCard` is gated only on `settleFlagOn && typeof player.owedAmount === 'number' && !writtenOff` — it never checks whether the **session is still settled**. So a frozen `owedAmount` left on the player docs keeps rendering after the session is unsettled, showing a stale per-person figure that no longer applies.

## The fix

Also gate the per-row amount on `!!viewedSession?.settled`. A per-person owed figure is only meaningful while the session is settled; once unsettled, the header shows the live split and no frozen per-row tags render. Any orphaned `owedAmount` still on the docs is now never displayed (and gets overwritten on the next finalize; `classifyOwed` already ignores it for unsettled sessions, so balances were never wrong — only this display was).

Existing per-row tests use a **settled** session, so they still pass. Added a regression test: unsettled session + lingering `owedAmount` → no per-row `$`.

## Verification
`npm run lint` → 0 errors · `npm test` → **1098 passed** · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_