### PR TITLE
Cost form: total all shuttle purchases, not just the one it edits

### DIFF
--- a/__tests__/components/NextSessionCard.test.tsx
+++ b/__tests__/components/NextSessionCard.test.tsx
@@ -163,12 +163,15 @@ describe('<NextSessionCard />', () => {
     };
     const settledSession = {
       ...session,
+      // costPerCourt × courts (45 × 2 = 90) matches settled.totalCost, so the
+      // live cost equals the frozen cost → no false "cost changed" nudge.
+      costPerCourt: 45,
       settled: {
         at: '2026-05-08T20:00:00.000Z',
         costPerPerson: 15,
         totalCost: 90,
-        courtTotal: 60,
-        birdTotal: 30,
+        courtTotal: 90,
+        birdTotal: 0,
         playerCount: 6,
         playerNames: ['Alice', 'Bob', 'Carol', 'Dan', 'Eve', 'Frank'],
       },
@@ -287,17 +290,37 @@ describe('<NextSessionCard />', () => {
       }
     });
 
-    it('does NOT flag a stale split when the roster still matches', async () => {
+    it('does NOT flag a stale split when the roster and cost still match', async () => {
       const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
       process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
       try {
-        // 6 frozen, 6 active now → matches, no nudge.
+        // 6 frozen, 6 active now + live cost == frozen cost → no nudge at all.
         mockFetch(makeFetcher(settledSession, [
           { id: 'p1' }, { id: 'p2' }, { id: 'p3' }, { id: 'p4' }, { id: 'p5' }, { id: 'p6' },
         ]));
         render(<NextSessionCard onShareCost={() => {}} />);
         await waitFor(() => expect(screen.getByText(/Sent · \$15/)).toBeTruthy());
         expect(screen.queryByText(/Roster changed since you finalized/)).toBeNull();
+        expect(screen.queryByText(/cost changed since you finalized/i)).toBeNull();
+      } finally {
+        process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
+      }
+    });
+
+    it('flags a stale bill when the cost changed after finalizing (Edit-bill footgun)', async () => {
+      const prev = process.env.NEXT_PUBLIC_FLAG_SETTLE;
+      process.env.NEXT_PUBLIC_FLAG_SETTLE = 'true';
+      try {
+        // Frozen at $90 total, but the court cost was edited down (30 × 2 = 60
+        // live) after finalizing → the bill is stale until unsettled.
+        const costEdited = { ...settledSession, costPerCourt: 30 };
+        mockFetch(makeFetcher(costEdited, [
+          { id: 'p1' }, { id: 'p2' }, { id: 'p3' }, { id: 'p4' }, { id: 'p5' }, { id: 'p6' },
+        ]));
+        render(<NextSessionCard onShareCost={() => {}} />);
+        await waitFor(() => expect(screen.getByText(/cost changed since you finalized/i)).toBeTruthy());
+        // Names the frozen vs live totals and points at Edit bill.
+        expect(screen.getByText(/\$60\.00 now vs \$90\.00 when sent/)).toBeTruthy();
       } finally {
         process.env.NEXT_PUBLIC_FLAG_SETTLE = prev;
       }

--- a/components/admin/CommandCenter/NextSessionCard.tsx
+++ b/components/admin/CommandCenter/NextSessionCard.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState, useCallback } from 'react';
 import { fmtSessionLabel as fmtDate, fmtDeadline } from '@/lib/fmt';
 import { isFlagOn } from '@/lib/flags';
-import type { SettledSnapshot } from '@/lib/types';
+import type { SettledSnapshot, BirdUsage } from '@/lib/types';
+import { sessionCostTotals } from '@/lib/sessionCost';
 import CardSkeleton from '@/components/primitives/CardSkeleton';
 import { BottomSheet, BottomSheetHeader, BottomSheetBody } from '@/components/BottomSheet';
 
@@ -18,6 +19,8 @@ interface Session {
   maxPlayers?: number;
   signupOpen?: boolean;
   costPerCourt?: number;
+  birdUsage?: BirdUsage;
+  birdUsages?: BirdUsage[];
   settled?: SettledSnapshot;
 }
 
@@ -223,6 +226,21 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
   const settledRosterSize = session.settled?.playerNames?.length;
   const rosterChanged =
     isSettled && activeCount > 0 && typeof settledRosterSize === 'number' && settledRosterSize !== activeCount;
+  // The cost inputs changed after finalizing. A finalized bill is frozen, so
+  // editing court/bird cost does NOT update what people owe — the Payments card
+  // keeps showing the frozen per-person until the admin unsettles. This is the
+  // single most confusing footgun (admin edits the cost, saves, and the amount
+  // "won't change"). Surface it explicitly.
+  const frozenTotal = session.settled?.totalCost;
+  const liveTotal = sessionCostTotals({
+    costPerCourt: session.costPerCourt ?? 0,
+    courts: session.courts ?? 0,
+    birdUsage: session.birdUsage,
+    birdUsages: session.birdUsages,
+  }).totalCost;
+  const costChanged =
+    isSettled && typeof frozenTotal === 'number' && Math.abs(liveTotal - frozenTotal) > 0.01;
+  const staleBill = rosterChanged || costChanged;
 
   return (
     <section className="glass-card p-4 space-y-3 animate-fadeIn" aria-label="Next session">
@@ -363,7 +381,7 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         </div>
       )}
 
-      {rosterChanged && (
+      {staleBill && (
         <p
           role="status"
           className="fs-sm"
@@ -371,7 +389,15 @@ export default function NextSessionCard({ refreshKey = 0, onEdit, onAdvance, onS
         >
           <span className="material-icons" style={{ fontSize: 'var(--icon-sm)', flexShrink: 0 }} aria-hidden="true">warning</span>
           <span>
-            Roster changed since you finalized ({activeCount} now vs {settledRosterSize} when sent) — the split is stale. Tap &ldquo;Edit bill&rdquo; to recompute.
+            {costChanged ? (
+              <>
+                This bill is locked at ${session.settled?.costPerPerson} each. The cost changed since you finalized (${liveTotal.toFixed(2)} now vs ${frozenTotal?.toFixed(2)} when sent) — editing the cost doesn&rsquo;t update a bill that&rsquo;s already out. Tap &ldquo;Edit bill&rdquo; to unfreeze, then Finalize again.
+              </>
+            ) : (
+              <>
+                Roster changed since you finalized ({activeCount} now vs {settledRosterSize} when sent) — the split is stale. Tap &ldquo;Edit bill&rdquo; to recompute.
+              </>
+            )}
           </span>
         </p>
       )}

--- a/components/admin/CommandCenter/SetupPage.tsx
+++ b/components/admin/CommandCenter/SetupPage.tsx
@@ -171,10 +171,26 @@ export default function SetupPage({ onBack }: SetupPageProps) {
     [birdPurchases, tubePurchaseId],
   );
 
+  // Cost of shuttle purchases OTHER than the one this form edits. A session can
+  // carry tubes from ≥2 purchases (retro-assigned on the Birds page), but this
+  // form only edits ONE. Counting just the edited purchase made the total (and
+  // the "$ each" + share preview) read LOW — a stray second entry silently
+  // inflated the real bill while the form showed a smaller number. Total them
+  // all so the form never disagrees with the receipt/settle.
+  const otherBirdCost = useMemo(() => {
+    let sum = 0;
+    for (const [pid, t] of originalSessionTubes) {
+      if (pid === tubePurchaseId) continue; // edited line counted below
+      const p = birdPurchases.find((x) => x.id === pid);
+      if (p) sum += t * p.costPerTube;
+    }
+    return Math.round(sum * 100) / 100;
+  }, [originalSessionTubes, tubePurchaseId, birdPurchases]);
+
   const birdCost = useMemo(() => {
-    if (!tubePurchase) return 0;
-    return Math.round(tubes * tubePurchase.costPerTube * 100) / 100;
-  }, [tubes, tubePurchase]);
+    const edited = tubePurchase ? tubes * tubePurchase.costPerTube : 0;
+    return Math.round((edited + otherBirdCost) * 100) / 100;
+  }, [tubes, tubePurchase, otherBirdCost]);
 
   const courtCost = useMemo(() => (costPerCourt ?? 0) * courts, [costPerCourt, courts]);
   const totalCost = courtCost + birdCost;
@@ -468,6 +484,16 @@ export default function SetupPage({ onBack }: SetupPageProps) {
               incDisabled={atMax}
             />
           </div>
+        )}
+
+        {/* This session also carries shuttles from another purchase, which this
+            form can't edit. Surface its cost (it's already in the total) and
+            point to where it CAN be changed, so a stray entry can't hide. */}
+        {otherBirdCost > 0 && (
+          <p style={{ fontSize: 'var(--fs-xs)', color: 'var(--amber)', margin: 0, display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+            <span className="material-icons" style={{ fontSize: 'var(--icon-sm)', flexShrink: 0 }} aria-hidden="true">warning</span>
+            <span>+${otherBirdCost.toFixed(2)} of shuttles from another purchase is also on this session (included in the total above). Edit or remove it on the Birds page.</span>
+          </p>
         )}
 
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '2px 0' }}>


### PR DESCRIPTION
## Root cause (found via a live debugging session)

An admin reported "$19.28 per person won't go down no matter what I do." After pulling the real receipt total ($212.11), the cause was concrete:

**A session can carry shuttle tubes from more than one bird purchase** (retro-assigned on the Birds page), but `SetupPage`'s cost editor only ever loads and edits the **first** one (`existingUsages[0]`) and computed `birdCost` from that single purchase. So a session with a **stray second shuttle entry** showed a too-**low** total + "$ each" + share preview in the form, while the receipt / Payments card / settle — which sum **all** usages via `sessionCostTotals` — showed the true, higher number.

Concretely: session billed **$212.11** (2 courts $126 + ~2.2 tubes) while the cost form showed **$174.61** (1.25 tubes). The extra ~1 tube lived on a second purchase the form never surfaced — so the admin couldn't reconcile the two numbers, and couldn't even see or remove the stray entry from the cost screen.

## Fix

- `birdCost` now adds the cost of **every other** shuttle purchase on the session (from the load-time usage snapshot) to the edited line, so the form's total matches the receipt/settle.
- When such an entry exists, an amber note shows its cost and points to the **Birds page** (the only place it can be edited), so a stray tube can't silently inflate a bill again.

No change to billing/settle math (those were always correct) — this makes the **editor** stop under-reporting.

## Verification
`npm run lint` → 0 errors · `npm test` → **1101 passed** · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_