### PR TITLE
Warn when the cost changed after a bill was finalized

### DIFF
--- a/__tests__/components/NextSessionCard.test.tsx
+++ b/__tests__/components/NextSessionCard.test.tsx
@@ -163,12 +163,15 @@ describe('<NextSessionCard />', () => {
     };
     const settledSession = {
       ...session,
+      // costPerCourt × courts (45 × 2 = 90) matches settled.totalCost, so the
+      // live cost equals the frozen cost → no false "cost changed" nudge.
+      costPerCourt: 45,
       settled: {
         at: '2026-05-08T20:00:00.000Z',
         costPerPerson: 15,
         totalCost: 90,
-        courtTotal: 60,
-        birdTotal: 30,
+        courtTotal: 90,
+        birdTotal: 0,
         playerCount: 6,
         playerNames: ['Alice', 'Bob', 'Carol', 'Dan', 'Eve', 'Frank'],
       },
@@ -287,17 +290,37 @@ describe('<NextSessionCard />', () => {
       }
     });
 
-    it('does NOT flag a stale split when the roster still matches', async () => {
+    it('does NOT flag a stale split when the roster and cost still match', async () => {
       const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
       process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
       try {
-        // 6 frozen, 6 active now → matches, no nudge.
+        // 6 frozen, 6 active now + live cost == frozen cost → no nudge at all.
         mockFetch(makeFetcher(settledSession, [
           { id: 'p1' }, { id: 'p2' }, { id: 'p3' }, { id: 'p4' }, { id: 'p5' }, { id: 'p6' },
         ]));
         render(<NextSessionCard onShareCost={() => {}} />);
         await waitFor(() => expect(screen.getByText(/Sent · \$15/)).toBeTruthy());
         expect(screen.queryByText(/Roster changed since you finalized/)).toBeNull();
+        expect(screen.queryByText(/cost changed since you finalized/i)).toBeNull();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('flags a stale bill when the cost changed after finalizing (Edit-bill footgun)', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // Frozen at $90 total, but the court cost was edited down (30 × 2 = 60
+        // live) after finalizing → the bill is stale until unsettled.
+        const costEdited = { ...settledSession, costPerCourt: 30 };
+        mockFetch(makeFetcher(costEdited, [
+          { id: 'p1' }, { id: 'p2' }, { id: 'p3' }, { id: 'p4' }, { id: 'p5' }, { id: 'p6' },
+        ]));
+        render(<NextSessionCard onShareCost={() => {}} />);
+        await waitFor(() => expect(screen.getByText(/cost changed since you finalized/i)).toBeTruthy());
+        // Names the frozen vs live totals and points at Edit bill.
+        expect(screen.getByText(/\$60\.00 now vs \$90\.00 when sent/)).toBeTruthy();
       } finally {
         process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
       }

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState, useCallback } from 'react';
 import { fmtSessionLabel as fmtDate, fmtDeadline } from '@/lib/fmt';
 import { isFlagOn } from '@/lib/flags';
-import type { SettledSnapshot } from '@/lib/types';
+import type { SettledSnapshot, BirdUsage } from '@/lib/types';
+import { sessionCostTotals } from '@/lib/sessionCost';
 import CardSkeleton from '@/components/primitives/CardSkeleton';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 
@@ -18,6 +19,8 @@ interface Session {
   maxPlayers?: number;
   signupOpen?: boolean;
   costPerCourt?: number;
+  birdUsage?: BirdUsage;
+  birdUsages?: BirdUsage[];
   settled?: SettledSnapshot;
 }
 
@@ -223,6 +226,21 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
   const settledRosterSize = session.settled?.playerNames?.length;
   const rosterChanged =
     isSettled && activeCount > 0 && typeof settledRosterSize === 'number' && settledRosterSize !== activeCount;
+  // The cost inputs changed after finalizing. A finalized bill is frozen, so
+  // editing court/bird cost does NOT update what people owe — the Payments card
+  // keeps showing the frozen per-person until the admin unsettles. This is the
+  // single most confusing footgun (admin edits the cost, saves, and the amount
+  // "won't change"). Surface it explicitly.
+  const frozenTotal = session.settled?.totalCost;
+  const liveTotal = sessionCostTotals({
+    costPerCourt: session.costPerCourt ?? 0,
+    courts: session.courts ?? 0,
+    birdUsage: session.birdUsage,
+    birdUsages: session.birdUsages,
+  }).totalCost;
+  const costChanged =
+    isSettled && typeof frozenTotal === 'number' && Math.abs(liveTotal - frozenTotal) > 0.01;
+  const staleBill = rosterChanged || costChanged;
 
   return (
     <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Next session">
@@ -363,7 +381,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         </div>
       )}
 
-      {rosterChanged && (
+      {staleBill && (
         <p
           role="status"
           className="fs-sm"
@@ -371,7 +389,15 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         >
           <span className="material-icons" style={{ fontSize: 'var(--icon-sm)', flexShrink: 0 }} aria-hidden="true">warning</span>
           <span>
-            Roster changed since you finalized ({activeCount} now vs {settledRosterSize} when sent) — the split is stale. Tap &ldquo;Edit bill&rdquo; to recompute.
+            {costChanged ? (
+              <>
+                This bill is locked at ${session.settled?.costPerPerson} each. The cost changed since you finalized (${liveTotal.toFixed(2)} now vs ${frozenTotal?.toFixed(2)} when sent) — editing the cost doesn&rsquo;t update a bill that&rsquo;s already out. Tap &ldquo;Edit bill&rdquo; to unfreeze, then Finalize again.
+              </>
+            ) : (
+              <>
+                Roster changed since you finalized ({activeCount} now vs {settledRosterSize} when sent) — the split is stale. Tap &ldquo;Edit bill&rdquo; to recompute.
+              </>
+            )}
           </span>
         </p>
       )}


### PR DESCRIPTION
## What I reproduced

Using the app locally (bpm-next mock), I nailed down the "$19.28 won't go away" report:

```
Finalize at cost $134  →  frozen $19.14 each
Edit cost down to $126  →  settled snapshot STILL present, still frozen $19.14, costPerCourt now 63
```

**A finalized bill is frozen.** Editing the court/bird cost afterward doesn't change what people owe — the Payments card keeps showing the frozen per-person while the cost form shows the new live amount. Admins (understandably) read this as "the app won't update," when the real action is **Edit bill** (unsettle) → then Finalize again.

## Fix

The v1.5 stale-bill nudge only checked the **roster** (11 == 11 → stayed silent, which is why the user got no hint). It now **also** fires when the live cost differs from the frozen `settled.totalCost`, with an explicit message:

> ⚠️ This bill is locked at $X each. The cost changed since you finalized ($60.00 now vs $90.00 when sent) — editing the cost doesn't update a bill that's already out. Tap "Edit bill" to unfreeze, then Finalize again.

Purely additive UI guidance — no settle/cost logic changed.

## Tests
- Cost-changed nudge renders with the correct frozen-vs-live totals.
- No nudge when roster **and** cost still match (fixture cost inputs aligned to the frozen total).

## Verification
`npm run lint` → 0 errors · `npm test` → **1101 passed** · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_