### PR TITLE
fix(receipt): shared receipt image "can't be displayed" on iPhone PWA

### DIFF
--- a/components/admin/CommandCenter/ReceiptSheet.tsx
+++ b/components/admin/CommandCenter/ReceiptSheet.tsx
@@ -72,12 +72,24 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
   }
 
   async function shareImage() {
-    if (!imageDataUrl) return;
+    const canvas = canvasRef.current;
+    if (!canvas || !imageDataUrl) return;
     setActionError(null);
+    // Build the Blob straight from the canvas rather than round-tripping
+    // through `fetch(dataUrl).then(r => r.blob())`. Fetching a `data:` URI to
+    // reconstruct a Blob is a known-flaky pattern in iOS Safari's standalone
+    // (home-screen PWA) context — the preview `<img src={dataUrl}>` decodes
+    // fine (no fetch involved), but the shared file can come out truncated/
+    // corrupted ("can't be displayed"). canvas.toBlob() hands back the bitmap
+    // directly with no intermediate base64 string round trip.
+    const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+    if (!blob) {
+      setActionError('Couldn’t generate the image — try again.');
+      return;
+    }
+    const file = new File([blob], 'bpm-receipt.png', { type: 'image/png' });
     let nativeShareTried = false;
     try {
-      const blob = await (await fetch(imageDataUrl)).blob();
-      const file = new File([blob], `bpm-receipt.png`, { type: 'image/png' });
       const navAny = navigator as Navigator & { canShare?: (data: { files: File[] }) => boolean; share?: (data: { files: File[] }) => Promise<void> };
       if (navAny.canShare?.({ files: [file] }) && navAny.share) {
         nativeShareTried = true;
@@ -95,11 +107,13 @@ export default function ReceiptSheet({ open, onClose, input, error, initialMode 
       if (!nativeShareTried) console.warn('shareImage:', err);
     }
     try {
+      const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      a.href = imageDataUrl;
+      a.href = url;
       a.download = 'bpm-receipt.png';
       markExternalExcursion();
       a.click();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
     } catch {
       setActionError('Couldn’t download — try Copy text instead.');
     }


### PR DESCRIPTION
## Bug

Pressing "Share cost" → "Share image" from an iPhone home-screen PWA produced a file the recipient (or the user) couldn't open — literally "can't be displayed." The bottom-sheet preview rendered fine; only the shared/downloaded file was broken.

## Root cause

`ReceiptSheet`'s preview `<img>` decodes the canvas's `toDataURL()` string directly — no `fetch` involved, so it always worked. But `shareImage()` re-derived the `Blob` for sharing via:

```ts
const blob = await (await fetch(imageDataUrl)).blob();
```

Fetching a `data:` URI to reconstruct a `Blob` is a known-flaky pattern in iOS Safari's **standalone** (home-screen PWA) context, especially under memory pressure — the preview can decode fine while this reconstructed blob comes out truncated/corrupted. This matches the exact reported symptom: preview looked correct, shared file did not open.

## Fix

Use `canvas.toBlob()` directly — it hands back the bitmap with no intermediate base64 string encode/decode round trip. Both the native `navigator.share({ files })` path and the download fallback now share that same `Blob` (the fallback via `URL.createObjectURL` instead of an `<a href={dataUrl} download>`, which has its own iOS reliability history).

Only `components/admin/CommandCenter/ReceiptSheet.tsx` changed — the preview `<img>`/`toDataURL()` path is untouched since it wasn't the broken piece.

## Investigation

Could not reproduce with headless Chrome + a local mock-store session (fresh, settled, with pooled shuttle cost, missing e-transfer recipient all rendered/shared correctly) — this class of bug is iOS-standalone-specific and doesn't show up in that environment. Confirmed the failure point and device (iPhone home-screen PWA, preview fine, share broken) with the reporter before diagnosing further.

## Verification
- `npm run lint` → 0 errors (401 pre-existing warnings, unrelated).
- `npm test` → 1111 passed / 135 suites.
- `npm run build` → compiles clean.
- Scripted browser check: `canvas.toBlob('image/png')` produces a valid PNG (correct magic bytes, 32.6 KB) and the download-fallback path saves that same valid PNG end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkPAFUmMv3ihsjtjzU8eUb)_