### PR TITLE
Reload Payments card after settle/unsettle; fix "0 of us" cost preview

### DIFF
--- a/__tests__/components/NextSessionCard.test.tsx
+++ b/__tests__/components/NextSessionCard.test.tsx
@@ -302,5 +302,52 @@ describe('<NextSessionCard />', () => {
         process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
       }
     });
+
+    it('fires onChanged after a successful finalize (so sibling cards reload)', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      let changed = 0;
+      global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        const method = init?.method ?? 'GET';
+        if (method === 'POST' && url.includes('/api/session/settle')) return new Response('{}', { status: 200 });
+        if (url.includes('/api/players')) return new Response(JSON.stringify([{ id: 'p1' }, { id: 'p2' }]), { status: 200 });
+        // signupOpen:false → no confirm guard on finalize.
+        if (url.includes('/api/session')) return new Response(JSON.stringify(
+          { id: 's', title: 'X', datetime: new Date(Date.now() + 86_400_000).toISOString(), deadline: new Date(Date.now() + 3_600_000).toISOString(), courts: 2, maxPlayers: 12, signupOpen: false },
+        ), { status: 200 });
+        return new Response('nf', { status: 404 });
+      }) as typeof fetch;
+      try {
+        render(<NextSessionCard onShareCost={() => {}} onChanged={() => { changed += 1; }} />);
+        fireEvent.click(await screen.findByRole('button', { name: /Finalize cost/ }));
+        await waitFor(() => expect(changed).toBe(1));
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('fires onChanged after a successful unsettle (Edit bill)', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      let changed = 0;
+      global.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        const method = init?.method ?? 'GET';
+        if (method === 'DELETE' && url.includes('/api/session/settle')) return new Response('{}', { status: 200 });
+        if (url.includes('/api/players')) return new Response(JSON.stringify([]), { status: 200 });
+        if (url.includes('/api/session')) return new Response(JSON.stringify(settledSession), { status: 200 });
+        return new Response('nf', { status: 404 });
+      }) as typeof fetch;
+      try {
+        render(<NextSessionCard onShareCost={() => {}} onChanged={() => { changed += 1; }} />);
+        fireEvent.click(await screen.findByRole('button', { name: /Edit bill/ }));
+        await waitFor(() => expect(changed).toBe(1));
+      } finally {
+        confirmSpy.mockRestore();
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
   });
 });

--- a/components/admin/CommandCenter/CommandCenter.tsx
+++ b/components/admin/CommandCenter/CommandCenter.tsx
@@ -129,6 +129,7 @@ export default function CommandCenter({ refreshKey, setView, onExit }: CommandCe
         onEdit={() => setView('session-details')}
         onAdvance={() => setView('advance')}
         onShareCost={() => openReceipt({ mode: 'group' })}
+        onChanged={() => setLocalRefresh((n) => n + 1)}
       />
       <AdminDashTiles
         onOpenBirds={() => setView('birds')}

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -35,6 +35,12 @@ interface NextSessionCardProps {
    *  to the group chat" action. Belongs alongside session details since
    *  it's about the session, not about whose payment has come in. */
   onShareCost?: () => void;
+  /** Fired after a settle/unsettle succeeds. The parent bumps its shared
+   *  refresh key so sibling cards (esp. PaymentsCard, which reads the frozen
+   *  per-person + owed amounts) reload instead of showing the pre-change
+   *  snapshot. Without it, unsettling here leaves the Payments card showing a
+   *  stale "$X each". */
+  onChanged?: () => void;
 }
 
 function fmtCountdown(deadline: string | undefined): string | null {
@@ -50,7 +56,7 @@ function fmtCountdown(deadline: string | undefined): string | null {
   return `${mins}m`;
 }
 
-export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onShareCost }: NextSessionCardProps) {
+export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onShareCost, onChanged }: NextSessionCardProps) {
   const [session, setSession] = useState<Session | null>(null);
   const [activeCount, setActiveCount] = useState<number>(0);
   const [waitlistCount, setWaitlistCount] = useState<number>(0);
@@ -139,13 +145,14 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         return;
       }
       await load();
+      onChanged?.();
       onShareCost?.();
     } catch {
       setSettleError("Couldn't reach server. Try again.");
     } finally {
       setSettling(false);
     }
-  }, [load, onShareCost, session?.signupOpen, activeCount]);
+  }, [load, onChanged, onShareCost, session?.signupOpen, activeCount]);
 
   const editBill = useCallback(async () => {
     if (!confirm("Edit the bill? This clears what each person owes (paid checkmarks stay).")) return;
@@ -159,12 +166,13 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         return;
       }
       await load();
+      onChanged?.();
     } catch {
       setSettleError("Couldn't reach server. Try again.");
     } finally {
       setSettling(false);
     }
-  }, [load]);
+  }, [load, onChanged]);
 
   // Open/close sign-ups in place — optimistic flip + rollback on failure.
   // `PUT /api/session` is a read-merge and only targets the active session,

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -69,7 +69,8 @@ export default function SetupPage({ onBack }: SetupPageProps) {
   const [originalSessionTubes, setOriginalSessionTubes] = useState<Map<string, number>>(new Map());
 
   // Live data for the Share preview.
-  const [activePlayerCount, setActivePlayerCount] = useState(0);
+  const [activePlayerNames, setActivePlayerNames] = useState<string[]>([]);
+  const activePlayerCount = activePlayerNames.length;
   const [recipient, setRecipient] = useState<{ name: string; email: string; memo?: string } | null>(null);
 
   // Recent costs for chip suggestions
@@ -95,7 +96,7 @@ export default function SetupPage({ onBack }: SetupPageProps) {
       const session = sessionRes.ok ? await sessionRes.json() as Session : null;
       const birds = birdsRes.ok ? await birdsRes.json() as { purchases: BirdPurchase[]; currentStock?: number } : null;
       const allSessions = sessionsRes.ok ? await sessionsRes.json() as Session[] : [];
-      const players = playersRes.ok ? await playersRes.json() as Array<{ removed?: boolean; waitlisted?: boolean }> : [];
+      const players = playersRes.ok ? await playersRes.json() as Array<{ name?: string; removed?: boolean; waitlisted?: boolean }> : [];
       const members = membersRes.ok ? await membersRes.json() as Array<{ role?: string; eTransferRecipient?: { name: string; email: string; memo?: string } }> : [];
       const costs = recentCostsRes.ok ? await recentCostsRes.json() as { costs: number[] } : null;
 
@@ -144,7 +145,9 @@ export default function SetupPage({ onBack }: SetupPageProps) {
         }
       }
 
-      setActivePlayerCount(players.filter((p) => !p.removed && !p.waitlisted).length);
+      setActivePlayerNames(
+        players.filter((p) => !p.removed && !p.waitlisted).map((p) => p.name).filter((n): n is string => !!n),
+      );
 
       const adminMember = Array.isArray(members) ? members.find((m) => m.role === 'admin') : null;
       const sessionRecipient = (session as Session & { eTransferRecipient?: { name: string; email: string; memo?: string } } | null)?.eTransferRecipient;
@@ -261,11 +264,11 @@ export default function SetupPage({ onBack }: SetupPageProps) {
       costPerPerson: perPlayer,
       courts,
       totalCost,
-      playerNames: [],
+      playerNames: activePlayerNames,
       recipient: { name: recipient.name, email: recipient.email },
       memoTemplate: recipient.memo,
     };
-  }, [recipient, date, time, perPlayer, courts, totalCost]);
+  }, [recipient, date, time, perPlayer, courts, totalCost, activePlayerNames]);
 
   const previewText = receiptInput ? renderGroupText(receiptInput) : '';
 


### PR DESCRIPTION
## Context

Follow-up on the stuck-$19.28 report, from live screenshots on bpm-next. I reproduced the settle flow locally and **confirmed the backend is correct** — after unsettle, re-finalizing recomputes from the *current* saved cost + roster (126 ÷ 10 = $12.60 in the repro). So the frozen amount was never a settle-math bug. Two client-side gaps made a correctly-frozen number look stuck:

## Fixes

**1. Stale Payments card after unsettle.** `NextSessionCard`'s finalize/unsettle only reloaded *itself* — the shared `CommandCenter` refresh key never bumped, so `PaymentsCard` kept showing the pre-change snapshot. (In the screenshots: the Next-session card correctly flipped to "Finalize cost" while Payments still read "$19.28 each".) `NextSessionCard` now fires an `onChanged` callback after a successful finalize/unsettle, and `CommandCenter` bumps `localRefresh` so sibling cards reload.

**2. "0 of us" in the cost-form share preview.** `SetupPage` hardcoded `playerNames: []` in the receipt input, so the preview printed "0 of us" (and an empty WHO-PLAYED list) even with a full roster. It already loads the active roster for the per-person denominator — now it keeps the names and feeds them to the preview (the count derives from them).

## Tests
`onChanged` fires after finalize and after unsettle.

## Verification
`npm run lint` → 0 errors · `npm test` → **1100 passed** · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_