### PR TITLE
Shuttle model B (stage 1): pooled per-session usage at current price

### DIFF
--- a/__tests__/birdUsages.helpers.test.ts
+++ b/__tests__/birdUsages.helpers.test.ts
@@ -1,6 +1,35 @@
 import { describe, it, expect } from 'vitest';
-import { tubesUsedAcross, avgTubesPerSession, runwayWeeks, mergeBirdUsageEdit, snapshotBirdUsage } from '@/lib/birdUsages';
+import { tubesUsedAcross, avgTubesPerSession, runwayWeeks, mergeBirdUsageEdit, snapshotBirdUsage, currentPricePerTube, snapshotPooledUsage, POOLED_PURCHASE_ID } from '@/lib/birdUsages';
 import type { Session, BirdUsage } from '@/lib/types';
+
+describe('currentPricePerTube — latest purchase sets the going rate', () => {
+  it('returns the most recent purchase price by date', () => {
+    expect(currentPricePerTube([
+      { costPerTube: 30, date: '2026-06-01' },
+      { costPerTube: 35, date: '2026-07-01' },
+      { costPerTube: 33, date: '2026-05-20' },
+    ])).toBe(35);
+  });
+  it('returns 0 when there are no priced purchases', () => {
+    expect(currentPricePerTube([])).toBe(0);
+  });
+});
+
+describe('snapshotPooledUsage — pooled shuttle line at current price', () => {
+  it('tags the pooled sentinel and freezes the cost', () => {
+    expect(snapshotPooledUsage(1.25, 35)).toEqual({
+      purchaseId: POOLED_PURCHASE_ID,
+      purchaseName: 'Shuttles',
+      tubes: 1.25,
+      costPerTube: 35,
+      totalBirdCost: 43.75,
+    });
+  });
+  it('rounds cost to cents', () => {
+    // 1.5 * 38.89 = 58.335 → 58.34
+    expect(snapshotPooledUsage(1.5, 38.89).totalBirdCost).toBe(58.34);
+  });
+});
 
 describe('mergeBirdUsageEdit — preserve other purchases when editing one', () => {
   const sorted = (arr: { purchaseId: string; tubes: number }[]) =>

--- a/__tests__/birdWrite.test.ts
+++ b/__tests__/birdWrite.test.ts
@@ -56,4 +56,44 @@ describe('resolveBirdUsages', () => {
       expect(r.usages[0]).toMatchObject({ purchaseId: 'p1', purchaseName: 'Yonex AS-30', tubes: 2, totalBirdCost: 24 });
     }
   });
+
+  // A pooled entry (Model B: one "tubes used" number, no batch) snapshots at the
+  // CURRENT price = the most recent purchase's costPerTube.
+  function stubBirdsWithPurchases(purchases: unknown[], read?: () => Promise<{ resource: unknown }>) {
+    vi.spyOn(cosmos, 'getContainer').mockReturnValue({
+      item: () => ({ read: read ?? (() => Promise.resolve({ resource: undefined })) }),
+      items: { query: () => ({ fetchAll: () => Promise.resolve({ resources: purchases }) }) },
+    } as unknown as ReturnType<typeof cosmos.getContainer>);
+  }
+
+  it('snapshots a pooled entry at the current (latest) price-per-tube', async () => {
+    stubBirdsWithPurchases([
+      { costPerTube: 30, date: '2026-06-01' },
+      { costPerTube: 35, date: '2026-07-01' }, // latest → $35 is the going rate
+    ]);
+    const r = await resolveBirdUsages([{ pooled: true, tubes: 1.25 }]);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.usages).toHaveLength(1);
+      expect(r.usages[0]).toMatchObject({
+        purchaseId: 'pool', purchaseName: 'Shuttles', tubes: 1.25, costPerTube: 35, totalBirdCost: 43.75,
+      });
+    }
+  });
+
+  it('ignores adjustment docs when picking the current pooled price', async () => {
+    stubBirdsWithPurchases([
+      { costPerTube: 35, date: '2026-07-01' },
+      { type: 'adjustment', date: '2026-07-05' }, // no costPerTube — must not win
+    ]);
+    const r = await resolveBirdUsages([{ pooled: true, tubes: 1 }]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.usages[0]).toMatchObject({ costPerTube: 35, totalBirdCost: 35 });
+  });
+
+  it('pooled tubes:0 is dropped (removes the shuttle line)', async () => {
+    stubBirdsWithPurchases([{ costPerTube: 35, date: '2026-07-01' }]);
+    const r = await resolveBirdUsages([{ pooled: true, tubes: 0 }]);
+    expect(r).toEqual({ ok: true, usages: [] });
+  });
 });

--- a/lib/birdUsages.ts
+++ b/lib/birdUsages.ts
@@ -104,6 +104,53 @@ export function snapshotBirdUsage(
 }
 
 /**
+ * Sentinel `purchaseId` for a POOLED shuttle usage — a session that logged a
+ * single "tubes used" number at the current price-per-tube, with no specific
+ * purchase batch (the simplified "Model B" shuttle model). It is deliberately
+ * NOT a real purchase id (those are `randomBytes` hex), so:
+ *   - `remainingByPurchase` (which iterates real purchases) never attributes a
+ *     pooled tube to a batch — but `totalUsed`/`currentStock` still count it
+ *     (they sum every usage's `tubes`), so overall stock stays correct;
+ *   - the DELETE referential guard and AssignUsageSheet (both match a real
+ *     purchase id) simply ignore pooled entries.
+ * Cost still flows through the snapshotted `totalBirdCost`, so receipts /
+ * settle / history are unchanged.
+ */
+export const POOLED_PURCHASE_ID = 'pool';
+
+/**
+ * The "current price per tube" = the most recent purchase's `costPerTube`
+ * (latest by `date`). Buying a new batch at a new price moves the going rate;
+ * each session snapshots this at log time so past sessions never shift.
+ * Returns 0 when there are no priced purchases (caller shows $0 / "set a price").
+ */
+export function currentPricePerTube(
+  purchases: Array<Pick<BirdPurchase, 'costPerTube' | 'date'>>,
+): number {
+  let latest: Pick<BirdPurchase, 'costPerTube' | 'date'> | null = null;
+  for (const p of purchases) {
+    if (typeof p.costPerTube !== 'number' || !Number.isFinite(p.costPerTube)) continue;
+    if (!latest || (p.date ?? '') >= (latest.date ?? '')) latest = p;
+  }
+  return latest ? latest.costPerTube : 0;
+}
+
+/**
+ * Build a pooled `BirdUsage` snapshot: a session's single "tubes used" at the
+ * current price-per-tube, tagged with the `POOLED_PURCHASE_ID` sentinel. Same
+ * frozen cost shape as `snapshotBirdUsage`, so cost math is identical.
+ */
+export function snapshotPooledUsage(tubes: number, pricePerTube: number): BirdUsage {
+  return {
+    purchaseId: POOLED_PURCHASE_ID,
+    purchaseName: 'Shuttles',
+    tubes,
+    costPerTube: pricePerTube,
+    totalBirdCost: Math.round(tubes * pricePerTube * 100) / 100,
+  };
+}
+
+/**
  * Apply a single-purchase tube edit to a session's full usage map WITHOUT
  * dropping the other purchases. Returns the `{ purchaseId, tubes }` array that
  * `PUT /api/session` accepts (the server re-derives cost from the purchase).

--- a/lib/birdWrite.ts
+++ b/lib/birdWrite.ts
@@ -1,6 +1,13 @@
 import { getContainer } from './cosmos';
-import { snapshotBirdUsage, validateBirdEntry } from './birdUsages';
-import type { BirdUsage } from './types';
+import {
+  snapshotBirdUsage,
+  snapshotPooledUsage,
+  validateBirdEntry,
+  validateTubeCount,
+  currentPricePerTube,
+  POOLED_PURCHASE_ID,
+} from './birdUsages';
+import type { BirdPurchase, BirdUsage } from './types';
 
 export type ResolveBirdUsagesResult =
   | { ok: true; usages: BirdUsage[] }
@@ -23,8 +30,19 @@ export type ResolveBirdUsagesResult =
 export async function resolveBirdUsages(raw: unknown): Promise<ResolveBirdUsagesResult> {
   if (!Array.isArray(raw)) return { ok: true, usages: [] };
 
+  // A pooled entry (`{ pooled: true, tubes }`) logs shuttles at the current
+  // price with no specific batch (Model B). Detected before validateBirdEntry
+  // (which requires a purchaseId) and keyed by the POOLED_PURCHASE_ID sentinel,
+  // so per-purchase entries and the single pooled bucket coexist in one map.
   const byId = new Map<string, number>();
   for (const entry of raw) {
+    if (entry && typeof entry === 'object' && (entry as { pooled?: unknown }).pooled === true) {
+      const tubes = Number((entry as { tubes?: unknown }).tubes);
+      const err = validateTubeCount(tubes, 0, 100);
+      if (err) return { ok: false, status: 400, error: err };
+      byId.set(POOLED_PURCHASE_ID, tubes); // last occurrence wins
+      continue;
+    }
     const v = validateBirdEntry(entry);
     if (!v.ok) return { ok: false, status: 400, error: v.error };
     byId.set(v.value.purchaseId, v.value.tubes); // last occurrence wins
@@ -33,27 +51,49 @@ export async function resolveBirdUsages(raw: unknown): Promise<ResolveBirdUsages
   const wanted = [...byId].filter(([, tubes]) => tubes > 0); // 0 = remove/omit
   if (wanted.length === 0) return { ok: true, usages: [] };
 
+  const pooled = wanted.filter(([id]) => id === POOLED_PURCHASE_ID);
+  const perPurchase = wanted.filter(([id]) => id !== POOLED_PURCHASE_ID);
   const birds = getContainer('birds');
-  let reads;
-  try {
-    reads = await Promise.all(wanted.map(([id]) => birds.item(id, id).read()));
-  } catch {
-    // A transient inventory read failure (throttle / network blip) must fail
-    // LEGIBLY and retryably — not silently drop bird cost (legible-fail rule)
-    // nor bubble an opaque 500. A 404-miss does NOT throw (resource is just
-    // undefined), so this only catches genuine read errors.
-    return { ok: false, status: 503, error: 'Could not read bird inventory. Please try again.' };
-  }
   const usages: BirdUsage[] = [];
-  for (let i = 0; i < wanted.length; i++) {
-    const purchase = reads[i].resource;
-    // Reject unknown ids AND adjustment docs — an adjustment has no costPerTube,
-    // so snapshotting one yields NaN cost (CLAUDE.md: never let adjustment docs
-    // into bird cost math).
-    if (!purchase || purchase.type === 'adjustment') {
-      return { ok: false, status: 404, error: 'Selected bird purchase not found' };
+
+  // Per-purchase entries (legacy path): read each batch, snapshot at its price.
+  if (perPurchase.length > 0) {
+    let reads;
+    try {
+      reads = await Promise.all(perPurchase.map(([id]) => birds.item(id, id).read()));
+    } catch {
+      // A transient inventory read failure (throttle / network blip) must fail
+      // LEGIBLY and retryably — not silently drop bird cost (legible-fail rule)
+      // nor bubble an opaque 500. A 404-miss does NOT throw (resource is just
+      // undefined), so this only catches genuine read errors.
+      return { ok: false, status: 503, error: 'Could not read bird inventory. Please try again.' };
     }
-    usages.push(snapshotBirdUsage(purchase, wanted[i][1]));
+    for (let i = 0; i < perPurchase.length; i++) {
+      const purchase = reads[i].resource;
+      // Reject unknown ids AND adjustment docs — an adjustment has no costPerTube,
+      // so snapshotting one yields NaN cost (CLAUDE.md: never let adjustment docs
+      // into bird cost math).
+      if (!purchase || purchase.type === 'adjustment') {
+        return { ok: false, status: 404, error: 'Selected bird purchase not found' };
+      }
+      usages.push(snapshotBirdUsage(purchase, perPurchase[i][1]));
+    }
   }
+
+  // Pooled entry: snapshot at the current price-per-tube (latest purchase).
+  if (pooled.length > 0) {
+    let purchases;
+    try {
+      const { resources } = await birds.items
+        .query({ query: 'SELECT c.costPerTube, c.date, c.type FROM c' })
+        .fetchAll();
+      purchases = (resources as Array<Pick<BirdPurchase, 'costPerTube' | 'date'> & { type?: string }>)
+        .filter((d) => d.type !== 'adjustment');
+    } catch {
+      return { ok: false, status: 503, error: 'Could not read bird inventory. Please try again.' };
+    }
+    usages.push(snapshotPooledUsage(pooled[0][1], currentPricePerTube(purchases)));
+  }
+
   return { ok: true, usages };
 }


### PR DESCRIPTION
## Context

You chose **Model B** for shuttle tracking: log one "tubes used" number per session at the current price-per-tube (auto = your latest purchase's price), keep a running "tubes on hand," and stop picking batches. This is **stage 1 of 3** — the backend plumbing.

**Purely additive, no behavior change yet** — nothing in the UI writes a pooled entry until stage 2, and the existing per-purchase path is untouched. Your existing per-batch sessions stay readable and correctly costed.

## What's here

- **`currentPricePerTube(purchases)`** — the most recent purchase's `costPerTube` is the going rate. Each session snapshots this at log time, so past weeks never shift when the price later changes.
- **`snapshotPooledUsage(tubes, price)` + `POOLED_PURCHASE_ID` sentinel** — a batch-less `BirdUsage`. The sentinel is deliberately not a real purchase id, so:
  - `remainingByPurchase` (iterates real purchases) never mis-attributes a pooled tube,
  - `totalUsed` / `currentStock` still count it (they sum every usage's `tubes`), so overall stock stays correct,
  - cost flows through the frozen `totalBirdCost` — receipts / settle / history unchanged.
- **`resolveBirdUsages`** now accepts `{ pooled: true, tubes }` entries alongside per-purchase `{ purchaseId, tubes }`, snapshotting pooled ones at the current price (adjustment docs excluded from the price pick).

## Next
- Stage 2: session logging UI (cost form + advance form → single "tubes used" stepper writing a pooled entry).
- Stage 3: Birds page becomes stock + current price + purchase/restock history.

## Verification
`npm run lint` → 0 errors · `npm test` → **1108 passed** (+7 new bird tests) · `npm run build` → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_