### PR TITLE
Shuttle model B: accept a manual price on the pooled entry

### DIFF
--- a/__tests__/birdWrite.test.ts
+++ b/__tests__/birdWrite.test.ts
@@ -96,4 +96,25 @@ describe('resolveBirdUsages', () => {
     const r = await resolveBirdUsages([{ pooled: true, tubes: 0 }]);
     expect(r).toEqual({ ok: true, usages: [] });
   });
+
+  it('a manual pricePerTube overrides the auto (latest-purchase) price', async () => {
+    stubBirdsWithPurchases([{ costPerTube: 35, date: '2026-07-01' }]);
+    const r = await resolveBirdUsages([{ pooled: true, tubes: 2, pricePerTube: 40 }]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.usages[0]).toMatchObject({ costPerTube: 40, totalBirdCost: 80 });
+  });
+
+  it('falls back to a manual price when there are no purchases yet', async () => {
+    stubBirdsWithPurchases([]); // auto price would be 0
+    const r = await resolveBirdUsages([{ pooled: true, tubes: 1, pricePerTube: 35 }]);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.usages[0]).toMatchObject({ costPerTube: 35, totalBirdCost: 35 });
+  });
+
+  it('rejects an out-of-range manual price with 400', async () => {
+    stubBirdsWithPurchases([]);
+    const r = await resolveBirdUsages([{ pooled: true, tubes: 1, pricePerTube: -5 }]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
 });

--- a/lib/birdWrite.ts
+++ b/lib/birdWrite.ts
@@ -34,12 +34,24 @@ export async function resolveBirdUsages(raw: unknown): Promise<ResolveBirdUsages
   // price with no specific batch (Model B). Detected before validateBirdEntry
   // (which requires a purchaseId) and keyed by the POOLED_PURCHASE_ID sentinel,
   // so per-purchase entries and the single pooled bucket coexist in one map.
+  // A manually-entered price on the pooled entry overrides the auto (latest
+  // purchase) price — the fallback for when no purchase is recorded yet, and an
+  // override when a batch was bought at a one-off price. Null → use the auto price.
+  let pooledPrice: number | null = null;
   const byId = new Map<string, number>();
   for (const entry of raw) {
     if (entry && typeof entry === 'object' && (entry as { pooled?: unknown }).pooled === true) {
       const tubes = Number((entry as { tubes?: unknown }).tubes);
       const err = validateTubeCount(tubes, 0, 100);
       if (err) return { ok: false, status: 400, error: err };
+      const rawPrice = (entry as { pricePerTube?: unknown }).pricePerTube;
+      if (rawPrice !== undefined && rawPrice !== null && rawPrice !== '') {
+        const p = Number(rawPrice);
+        if (!Number.isFinite(p) || p < 0 || p > 10000) {
+          return { ok: false, status: 400, error: 'Price per tube must be between 0 and 10000' };
+        }
+        pooledPrice = p; // last occurrence wins
+      }
       byId.set(POOLED_PURCHASE_ID, tubes); // last occurrence wins
       continue;
     }
@@ -80,19 +92,24 @@ export async function resolveBirdUsages(raw: unknown): Promise<ResolveBirdUsages
     }
   }
 
-  // Pooled entry: snapshot at the current price-per-tube (latest purchase).
+  // Pooled entry: snapshot at the manual price if one was given, else the
+  // current price-per-tube (latest purchase). Only reads inventory when it
+  // needs the auto price.
   if (pooled.length > 0) {
-    let purchases;
-    try {
-      const { resources } = await birds.items
-        .query({ query: 'SELECT c.costPerTube, c.date, c.type FROM c' })
-        .fetchAll();
-      purchases = (resources as Array<Pick<BirdPurchase, 'costPerTube' | 'date'> & { type?: string }>)
-        .filter((d) => d.type !== 'adjustment');
-    } catch {
-      return { ok: false, status: 503, error: 'Could not read bird inventory. Please try again.' };
+    let price = pooledPrice;
+    if (price === null) {
+      try {
+        const { resources } = await birds.items
+          .query({ query: 'SELECT c.costPerTube, c.date, c.type FROM c' })
+          .fetchAll();
+        const purchases = (resources as Array<Pick<BirdPurchase, 'costPerTube' | 'date'> & { type?: string }>)
+          .filter((d) => d.type !== 'adjustment');
+        price = currentPricePerTube(purchases);
+      } catch {
+        return { ok: false, status: 503, error: 'Could not read bird inventory. Please try again.' };
+      }
     }
-    usages.push(snapshotPooledUsage(pooled[0][1], currentPricePerTube(purchases)));
+    usages.push(snapshotPooledUsage(pooled[0][1], price));
   }
 
   return { ok: true, usages };


### PR DESCRIPTION
## What

Completes the Model-B pooled shuttle write path (builds on #230). A pooled entry `{ pooled: true, tubes }` may now carry an optional **`pricePerTube`**:
- present + in `[0, 10000]` → overrides the auto latest-purchase price (the **manual fallback** for "no purchase recorded yet," and an override for a one-off batch price),
- absent → the auto price is used (inventory is only read in that case),
- snapshotted per session, so past weeks never shift.

Still backend-only + additive — no UI writes it yet.

## Tests
Manual price overrides auto; manual price works with zero purchases; out-of-range price → 400.

## Verification
`npm run lint` → 0 errors · `npm test` → **1111 passed** · `npm run build` → green.

## Next (Stage 2 — the visible part)
Rework the cost form's shuttle input from batch-picker → a single **"tubes used + $/tube"** control (price pre-filled from latest purchase, editable). This is a delicate change to the money form, so I want to build it with in-app screenshot verification rather than rush it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_